### PR TITLE
Fix a lot of things

### DIFF
--- a/config/webpackDevServer.config.js
+++ b/config/webpackDevServer.config.js
@@ -16,10 +16,6 @@ const sockPort = process.env.WDS_SOCKET_PORT;
 
 module.exports = function (proxy, allowedHost) {
   return {
-    headers: {
-      "Cross-Origin-Opener-Policy": "same-origin",
-      "Cross-Origin-Embedder-Policy": "require-corp"
-    },
     // WebpackDevServer 2.4.3 introduced a security fix that prevents remote
     // websites from potentially accessing local content through DNS rebinding:
     // https://github.com/webpack/webpack-dev-server/issues/887

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,3 +1,5 @@
+export const MAIN_APP_ID = "papyros";
+
 export const OUTPUT_TA_ID = "code-output-area";
 export const INPUT_TA_ID = "code-input-area";
 export const CODE_TA_ID = "code-area";
@@ -8,3 +10,5 @@ export const TERMINATE_BTN_ID = "terminate-btn";
 export const LANGUAGE_SELECT_ID = "language-select";
 
 export const DEFAULT_PROGRAMMING_LANGUAGE = /*"javascript"*/ "python";
+
+export const INPUT_RELATIVE_URL = "/__papyros_input";

--- a/src/Papyros.ts
+++ b/src/Papyros.ts
@@ -1,10 +1,11 @@
 import { proxy, Remote } from "comlink";
 import { Backend} from "./Backend";
 import { getBackend, stopBackend } from "./BackendManager";
-import { CODE_TA_ID, DEFAULT_PROGRAMMING_LANGUAGE, INPUT_TA_ID, LANGUAGE_SELECT_ID, OUTPUT_TA_ID, RUN_BTN_ID, TERMINATE_BTN_ID } from "./Constants";
+import { CODE_TA_ID, DEFAULT_PROGRAMMING_LANGUAGE, INPUT_RELATIVE_URL, INPUT_TA_ID, LANGUAGE_SELECT_ID, OUTPUT_TA_ID, RUN_BTN_ID, TERMINATE_BTN_ID } from "./Constants";
 import { PapyrosEvent } from "./PapyrosEvent";
+import { LogType, papyrosLog } from "./util/Logging";
 
-export function Papyros(){
+export function Papyros(inputTextArray?: Uint8Array, inputMetaData?: Int32Array){
     let backend: Remote<Backend>;
 
     // textareas
@@ -23,21 +24,6 @@ export function Papyros(){
     // Input handling
     let awaitingInput = false;
     const encoder = new TextEncoder();
-
-    // shared memory
-    let inputTextArray: Uint8Array | undefined = undefined;
-        // 2 Int32s: index 0 indicates whether data is written, index 1 denotes length of the string
-    let inputMetaData: Int32Array | undefined = undefined;
-    const fetchInputUrl = `${document.location.pathname}input`
-    if(typeof SharedArrayBuffer !== "undefined"){
-        inputTextArray = new Uint8Array(new SharedArrayBuffer(Uint8Array.BYTES_PER_ELEMENT * 1024));
-        inputMetaData = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2));
-        //let interruptBuffer = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
-    } else if ("serviceWorker" in navigator) {
-        navigator.serviceWorker.register("./inputServiceWorker.js", { scope: "" });
-    } else {
-        document.getElementById("papyros")!.innerHTML = "Your browser is unsupported. Please use a modern version of Chrome, Safari, Firefox, ...";
-    }
 
 
     function init(): void {
@@ -66,28 +52,28 @@ export function Papyros(){
 
     function initTextAreas(): void {
         inputArea.onkeydown = (e) => {
-            console.log("Key down in inputArea", e);
+            papyrosLog(LogType.Debug, "Key down in inputArea", e);
             if(awaitingInput && e.key.toLowerCase() === "enter"){
-                console.log("Pressed enter! Sending input to user");
+                papyrosLog(LogType.Debug, "Pressed enter! Sending input to user");
                 sendInput();
             }
         }
     }
 
     function onError(e: PapyrosEvent): void {
-        console.log("Got error in Papyros: ", e);
+        papyrosLog(LogType.Debug, "Got error in Papyros: ", e);
         // todo prettify errors
         outputArea.value += e.data;
     }
 
     async function sendInput(){
-        console.log("Handling send Input in Papyros");
+        papyrosLog(LogType.Debug, "Handling send Input in Papyros");
         const lines = inputArea.value.split("\n");
         if(lines.length > lineNr && lines[lineNr]){
-            console.log("Sending input to user: " + lines[lineNr]);
+            papyrosLog(LogType.Debug, "Sending input to user: " + lines[lineNr]);
             const line = lines[lineNr];
             if(!inputMetaData || !inputTextArray){
-               await fetch(fetchInputUrl, {method: "POST", body: JSON.stringify({"input": line})});
+               await fetch(INPUT_RELATIVE_URL, {method: "POST", body: JSON.stringify({"input": line})});
             } else {
                 const encoded = encoder.encode(lines[lineNr]);
                 inputTextArray.set(encoded);
@@ -98,22 +84,22 @@ export function Papyros(){
             awaitingInput = false;
             return true;
         } else {
-            console.log("Had no input to send, still waiting!");
+            papyrosLog(LogType.Debug, "Had no input to send, still waiting!");
             return false;
         }
     }
 
     async function onInput(e: PapyrosEvent): Promise<void> {
-        console.log("Received onInput event in Papyros: ", e);
+        papyrosLog(LogType.Debug, "Received onInput event in Papyros: ", e);
         if(!await sendInput()){
             // todo render something based on the event
             awaitingInput = true;
-            console.log("User needs to enter input before code can continue");
+            papyrosLog(LogType.Debug, "User needs to enter input before code can continue");
         }
     }
 
     function onMessage(e: PapyrosEvent): void {
-        console.log("received event in onMessage", e);
+        papyrosLog(LogType.Debug, "received event in onMessage", e);
         if(e.type === "output"){
             outputArea.value += e.data;
         } else if(e.type === "input"){
@@ -128,7 +114,7 @@ export function Papyros(){
         lineNr = 0;
         outputArea.value = "";
         terminateButton.hidden = false;
-        console.log("Running code in Papyros, sending to backend");
+        papyrosLog(LogType.Debug, "Running code in Papyros, sending to backend");
         return backend.runCode(codeArea.value)
             .catch(onError)
             .finally(() => {
@@ -138,16 +124,12 @@ export function Papyros(){
     }
 
     function terminate(): Promise<void> {
-        console.log("Called terminate, stopping backend!");
+        papyrosLog(LogType.Debug, "Called terminate, stopping backend!");
         terminateButton.hidden = true;
         return stopBackend(backend).then(() => initBackend());
     }
 
     function initButtons(): void {
-        /*runButton.addEventListener("click", () => {
-            //sendInput();
-            fetch("/input").then(r => console.log("Got result from GET /input", r));
-        });*/
         runButton.addEventListener("click", () => runCode());
         terminateButton.addEventListener("click", () => terminate());
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,47 @@
 import 'bootstrap/dist/css/bootstrap.css';
 import './App.css';
+import { MAIN_APP_ID } from './Constants';
 import { Papyros } from './Papyros';
+import { papyrosLog, LogType } from './util/Logging';
 
-Papyros();
+const RELOAD_STORAGE_KEY = "__papyros_reloading";
+const SERVICE_WORKER_PATH = "./inputServiceWorker.js";
+
+if(window.localStorage.getItem(RELOAD_STORAGE_KEY)){
+    // We are the result of the page reload, so we can start
+    window.localStorage.removeItem(RELOAD_STORAGE_KEY);
+    startPapyros();
+} else {
+    if(typeof SharedArrayBuffer === "undefined"){
+        papyrosLog(LogType.Important, "SharedArrayBuffers are not available. ");
+        if("serviceWorker" in navigator){
+            papyrosLog(LogType.Important, "Registering service worker.");
+            // Store that we are reloading, to prevent the next load from doing all this again
+            window.localStorage.setItem(RELOAD_STORAGE_KEY, RELOAD_STORAGE_KEY);
+            navigator.serviceWorker.register(SERVICE_WORKER_PATH, { scope: "" })
+                // service worker adds new headers that may allow SharedArrayBuffers to be used anyway
+                .then(() => window.location.reload());
+        } else {
+            document.getElementById(MAIN_APP_ID)!.innerHTML = "Your browser is unsupported. Please use a modern version of Chrome, Safari, Firefox, ...";
+        }
+    } else {
+        startPapyros();
+    }
+}
+
+
+function startPapyros(){
+    let inputTextArray: Uint8Array | undefined = undefined;
+    let inputMetaData: Int32Array | undefined = undefined;
+    if(typeof SharedArrayBuffer !== "undefined"){
+        papyrosLog(LogType.Important, "Using SharedArrayBuffers");
+        // shared memory
+        inputTextArray = new Uint8Array(new SharedArrayBuffer(Uint8Array.BYTES_PER_ELEMENT * 1024));
+        // 2 Int32s: index 0 indicates whether data is written, index 1 denotes length of the string
+        inputMetaData = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2));
+    } else {
+        papyrosLog(LogType.Important, "Using serviceWorker for input");
+    }
+
+    Papyros(inputTextArray, inputMetaData);
+}

--- a/src/util/Logging.ts
+++ b/src/util/Logging.ts
@@ -1,0 +1,15 @@
+export enum LogType {
+    Debug, Error, Important 
+}
+
+const ENVIRONMENT: string = process.env.NODE_ENV || 'development';
+export function papyrosLog(logType: LogType, ...args: any[]){
+    const doLog = ENVIRONMENT !== "production" || logType !== LogType.Debug;
+    if(doLog){
+        if(logType === LogType.Error){
+            console.error(...args);
+        } else {
+            console.log(...args);
+        }
+    }
+}

--- a/src/workers/javascript/index.ts
+++ b/src/workers/javascript/index.ts
@@ -1,11 +1,10 @@
 import { expose } from 'comlink';
 import { Backend } from '../../Backend';
-import { PapyrosEvent } from '../../PapyrosEvent';
 
 
 class JavaScriptWorker extends Backend {
 
-    getFunctionToRun(code: string){
+    _runCodeInternal(code: string){
         const toRestore = new Map([
             ["prompt", "__prompt"],
             ["console.log", "__papyros_log"],
@@ -69,20 +68,7 @@ ${restoreBuiltins.join('\n')}
         `);
         const fnBody = newBody.join('\n');
         // eslint-disable-next-line no-new-func
-        return new Function("ctx", fnBody)(newContext);
-    }
-
-    runCode(code: string){
-        //console.log("Running code in worker: ", code);
-        let result: PapyrosEvent;
-        try {
-            // eslint-disable-next-line
-            result = {type: "success", data: this.getFunctionToRun(code)};
-            console.log("ran code: " + code + " and received: ", result);
-        } catch (error: any) {
-            result = {type: "error", data: error};
-        }
-        this.onEvent(result);
+        return Promise.resolve(new Function("ctx", fnBody)(newContext));
     }
 }
 

--- a/src/workers/python/init.py.ts
+++ b/src/workers/python/init.py.ts
@@ -1,7 +1,6 @@
 export const INITIALIZATION_CODE = 
 `
 from pyodide import to_js
-from js import console
 import sys
 
 def __override_builtins(cb):
@@ -9,13 +8,10 @@ def __override_builtins(cb):
     __override_stdin(cb)
 
 def __capture_stdout(cb):
-    console.log("Rerouting print")
     class _OutputWriter:
 
         def write(self, s):
-            console.log("Writing : " + s)
             cb(to_js({"type": "output", "data":s}))
-            console.log("Called cb")
 
         def flush(self):
             pass # Given data is always immediately written
@@ -25,7 +21,6 @@ def __capture_stdout(cb):
     __writer = _OutputWriter()
 
     def __dodona_print(*objects, sep=' ', end='\\n', file=sys.stdout, flush=False):
-        console.log(f"Called my print with {objects}")
         if file == sys.stdout:
             __original_print(*objects, sep=sep, end=end, file=__writer, flush=flush)
         else:
@@ -36,13 +31,15 @@ def __capture_stdout(cb):
 def __override_stdin(cb):
     global input
     def __dodona_input(prompt=""):
-        console.log("Called print with prompt: " + prompt)
         print(prompt, end="")
         user_value = cb(to_js({"type": "input", "data":prompt}))
         print(user_value)
         return user_value
 
     input = __dodona_input
+
+def __run_code(code):
+    return exec(code, dict(globals()))
 `;
 
      


### PR DESCRIPTION
Contains fixes for the following features:

Where possible, console.log and similar calls have been replaced by calls to papyrosLog, to reduce the amount of logs in production that might be useful in development.

The inputServiceWorker now adds extra headers to responses from requests for urls within our domain, allowing the use of SharedArrayBuffers even in GitHub pages. Locally this worked thanks to the webpack-devServer, but these headers are not added by GitHub. Now the more efficient input calls should work in supporting browsers. This logic has also been moved to index.ts, as it relies on a reload of the page. After starting the service worker, we need a reload to ensure that our page is fetched with the correct headers. A key in localStorage tells the app whether it can proceed or needs to reload. 

The Python scoping is now correct. Defining a variable in a code execution run, will no longer cause it to be available at next runs, as it is now a separate namespace.

Errors thrown by running the code are converted into strings, which hopefully fixes #10 as errors on Safari seem to have a different shape, causing them to be uncloneable by Comlink.