### PR TITLE
Fix running code containing Python doctests

### DIFF
--- a/src/workers/python/PythonWorker.worker.ts
+++ b/src/workers/python/PythonWorker.worker.ts
@@ -1,7 +1,6 @@
 import { expose } from "comlink";
 import { Backend } from "../../Backend";
 import { PapyrosEvent } from "../../PapyrosEvent";
-import { LogType, papyrosLog } from "../../util/Logging";
 import { INITIALIZATION_CODE } from "./init.py";
 
 interface Pyodide {
@@ -41,7 +40,7 @@ class PythonWorker extends Backend {
         const eventCallback = (data: any): void => {
             const jsEvent: PapyrosEvent = "toJs" in data ? data.toJs() : Object.fromEntries(data);
             this.onEvent(jsEvent);
-        }
+        };
         this.pyodide.globals.get("__override_builtins")(eventCallback);
         this.globals = new Map((this.pyodide.globals as any).toJs());
         this.initialized = true;

--- a/src/workers/python/PythonWorker.worker.ts
+++ b/src/workers/python/PythonWorker.worker.ts
@@ -8,9 +8,11 @@ interface LoadPyodideArgs {
     fullStdLib: boolean;
 }
 interface Pyodide {
+    runPython: (code: string, globals?: any) => any;
     runPythonAsync: (code: string) => Promise<void>;
     loadPackagesFromImports: (code: string) => Promise<void>;
     globals: Map<string, any>;
+    toPy: (obj: any) => any;
 }
 declare function importScripts(...urls: string[]): void;
 declare function loadPyodide(args: LoadPyodideArgs): Promise<Pyodide>;
@@ -21,11 +23,13 @@ importScripts("https://cdn.jsdelivr.net/pyodide/v0.18.1/full/pyodide.js");
 class PythonWorker extends Backend {
     pyodide: Pyodide;
     initialized: boolean;
+    globals: Map<string, any>;
 
     constructor() {
         super();
         this.pyodide = {} as Pyodide;
         this.initialized = false;
+        this.globals = new Map();
     }
 
     override async launch(onEvent: (e: PapyrosEvent) => void,
@@ -33,7 +37,7 @@ class PythonWorker extends Backend {
         await super.launch(onEvent, inputTextArray, inputMetaData);
         const pyodide = await loadPyodide({
             indexURL: "https://cdn.jsdelivr.net/pyodide/v0.18.1/full/",
-            fullStdLib: true
+            fullStdLib: false
         });
         this.pyodide = pyodide;
         await this.runCode(INITIALIZATION_CODE, 0);
@@ -41,13 +45,20 @@ class PythonWorker extends Backend {
         const eventCallback = (data: Map<string, any>): void =>
             this.onEvent(Object.fromEntries(data) as PapyrosEvent);
         this.pyodide.globals.get("__override_builtins")(eventCallback);
+        this.globals = new Map(this.pyodide.globals.get("__dodona_globals").toJs());
+        const originalOnEvent = this.onEvent;
+        this.onEvent = (e: PapyrosEvent) => {
+            const jsEvent: PapyrosEvent = "toJs" in e ? (e as any).toJs() as PapyrosEvent : e;
+            return originalOnEvent(jsEvent);
+        };
         this.initialized = true;
     }
 
     override async _runCodeInternal(code: string): Promise<any> {
         await this.pyodide.loadPackagesFromImports(code);
         if (this.initialized) {
-            return this.pyodide.globals.get("__run_code")(code);
+            // return this.pyodide.runPython(code, this.pyodide.toPy(new Map(this.globals)));
+            return this.pyodide.runPython(code);
         } else {
             return this.pyodide.runPythonAsync(code);
         }

--- a/src/workers/python/init.py.ts
+++ b/src/workers/python/init.py.ts
@@ -6,9 +6,8 @@ import sys
 def __override_builtins(cb):
     __capture_stdout(cb)
     __override_stdin(cb)
-    global __dodona_globals
-    __dodona_globals = globals()
-    __dodona_globals["__name__"] = "__main__"
+    # set name to main instead of builtins
+    globals()["__name__"] = "__main__"
 
 def __capture_stdout(cb):
     class _OutputWriter:

--- a/src/workers/python/init.py.ts
+++ b/src/workers/python/init.py.ts
@@ -6,27 +6,22 @@ import sys
 def __override_builtins(cb):
     __capture_stdout(cb)
     __override_stdin(cb)
+    global __dodona_globals
+    __dodona_globals = globals()
+    __dodona_globals["__name__"] = "__main__"
 
 def __capture_stdout(cb):
     class _OutputWriter:
-
+        def __init__(self):
+            self.encoding = "utf-8"
+            
         def write(self, s):
             cb(to_js({"type": "output", "data":s}))
 
         def flush(self):
             pass # Given data is always immediately written
 
-    global print
-    __original_print = print
-    __writer = _OutputWriter()
-
-    def __dodona_print(*objects, sep=' ', end='\\n', file=sys.stdout, flush=False):
-        if file == sys.stdout:
-            __original_print(*objects, sep=sep, end=end, file=__writer, flush=flush)
-        else:
-            __original_print(*objects, sep=sep, end=end, file=file, flush=flush)
-
-    print = __dodona_print
+    sys.stdout = _OutputWriter()
 
 def __override_stdin(cb):
     global input
@@ -37,7 +32,4 @@ def __override_stdin(cb):
         return user_value
 
     input = __dodona_input
-
-def __run_code(code):
-    return exec(code, dict(globals()))
 `;


### PR DESCRIPTION
Closes #16
This PR allows doctests to work by doing the following:\
setting the module name to __main__ instead of builtins\
Changing the way the scoping works to allow doctest to find the relevant docstrings. This requires running the code in the global scope, and then resetting the scope to undo changes (preventing declared variables from being found later, as well as undoing overrides of builtins)\
Better conversion of PyProxy objects to actual JS objects to prevent type errors.