### PR TITLE
Add CodeMirror 6 editor

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,66 +1,106 @@
 {
-    "plugins": [
-      "jest"
+  "plugins": [
+    "jest"
+  ],
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module"
+  },
+  "extends": [
+    "eslint:recommended",
+    "google",
+    "plugin:jest/recommended"
+  ],
+  "rules": {
+    "arrow-parens": [
+      "error",
+      "as-needed"
     ],
-    "parserOptions": {
-      "ecmaVersion": 2020,
-      "sourceType": "module"
-    },
-    "extends": [
-      "eslint:recommended",
-      "google",
-      "plugin:jest/recommended"
-    ],
-    "rules": {
-      "arrow-parens": ["error", "as-needed"],
-      "comma-dangle": ["error", {
-          "arrays": "only-multiline",
-          "objects": "only-multiline",
-          "imports": "only-multiline",
-          "exports": "only-multiline",
-          "functions": "never"
-      }],
-      "indent": ["error", 4],
-      "max-len": ["warn", { "code": 100 }],
-      "no-invalid-this": "warn",
-      "no-param-reassign": ["error", { "props": false }],
-      "object-curly-spacing": ["error", "always"],
-      "quotes": ["error", "double"],
-      "require-jsdoc": "off",
-      "space-before-function-paren": [
-        "error",
-        { "anonymous": "always", "named": "never", "asyncArrow": "always" }
-      ]
-    },
-    "env": {
-      "browser": true,
-      "es6": true,
-      "jest/globals": true
-    },
-    "globals": {
-      "I18n": "readonly",
-    },
-    "overrides": [
+    "comma-dangle": [
+      "error",
       {
-        "extends": ["plugin:@typescript-eslint/recommended"],
-        "files": ["*.ts"],
-        "parser": "@typescript-eslint/parser",
-        "parserOptions": {
-          // this seems to be extremely slow
-          // without 1.5s, with 22s
-          //"project": "./tsconfig.json"
-        },
-        "plugins": ["@typescript-eslint"],
-        "rules": {
-          "@typescript-eslint/explicit-member-accessibility": "off",
-          "@typescript-eslint/explicit-function-return-type": [
-            "error",
-            { "allowExpressions": true }
-          ],
-          "@typescript-eslint/no-parameter-properties": "off",
-          "@typescript-eslint/no-explicit-any": "off",
-          "@typescript-eslint/no-non-null-assertion": "off"
-        }
+        "arrays": "only-multiline",
+        "objects": "only-multiline",
+        "imports": "only-multiline",
+        "exports": "only-multiline",
+        "functions": "never"
+      }
+    ],
+    "indent": [
+      "error",
+      4,
+      {
+        "SwitchCase": 1
+      }
+    ],
+    "max-len": [
+      "warn",
+      {
+        "code": 100
+      }
+    ],
+    "no-invalid-this": "warn",
+    "no-param-reassign": [
+      "error",
+      {
+        "props": false
+      }
+    ],
+    "object-curly-spacing": [
+      "error",
+      "always"
+    ],
+    "quotes": [
+      "error",
+      "double"
+    ],
+    "require-jsdoc": "off",
+    "space-before-function-paren": [
+      "error",
+      {
+        "anonymous": "always",
+        "named": "never",
+        "asyncArrow": "always"
       }
     ]
-  }
+  },
+  "env": {
+    "browser": true,
+    "es6": true,
+    "jest/globals": true
+  },
+  "globals": {
+    "I18n": "readonly"
+  },
+  "overrides": [
+    {
+      "extends": [
+        "plugin:@typescript-eslint/recommended"
+      ],
+      "files": [
+        "*.ts"
+      ],
+      "parser": "@typescript-eslint/parser",
+      "parserOptions": {
+        // this seems to be extremely slow
+        // without 1.5s, with 22s
+        //"project": "./tsconfig.json"
+      },
+      "plugins": [
+        "@typescript-eslint"
+      ],
+      "rules": {
+        "@typescript-eslint/explicit-member-accessibility": "off",
+        "@typescript-eslint/explicit-function-return-type": [
+          "error",
+          {
+            "allowExpressions": true
+          }
+        ],
+        "@typescript-eslint/no-parameter-properties": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-non-null-assertion": "off"
+      }
+    }
+  ]
+}

--- a/build/index.html
+++ b/build/index.html
@@ -41,19 +41,12 @@
       Papyros
     </div>
     <div id="papyros">
-      <div class="row h-64">
-        <div class="col">
-          <h1>Enter your code here:</h1>
-          <div id="code-area"></div>
-          <h1>Provide input for the code here:</h1>
-          <textarea id="code-input-area" class="border-2 h-auto"></textarea>
-        </div>
-        <div class="col">
-          <h1>Code output:</h1>
-          <textarea id="code-output-area" readonly class="border-2 h-full"></textarea>
-        </div>
-      </div>
-      <div class="flex flex-row">
+      <div class="flex flex-row items-center">
+        <label for="language-select">Programming language</label>
+        <select id="language-select" class="border-2">
+          <option value="Python">Python</option>
+          <option value="JavaScript">JavaScript</option>
+        </select>
         <button id="run-code-btn" type="button" class="mr-1 btn btn-primary">Run</button>
         <button id="terminate-btn" type="button" class="mr-1 btn btn-danger" hidden>Terminate</button>
         <div class="flex flex-row items-center">
@@ -64,12 +57,18 @@
           <div id="application-state-text">Loading</div>
         </div>
       </div>
-
-      <label for="language-select">Programming language</label>
-      <select id="language-select" class="border-2">
-        <option value="Python">Python</option>
-        <option value="JavaScript">JavaScript</option>
-      </select>
+      <div class="row">
+        <div class="col">
+          <h1>Enter your code here:</h1>
+          <div id="code-area"></div>
+        </div>
+        <div class="col">
+          <h1>Provide input for the code here:</h1>
+          <textarea id="code-input-area" class="border-2 h-auto" rows="5"></textarea>
+          <h1>Code output:</h1>
+          <textarea id="code-output-area" readonly class="border-2 h-full"></textarea>
+        </div>
+      </div>
     </div>
 
   </body>

--- a/build/index.html
+++ b/build/index.html
@@ -44,7 +44,7 @@
       <div class="row h-64">
         <div class="col">
           <h1>Enter your code here:</h1>
-          <textarea id="code-area" class="border-2 h-36"></textarea>
+          <div id="code-area"></div>
           <h1>Provide input for the code here:</h1>
           <textarea id="code-input-area" class="border-2 h-auto"></textarea>
         </div>

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "webpack-dev-server": "3.11.1"
   },
   "dependencies": {
+    "@codemirror/autocomplete": "^0.19.8",
     "@codemirror/basic-setup": "^0.19.0",
     "@codemirror/lang-javascript": "^0.19.3",
     "@codemirror/lang-python": "^0.19.2",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,15 @@
   },
   "dependencies": {
     "@codemirror/autocomplete": "^0.19.8",
-    "@codemirror/basic-setup": "^0.19.0",
+    "@codemirror/closebrackets": "^0.19.0",
+    "@codemirror/commands": "^0.19.5",
+    "@codemirror/comment": "^0.19.0",
+    "@codemirror/fold": "^0.19.1",
+    "@codemirror/history": "^0.19.0",
     "@codemirror/lang-javascript": "^0.19.3",
     "@codemirror/lang-python": "^0.19.2",
+    "@codemirror/rectangular-selection": "^0.19.1",
+    "@codemirror/search": "^0.19.3",
     "comlink": "^4.3.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "homepage": ".",
   "devDependencies": {
+    "@codemirror/language": "^0.19.5",
+    "@types/codemirror": "^5.60.5",
     "@typescript-eslint/eslint-plugin": "^4.5.0",
     "@typescript-eslint/parser": "^4.5.0",
     "autoprefixer": "^10.4.0",
@@ -31,6 +33,9 @@
     "webpack-dev-server": "3.11.1"
   },
   "dependencies": {
+    "@codemirror/basic-setup": "^0.19.0",
+    "@codemirror/lang-javascript": "^0.19.3",
+    "@codemirror/lang-python": "^0.19.2",
     "comlink": "^4.3.1"
   },
   "scripts": {

--- a/src/BackendManager.ts
+++ b/src/BackendManager.ts
@@ -1,29 +1,29 @@
 /* eslint-disable max-len */
 import { releaseProxy, Remote, wrap } from "comlink";
 import { Backend } from "./Backend";
+import { ProgrammingLanguage } from "./ProgrammingLanguage";
 
 // Store Worker per Backend as Comlink proxy has no explicit reference to the Worker
 // We need the Worker itself to be able to terminate it (@see stopBackend)
 const BACKEND_MAP: Map<Remote<Backend>, Worker> = new Map();
 
-export function getBackend(language: string): Remote<Backend> {
-    const backendLanguage = language.toLowerCase();
+export function getBackend(language: ProgrammingLanguage): Remote<Backend> {
     let worker;
-    switch (backendLanguage) {
-    // Requires switch to have actual string constants and make webpack bundle the workers
-    case "python": {
-        worker = new Worker(new URL("./workers/python/PythonWorker.worker.ts", import.meta.url));
-        break;
-    }
+    switch (language) {
+        // Requires switch to have actual string constants and make webpack bundle the workers
+        case ProgrammingLanguage.Python: {
+            worker = new Worker(new URL("./workers/python/PythonWorker.worker.ts", import.meta.url));
+            break;
+        }
 
-    case "javascript": {
-        worker = new Worker(new URL("./workers/javascript/JavaScriptWorker.worker.ts", import.meta.url));
-        break;
-    }
+        case ProgrammingLanguage.JavaScript: {
+            worker = new Worker(new URL("./workers/javascript/JavaScriptWorker.worker.ts", import.meta.url));
+            break;
+        }
 
-    default: {
-        throw new Error(`${language} is not yet supported.`);
-    }
+        default: {
+            throw new Error(`${language} is not yet supported.`);
+        }
     }
     const backend = wrap<Backend>(worker);
     // store worker itself in the map

--- a/src/CodeEditor.ts
+++ b/src/CodeEditor.ts
@@ -5,6 +5,7 @@ import { javascript } from "@codemirror/lang-javascript";
 import { ProgrammingLanguage } from "./ProgrammingLanguage";
 import { python } from "@codemirror/lang-python";
 import { LanguageSupport } from "@codemirror/language";
+import { autocompletion } from "@codemirror/autocomplete";
 
 function getLanguageSupport(language: ProgrammingLanguage): LanguageSupport {
     switch (language) {
@@ -26,9 +27,9 @@ function getEditorView(parentElement: HTMLElement,
         state: EditorState.create({
             doc: initialCode || "",
             extensions: [
+                getLanguageSupport(language),
                 basicSetup,
-                keymap.of([indentWithTab]),
-                getLanguageSupport(language)
+                keymap.of([indentWithTab])
             ]
         }),
         parent: parentElement
@@ -55,7 +56,7 @@ export class CodeEditor {
 
     getCode(): string {
         if (this.editorView) {
-            return this.editorView.state.sliceDoc();
+            return this.editorView.state.doc.toString();
         } else {
             return "";
         }

--- a/src/CodeEditor.ts
+++ b/src/CodeEditor.ts
@@ -1,0 +1,36 @@
+import { EditorState, basicSetup } from "@codemirror/basic-setup";
+import { EditorView, keymap } from "@codemirror/view";
+import { indentWithTab } from "@codemirror/commands";
+import { javascript } from "@codemirror/lang-javascript";
+import { ProgrammingLanguage } from "./ProgrammingLanguage";
+import { python } from "@codemirror/lang-python";
+import { LanguageSupport } from "@codemirror/language";
+
+function getLanguageSupport(language: ProgrammingLanguage): LanguageSupport {
+    switch (language) {
+        case ProgrammingLanguage.Python: {
+            return python();
+        }
+        case ProgrammingLanguage.JavaScript: {
+            return javascript();
+        }
+        default: {
+            throw new Error(`${language} is not yet supported.`);
+        }
+    }
+}
+
+export function initEditor(elemId: string, language: ProgrammingLanguage, initialCode?: string)
+    : EditorView {
+    return new EditorView({
+        state: EditorState.create({
+            doc: initialCode || "",
+            extensions: [
+                basicSetup,
+                keymap.of([indentWithTab]),
+                getLanguageSupport(language)
+            ]
+        }),
+        parent: document.getElementById(elemId) as HTMLElement
+    });
+}

--- a/src/CodeEditor.ts
+++ b/src/CodeEditor.ts
@@ -1,11 +1,28 @@
-import { EditorState, basicSetup } from "@codemirror/basic-setup";
-import { EditorView, keymap } from "@codemirror/view";
 import { indentWithTab } from "@codemirror/commands";
 import { javascript } from "@codemirror/lang-javascript";
 import { ProgrammingLanguage } from "./ProgrammingLanguage";
 import { python } from "@codemirror/lang-python";
 import { LanguageSupport } from "@codemirror/language";
-// import { autocompletion } from "@codemirror/autocomplete";
+import {
+    EditorView,
+    keymap, highlightSpecialChars,
+    drawSelection, highlightActiveLine
+}
+    from "@codemirror/view";
+import { EditorState, Extension } from "@codemirror/state";
+import { history, historyKeymap } from "@codemirror/history";
+import { foldGutter, foldKeymap } from "@codemirror/fold";
+import { indentOnInput } from "@codemirror/language";
+import { lineNumbers, highlightActiveLineGutter } from "@codemirror/gutter";
+import { defaultKeymap } from "@codemirror/commands";
+import { bracketMatching } from "@codemirror/matchbrackets";
+import { closeBrackets, closeBracketsKeymap } from "@codemirror/closebrackets";
+import { searchKeymap, highlightSelectionMatches } from "@codemirror/search";
+import { autocompletion, completionKeymap } from "@codemirror/autocomplete";
+import { commentKeymap } from "@codemirror/comment";
+import { rectangularSelection } from "@codemirror/rectangular-selection";
+import { defaultHighlightStyle } from "@codemirror/highlight";
+import { lintKeymap } from "@codemirror/lint";
 
 function getLanguageSupport(language: ProgrammingLanguage): LanguageSupport {
     switch (language) {
@@ -20,17 +37,68 @@ function getLanguageSupport(language: ProgrammingLanguage): LanguageSupport {
         }
     }
 }
+/*
+*  - [syntax highlighting depending on the language](#getLanguageSupport)
+*  - [line numbers](#gutter.lineNumbers)
+*  - [special character highlighting](#view.highlightSpecialChars)
+*  - [the undo history](#history.history)
+*  - [a fold gutter](#fold.foldGutter)
+*  - [custom selection drawing](#view.drawSelection)
+*  - [multiple selections](#state.EditorState^allowMultipleSelections)
+*  - [reindentation on input](#language.indentOnInput)
+*  - [the default highlight style](#highlight.defaultHighlightStyle) (as fallback)
+*  - [bracket matching](#matchbrackets.bracketMatching)
+*  - [bracket closing](#closebrackets.closeBrackets)
+*  - [autocompletion](#autocomplete.autocompletion)
+*  - [rectangular selection](#rectangular-selection.rectangularSelection)
+*  - [active line highlighting](#view.highlightActiveLine)
+*  - [active line gutter highlighting](#gutter.highlightActiveLineGutter)
+*  - [selection match highlighting](#search.highlightSelectionMatches)
+* Keymaps:
+*  - [the default command bindings](#commands.defaultKeymap)
+*  - [search](#search.searchKeymap)
+*  - [commenting](#comment.commentKeymap)
+*  - [linting](#lint.lintKeymap)
+*  - [indenting with tab](#commands.indentWithTab)
+*/
+function getExtensions(language: ProgrammingLanguage): Array<Extension> {
+    return [
+        getLanguageSupport(language),
+        lineNumbers(),
+        highlightActiveLineGutter(),
+        highlightSpecialChars(),
+        history(),
+        foldGutter(),
+        drawSelection(),
+        EditorState.allowMultipleSelections.of(true),
+        indentOnInput(),
+        defaultHighlightStyle.fallback,
+        bracketMatching(),
+        closeBrackets(),
+        autocompletion(),
+        rectangularSelection(),
+        highlightActiveLine(),
+        highlightSelectionMatches(),
+        keymap.of([
+            ...closeBracketsKeymap,
+            ...defaultKeymap,
+            ...searchKeymap,
+            ...historyKeymap,
+            ...foldKeymap,
+            ...commentKeymap,
+            ...completionKeymap,
+            ...lintKeymap
+        ]),
+        keymap.of([indentWithTab])
+    ];
+}
 
 function getEditorView(parentElement: HTMLElement,
     language: ProgrammingLanguage, initialCode?: string): EditorView {
     return new EditorView({
         state: EditorState.create({
             doc: initialCode || "",
-            extensions: [
-                getLanguageSupport(language),
-                basicSetup,
-                keymap.of([indentWithTab])
-            ]
+            extensions: getExtensions(language)
         }),
         parent: parentElement
     });

--- a/src/CodeEditor.ts
+++ b/src/CodeEditor.ts
@@ -5,7 +5,7 @@ import { javascript } from "@codemirror/lang-javascript";
 import { ProgrammingLanguage } from "./ProgrammingLanguage";
 import { python } from "@codemirror/lang-python";
 import { LanguageSupport } from "@codemirror/language";
-import { autocompletion } from "@codemirror/autocomplete";
+// import { autocompletion } from "@codemirror/autocomplete";
 
 function getLanguageSupport(language: ProgrammingLanguage): LanguageSupport {
     switch (language) {

--- a/src/CodeEditor.ts
+++ b/src/CodeEditor.ts
@@ -20,8 +20,8 @@ function getLanguageSupport(language: ProgrammingLanguage): LanguageSupport {
     }
 }
 
-export function initEditor(elemId: string, language: ProgrammingLanguage, initialCode?: string)
-    : EditorView {
+function getEditorView(parentElement: HTMLElement,
+    language: ProgrammingLanguage, initialCode?: string): EditorView {
     return new EditorView({
         state: EditorState.create({
             doc: initialCode || "",
@@ -31,6 +31,33 @@ export function initEditor(elemId: string, language: ProgrammingLanguage, initia
                 getLanguageSupport(language)
             ]
         }),
-        parent: document.getElementById(elemId) as HTMLElement
+        parent: parentElement
     });
+}
+
+export class CodeEditor {
+    element: HTMLElement;
+    editorView: EditorView | undefined;
+    minLines: number;
+
+    constructor(element: HTMLElement, language: ProgrammingLanguage,
+        initialCode?: string, minLines = 10) {
+        this.element = element;
+        this.minLines = minLines;
+        this.setLanguage(language, initialCode);
+    }
+
+    setLanguage(language: ProgrammingLanguage, code?: string): void {
+        const initialCode = code || new Array(this.minLines).fill("").join("\n");
+        this.editorView = getEditorView(this.element, language, initialCode);
+        this.element.replaceChildren(this.editorView.dom);
+    }
+
+    getCode(): string {
+        if (this.editorView) {
+            return this.editorView.state.sliceDoc();
+        } else {
+            return "";
+        }
+    }
 }

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,3 +1,5 @@
+import { ProgrammingLanguage } from "./ProgrammingLanguage";
+
 export const MAIN_APP_ID = "papyros";
 
 export const OUTPUT_TA_ID = "code-output-area";
@@ -12,6 +14,6 @@ export const TERMINATE_BTN_ID = "terminate-btn";
 
 export const LANGUAGE_SELECT_ID = "language-select";
 
-export const DEFAULT_PROGRAMMING_LANGUAGE = "Python";
+export const DEFAULT_PROGRAMMING_LANGUAGE = ProgrammingLanguage.Python;
 
 export const INPUT_RELATIVE_URL = "/__papyros_input";

--- a/src/Papyros.ts
+++ b/src/Papyros.ts
@@ -1,10 +1,7 @@
 import { proxy, Remote } from "comlink";
 import { Backend } from "./Backend";
 import { getBackend, stopBackend } from "./BackendManager";
-<<<<<<< HEAD
 import { CodeEditor } from "./CodeEditor";
-=======
->>>>>>> Add ProgrammingLanguage enum
 import {
     APPLICATION_STATE_TEXT_ID, CODE_TA_ID, DEFAULT_PROGRAMMING_LANGUAGE, INPUT_RELATIVE_URL,
     INPUT_TA_ID, LANGUAGE_SELECT_ID, OUTPUT_TA_ID,
@@ -63,12 +60,8 @@ export function papyros(inputTextArray?: Uint8Array, inputMetaData?: Int32Array)
             async () => {
                 const language = plFromString(languageSelect.value);
                 stopBackend(backend);
-<<<<<<< HEAD
                 codeEditor.setLanguage(language, codeEditor.getCode());
                 initBackend(language);
-=======
-                return initBackend(plFromString(languageSelect.value));
->>>>>>> Add ProgrammingLanguage enum
             }
         );
     }

--- a/src/Papyros.ts
+++ b/src/Papyros.ts
@@ -1,7 +1,10 @@
 import { proxy, Remote } from "comlink";
 import { Backend } from "./Backend";
 import { getBackend, stopBackend } from "./BackendManager";
+<<<<<<< HEAD
 import { CodeEditor } from "./CodeEditor";
+=======
+>>>>>>> Add ProgrammingLanguage enum
 import {
     APPLICATION_STATE_TEXT_ID, CODE_TA_ID, DEFAULT_PROGRAMMING_LANGUAGE, INPUT_RELATIVE_URL,
     INPUT_TA_ID, LANGUAGE_SELECT_ID, OUTPUT_TA_ID,
@@ -60,8 +63,12 @@ export function papyros(inputTextArray?: Uint8Array, inputMetaData?: Int32Array)
             async () => {
                 const language = plFromString(languageSelect.value);
                 stopBackend(backend);
+<<<<<<< HEAD
                 codeEditor.setLanguage(language, codeEditor.getCode());
                 initBackend(language);
+=======
+                return initBackend(plFromString(languageSelect.value));
+>>>>>>> Add ProgrammingLanguage enum
             }
         );
     }

--- a/src/Papyros.ts
+++ b/src/Papyros.ts
@@ -1,10 +1,13 @@
 import { proxy, Remote } from "comlink";
 import { Backend } from "./Backend";
 import { getBackend, stopBackend } from "./BackendManager";
-import { APPLICATION_STATE_TEXT_ID, CODE_TA_ID, DEFAULT_PROGRAMMING_LANGUAGE, INPUT_RELATIVE_URL,
+import {
+    APPLICATION_STATE_TEXT_ID, CODE_TA_ID, DEFAULT_PROGRAMMING_LANGUAGE, INPUT_RELATIVE_URL,
     INPUT_TA_ID, LANGUAGE_SELECT_ID, OUTPUT_TA_ID,
-    RUN_BTN_ID, STATE_SPINNER_ID, TERMINATE_BTN_ID } from "./Constants";
+    RUN_BTN_ID, STATE_SPINNER_ID, TERMINATE_BTN_ID
+} from "./Constants";
 import { PapyrosEvent } from "./PapyrosEvent";
+import { plFromString, ProgrammingLanguage } from "./ProgrammingLanguage";
 import { LogType, papyrosLog } from "./util/Logging";
 
 export function papyros(inputTextArray?: Uint8Array, inputMetaData?: Int32Array): void {
@@ -32,22 +35,20 @@ export function papyros(inputTextArray?: Uint8Array, inputMetaData?: Int32Array)
 
 
     function init(): void {
-        const language = new URLSearchParams(window.location.search).get("language") ||
-            DEFAULT_PROGRAMMING_LANGUAGE;
+        const language = plFromString(new URLSearchParams(window.location.search).get("language") ||
+                         DEFAULT_PROGRAMMING_LANGUAGE);
+        languageSelect.value = language;
         initBackend(language);
         initTextAreas();
         initButtons();
         initLanguageSelect();
     }
 
-    async function initBackend(language?: string): Promise<void> {
+    async function initBackend(language: ProgrammingLanguage): Promise<void> {
         runButton.disabled = true;
-        if (language) {
-            languageSelect.value = language;
-        }
         stateSpinner.style.display = "";
-        stateText.innerText = `Loading backend for ${languageSelect.value}`;
-        backend = getBackend(languageSelect.value);
+        stateText.innerText = `Loading backend for ${language}`;
+        backend = getBackend(language);
         await backend.launch(proxy(e => onMessage(e)), inputTextArray, inputMetaData);
         runButton.disabled = false;
         stateText.innerText = "";
@@ -58,7 +59,7 @@ export function papyros(inputTextArray?: Uint8Array, inputMetaData?: Int32Array)
         languageSelect.addEventListener("change",
             () => {
                 stopBackend(backend);
-                return initBackend();
+                return initBackend(plFromString(languageSelect.value));
             }
         );
     }
@@ -164,7 +165,7 @@ export function papyros(inputTextArray?: Uint8Array, inputMetaData?: Int32Array)
         stateText.innerText = "Terminating backend";
         terminateButton.hidden = true;
         stopBackend(backend);
-        return initBackend();
+        return initBackend(plFromString(languageSelect.value));
     }
 
     function initButtons(): void {

--- a/src/Papyros.ts
+++ b/src/Papyros.ts
@@ -60,7 +60,7 @@ export function papyros(inputTextArray?: Uint8Array, inputMetaData?: Int32Array)
             async () => {
                 const language = plFromString(languageSelect.value);
                 stopBackend(backend);
-                codeEditor.setLanguage(language);
+                codeEditor.setLanguage(language, codeEditor.getCode());
                 initBackend(language);
             }
         );

--- a/src/ProgrammingLanguage.ts
+++ b/src/ProgrammingLanguage.ts
@@ -1,0 +1,18 @@
+export enum ProgrammingLanguage {
+    Python = "Python",
+    JavaScript = "JavaScript"
+}
+
+const LANGUAGE_MAP = new Map([
+    ["python", ProgrammingLanguage.Python],
+    ["javascript", ProgrammingLanguage.JavaScript]
+]);
+
+export function plFromString(language: string): ProgrammingLanguage {
+    const langLC = language.toLowerCase();
+    if (LANGUAGE_MAP.has(langLC)) {
+        return LANGUAGE_MAP.get(langLC)!;
+    } else {
+        throw new Error(`Unsupported language: ${language}`);
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -412,27 +412,6 @@
     "@codemirror/view" "^0.19.0"
     "@lezer/common" "^0.15.0"
 
-"@codemirror/basic-setup@^0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@codemirror/basic-setup/-/basic-setup-0.19.0.tgz#dc84dd735c8a88dd38c9dcc80cbfefa31d7e8f20"
-  integrity sha512-Yhrf7fIz8+INHWOhpWeRwbs8fpc0KsydX9baD7TyYqniLVWyTi0Hwm52mr0f5O+k4YaJPeHAgT3x9gzDXZIvOw==
-  dependencies:
-    "@codemirror/autocomplete" "^0.19.0"
-    "@codemirror/closebrackets" "^0.19.0"
-    "@codemirror/commands" "^0.19.0"
-    "@codemirror/comment" "^0.19.0"
-    "@codemirror/fold" "^0.19.0"
-    "@codemirror/gutter" "^0.19.0"
-    "@codemirror/highlight" "^0.19.0"
-    "@codemirror/history" "^0.19.0"
-    "@codemirror/language" "^0.19.0"
-    "@codemirror/lint" "^0.19.0"
-    "@codemirror/matchbrackets" "^0.19.0"
-    "@codemirror/rectangular-selection" "^0.19.0"
-    "@codemirror/search" "^0.19.0"
-    "@codemirror/state" "^0.19.0"
-    "@codemirror/view" "^0.19.0"
-
 "@codemirror/closebrackets@^0.19.0":
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/@codemirror/closebrackets/-/closebrackets-0.19.0.tgz#69fdcee85779d638a00a42becd9f53a33a26d77f"
@@ -444,7 +423,7 @@
     "@codemirror/text" "^0.19.0"
     "@codemirror/view" "^0.19.0"
 
-"@codemirror/commands@^0.19.0":
+"@codemirror/commands@^0.19.5":
   version "0.19.5"
   resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-0.19.5.tgz#2607b5c12c5c96df2cabce2e43f6285c07cfaf11"
   integrity sha512-8PZOtx7d/GbKhFYA88zs2wINDtaUgj3pEjLYScKTd/Vsyw8qOp86tJQQNnMFTRZj/ISQl9Lbg3aAmHvroMqspw==
@@ -465,7 +444,7 @@
     "@codemirror/text" "^0.19.0"
     "@codemirror/view" "^0.19.0"
 
-"@codemirror/fold@^0.19.0":
+"@codemirror/fold@^0.19.1":
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@codemirror/fold/-/fold-0.19.1.tgz#52000ff329ab69c4ba32e94401777941e29d8ad0"
   integrity sha512-3GwQpxgv03urb8BPBvX1JSjl+uMXKqngRG6qHZXSM2FefxFKvTuyL44MCb35aodtfKjGwoxizk+7b6CbAOLyOw==
@@ -576,7 +555,7 @@
   dependencies:
     "@codemirror/state" "^0.19.0"
 
-"@codemirror/rectangular-selection@^0.19.0":
+"@codemirror/rectangular-selection@^0.19.1":
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@codemirror/rectangular-selection/-/rectangular-selection-0.19.1.tgz#5a88ece4fb68ce5682539497db8a64fc015aae63"
   integrity sha512-9ElnqOg3mpZIWe0prPRd1SZ48Q9QB3bR8Aocq8UtjboJSUG8ABhRrbuTZMW/rMqpBPSjVpCe9xkCCkEQMYQVmw==
@@ -585,14 +564,14 @@
     "@codemirror/text" "^0.19.4"
     "@codemirror/view" "^0.19.0"
 
-"@codemirror/search@^0.19.0":
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/@codemirror/search/-/search-0.19.2.tgz#d549c3daa527e17c173cdfc90b7c1b02deab1502"
-  integrity sha512-TrRxUxyJ/a7HXtUvMZhgkOUbKE1xO33UhXjn1XACEHKWhgovw1vEeEEti9dZejN8/QOOFJed39InUxmp7oQ8HA==
+"@codemirror/search@^0.19.3":
+  version "0.19.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/search/-/search-0.19.3.tgz#9c81f89e965e708a5095aeebb4a181c463d37f17"
+  integrity sha512-T8AcSGNYuYtmOUXzI0VtCa9SMA0C90/Zk7fxnabgy0dpViwokucCMY2+aBZMPncIatkgojzbiRn7d5Qo1Ugx9w==
   dependencies:
     "@codemirror/panel" "^0.19.0"
     "@codemirror/rangeset" "^0.19.0"
-    "@codemirror/state" "^0.19.2"
+    "@codemirror/state" "^0.19.3"
     "@codemirror/text" "^0.19.0"
     "@codemirror/view" "^0.19.0"
     crelt "^1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -400,7 +400,7 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@codemirror/autocomplete@^0.19.0":
+"@codemirror/autocomplete@^0.19.0", "@codemirror/autocomplete@^0.19.8":
   version "0.19.8"
   resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-0.19.8.tgz#a4a886089f0248a0d1ccdc11d9f8560c0b2c2abd"
   integrity sha512-o4I1pRlFjhBHOYab+QfpKcW0B8FqAH+2pdmCYrkTz3bm1djVwhlMEhv1s/aTKhdjLtkfZFUbdHBi+8xe22wUCA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -400,6 +400,234 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@codemirror/autocomplete@^0.19.0":
+  version "0.19.8"
+  resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-0.19.8.tgz#a4a886089f0248a0d1ccdc11d9f8560c0b2c2abd"
+  integrity sha512-o4I1pRlFjhBHOYab+QfpKcW0B8FqAH+2pdmCYrkTz3bm1djVwhlMEhv1s/aTKhdjLtkfZFUbdHBi+8xe22wUCA==
+  dependencies:
+    "@codemirror/language" "^0.19.0"
+    "@codemirror/state" "^0.19.4"
+    "@codemirror/text" "^0.19.2"
+    "@codemirror/tooltip" "^0.19.0"
+    "@codemirror/view" "^0.19.0"
+    "@lezer/common" "^0.15.0"
+
+"@codemirror/basic-setup@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/basic-setup/-/basic-setup-0.19.0.tgz#dc84dd735c8a88dd38c9dcc80cbfefa31d7e8f20"
+  integrity sha512-Yhrf7fIz8+INHWOhpWeRwbs8fpc0KsydX9baD7TyYqniLVWyTi0Hwm52mr0f5O+k4YaJPeHAgT3x9gzDXZIvOw==
+  dependencies:
+    "@codemirror/autocomplete" "^0.19.0"
+    "@codemirror/closebrackets" "^0.19.0"
+    "@codemirror/commands" "^0.19.0"
+    "@codemirror/comment" "^0.19.0"
+    "@codemirror/fold" "^0.19.0"
+    "@codemirror/gutter" "^0.19.0"
+    "@codemirror/highlight" "^0.19.0"
+    "@codemirror/history" "^0.19.0"
+    "@codemirror/language" "^0.19.0"
+    "@codemirror/lint" "^0.19.0"
+    "@codemirror/matchbrackets" "^0.19.0"
+    "@codemirror/rectangular-selection" "^0.19.0"
+    "@codemirror/search" "^0.19.0"
+    "@codemirror/state" "^0.19.0"
+    "@codemirror/view" "^0.19.0"
+
+"@codemirror/closebrackets@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/closebrackets/-/closebrackets-0.19.0.tgz#69fdcee85779d638a00a42becd9f53a33a26d77f"
+  integrity sha512-dFWX5OEVYWRNtGaifSbwIAlymnRRjxWMiMbffbAjF7p0zfGHDbdGkiT56q3Xud63h5/tQdSo5dK1iyNTzHz5vg==
+  dependencies:
+    "@codemirror/language" "^0.19.0"
+    "@codemirror/rangeset" "^0.19.0"
+    "@codemirror/state" "^0.19.0"
+    "@codemirror/text" "^0.19.0"
+    "@codemirror/view" "^0.19.0"
+
+"@codemirror/commands@^0.19.0":
+  version "0.19.5"
+  resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-0.19.5.tgz#2607b5c12c5c96df2cabce2e43f6285c07cfaf11"
+  integrity sha512-8PZOtx7d/GbKhFYA88zs2wINDtaUgj3pEjLYScKTd/Vsyw8qOp86tJQQNnMFTRZj/ISQl9Lbg3aAmHvroMqspw==
+  dependencies:
+    "@codemirror/language" "^0.19.0"
+    "@codemirror/matchbrackets" "^0.19.0"
+    "@codemirror/state" "^0.19.2"
+    "@codemirror/text" "^0.19.0"
+    "@codemirror/view" "^0.19.0"
+    "@lezer/common" "^0.15.0"
+
+"@codemirror/comment@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/comment/-/comment-0.19.0.tgz#4f23497924e9346898c2e0123011acc535a0bea6"
+  integrity sha512-3hqAd0548fxqOBm4khFMcXVIivX8p0bSlbAuZJ6PNoUn/0wXhxkxowPp0FmFzU2+y37Z+ZQF5cRB5EREWPRIiQ==
+  dependencies:
+    "@codemirror/state" "^0.19.0"
+    "@codemirror/text" "^0.19.0"
+    "@codemirror/view" "^0.19.0"
+
+"@codemirror/fold@^0.19.0":
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/fold/-/fold-0.19.1.tgz#52000ff329ab69c4ba32e94401777941e29d8ad0"
+  integrity sha512-3GwQpxgv03urb8BPBvX1JSjl+uMXKqngRG6qHZXSM2FefxFKvTuyL44MCb35aodtfKjGwoxizk+7b6CbAOLyOw==
+  dependencies:
+    "@codemirror/gutter" "^0.19.0"
+    "@codemirror/language" "^0.19.0"
+    "@codemirror/rangeset" "^0.19.0"
+    "@codemirror/state" "^0.19.0"
+    "@codemirror/view" "^0.19.0"
+
+"@codemirror/gutter@^0.19.0", "@codemirror/gutter@^0.19.4":
+  version "0.19.5"
+  resolved "https://registry.yarnpkg.com/@codemirror/gutter/-/gutter-0.19.5.tgz#b90527832c3f3066d1aeb53b003a764b5a561cfc"
+  integrity sha512-Vqy+RXgBdnmbxNYx4/irQcfU9ecFz8SB/vhDOeHHSGtDqs+TihYHnHgBZLz6uILEG0YIjp0/zYY3P2NgZ/iyEg==
+  dependencies:
+    "@codemirror/rangeset" "^0.19.0"
+    "@codemirror/state" "^0.19.0"
+    "@codemirror/view" "^0.19.0"
+
+"@codemirror/highlight@^0.19.0", "@codemirror/highlight@^0.19.6":
+  version "0.19.6"
+  resolved "https://registry.yarnpkg.com/@codemirror/highlight/-/highlight-0.19.6.tgz#7f2e066f83f5649e8e0748a3abe0aaeaf64b8ac2"
+  integrity sha512-+eibu6on9quY8uN3xJ/n3rH+YIDLlpX7YulVmFvqAIz/ukRQ5tWaBmB7fMixHmnmRIRBRZgB8rNtonuMwZSAHQ==
+  dependencies:
+    "@codemirror/language" "^0.19.0"
+    "@codemirror/rangeset" "^0.19.0"
+    "@codemirror/state" "^0.19.0"
+    "@codemirror/view" "^0.19.0"
+    "@lezer/common" "^0.15.0"
+    style-mod "^4.0.0"
+
+"@codemirror/history@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/history/-/history-0.19.0.tgz#cc8095c927c9566f7b69fa404074edde4c54d39c"
+  integrity sha512-E0H+lncH66IMDhaND9jgkjE7s0dhYfjCPmS+Ig2Yes9I8+UIEecIdObj8c8HPCFGctGg3fxXqRAw2mdHl2Wouw==
+  dependencies:
+    "@codemirror/state" "^0.19.0"
+    "@codemirror/view" "^0.19.0"
+
+"@codemirror/lang-javascript@^0.19.3":
+  version "0.19.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-javascript/-/lang-javascript-0.19.3.tgz#281b3447d8b65d98311ebf25893ef5c30a11418b"
+  integrity sha512-2NE5z98Nz9Rv4OS5UtgehCSnyQjac+P85+evzy1D/4wllp/EPaHIEEtSP1daBvrLy49SdI/9vES3ZJu6rSv4/w==
+  dependencies:
+    "@codemirror/autocomplete" "^0.19.0"
+    "@codemirror/highlight" "^0.19.6"
+    "@codemirror/language" "^0.19.0"
+    "@codemirror/lint" "^0.19.0"
+    "@codemirror/state" "^0.19.0"
+    "@codemirror/view" "^0.19.0"
+    "@lezer/javascript" "^0.15.1"
+
+"@codemirror/lang-python@^0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-python/-/lang-python-0.19.2.tgz#4c1bdb3bf4632481be7c3bc14cac3a162c9c4fbc"
+  integrity sha512-qeDymHL97+pNxFiDrtaMFvd/dActt7sZjebPnrc8T2V1CcBkc2YkcaxEOD5dssM/rQ9dG9LqON/Nbk2fIxcapA==
+  dependencies:
+    "@codemirror/highlight" "^0.19.0"
+    "@codemirror/language" "^0.19.0"
+    "@lezer/python" "^0.15.0"
+
+"@codemirror/language@^0.19.0", "@codemirror/language@^0.19.5":
+  version "0.19.5"
+  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-0.19.5.tgz#4d816ce3f72974ad443cbf1a18ff4fcd1e56f1d0"
+  integrity sha512-FnIST07vaM99mv1mJaMMLvxiHSDGgP3wdlcEZzmidndWdbxjrYYYnJzVUOEkeZJNGOfrtPRMF62UCyrTjQMR3g==
+  dependencies:
+    "@codemirror/state" "^0.19.0"
+    "@codemirror/text" "^0.19.0"
+    "@codemirror/view" "^0.19.0"
+    "@lezer/common" "^0.15.5"
+    "@lezer/lr" "^0.15.0"
+
+"@codemirror/lint@^0.19.0":
+  version "0.19.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/lint/-/lint-0.19.3.tgz#84101d0967fea8df114a8f0f79965c22ccd3b3cc"
+  integrity sha512-+c39s05ybD2NjghxkPFsUbH/qBL0cdzKmtHbzUm0RVspeL2OiP7uHYJ6J5+Qr9RjMIPWzcqSauRqxfmCrctUfg==
+  dependencies:
+    "@codemirror/gutter" "^0.19.4"
+    "@codemirror/panel" "^0.19.0"
+    "@codemirror/rangeset" "^0.19.1"
+    "@codemirror/state" "^0.19.4"
+    "@codemirror/tooltip" "^0.19.5"
+    "@codemirror/view" "^0.19.0"
+    crelt "^1.0.5"
+
+"@codemirror/matchbrackets@^0.19.0":
+  version "0.19.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/matchbrackets/-/matchbrackets-0.19.3.tgz#1f430ada6fa21af2205280ff344ef57bb95dd3cb"
+  integrity sha512-ljkrBxaLgh8jesroUiBa57pdEwqJamxkukXrJpL9LdyFZVJaF+9TldhztRaMsMZO1XnCSSHQ9sg32iuHo7Sc2g==
+  dependencies:
+    "@codemirror/language" "^0.19.0"
+    "@codemirror/state" "^0.19.0"
+    "@codemirror/view" "^0.19.0"
+    "@lezer/common" "^0.15.0"
+
+"@codemirror/panel@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/panel/-/panel-0.19.0.tgz#18c7a253a7a1ef686bece1ef13ec0e5eb6603265"
+  integrity sha512-LJuu49xnuhaAztlhnLJQ57ddOirSyf8/lnl7twsQUG/05RkxodBZ9F7q8r5AOLqOkaQOy9WySEKX1Ur8lD9Q5w==
+  dependencies:
+    "@codemirror/state" "^0.19.0"
+    "@codemirror/view" "^0.19.0"
+
+"@codemirror/rangeset@^0.19.0", "@codemirror/rangeset@^0.19.1":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/rangeset/-/rangeset-0.19.2.tgz#d7a999e4273c00fecef4aba8535a426073cdcddf"
+  integrity sha512-5d+X8LtmeZtfFtKrSx57bIHRUpKv2HD0b74clp4fGA7qJLLfYehF6FGkJJxJb8lKsqAga1gdjjWr0jiypmIxoQ==
+  dependencies:
+    "@codemirror/state" "^0.19.0"
+
+"@codemirror/rectangular-selection@^0.19.0":
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/rectangular-selection/-/rectangular-selection-0.19.1.tgz#5a88ece4fb68ce5682539497db8a64fc015aae63"
+  integrity sha512-9ElnqOg3mpZIWe0prPRd1SZ48Q9QB3bR8Aocq8UtjboJSUG8ABhRrbuTZMW/rMqpBPSjVpCe9xkCCkEQMYQVmw==
+  dependencies:
+    "@codemirror/state" "^0.19.0"
+    "@codemirror/text" "^0.19.4"
+    "@codemirror/view" "^0.19.0"
+
+"@codemirror/search@^0.19.0":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/search/-/search-0.19.2.tgz#d549c3daa527e17c173cdfc90b7c1b02deab1502"
+  integrity sha512-TrRxUxyJ/a7HXtUvMZhgkOUbKE1xO33UhXjn1XACEHKWhgovw1vEeEEti9dZejN8/QOOFJed39InUxmp7oQ8HA==
+  dependencies:
+    "@codemirror/panel" "^0.19.0"
+    "@codemirror/rangeset" "^0.19.0"
+    "@codemirror/state" "^0.19.2"
+    "@codemirror/text" "^0.19.0"
+    "@codemirror/view" "^0.19.0"
+    crelt "^1.0.5"
+
+"@codemirror/state@^0.19.0", "@codemirror/state@^0.19.2", "@codemirror/state@^0.19.3", "@codemirror/state@^0.19.4":
+  version "0.19.6"
+  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-0.19.6.tgz#d631f041d39ce41b7891b099fca26cb1fdb9763e"
+  integrity sha512-sqIQZE9VqwQj7D4c2oz9mfLhlT1ElAzGB5lO1lE33BPyrdNy1cJyCIOecT4cn4VeJOFrnjOeu+IftZ3zqdFETw==
+  dependencies:
+    "@codemirror/text" "^0.19.0"
+
+"@codemirror/text@^0.19.0", "@codemirror/text@^0.19.2", "@codemirror/text@^0.19.4":
+  version "0.19.5"
+  resolved "https://registry.yarnpkg.com/@codemirror/text/-/text-0.19.5.tgz#75033af2476214e79eae22b81ada618815441c18"
+  integrity sha512-Syu5Xc7tZzeUAM/y4fETkT0zgGr48rDG+w4U38bPwSIUr+L9S/7w2wDE1WGNzjaZPz12F6gb1gxWiSTg9ocLow==
+
+"@codemirror/tooltip@^0.19.0", "@codemirror/tooltip@^0.19.5":
+  version "0.19.8"
+  resolved "https://registry.yarnpkg.com/@codemirror/tooltip/-/tooltip-0.19.8.tgz#f9675c3690e8dafb00a5c8c1cb86d960b99b9235"
+  integrity sha512-Xg1H50utH3z1rmyzk5l/dfE0Lko+5pkxzaVlVzAbcqHlDsG9vARDkgRX+fEEpWg/rrvR83GVQhdKwl+wNxjOAg==
+  dependencies:
+    "@codemirror/state" "^0.19.0"
+    "@codemirror/view" "^0.19.0"
+
+"@codemirror/view@^0.19.0":
+  version "0.19.20"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-0.19.20.tgz#77969ff93cb097e3d4c9245b32e220efb80131be"
+  integrity sha512-j4cI/Egdhha77pMfKQQWZmpkcF7vhe21LqdZs8hsG09OtvsPVCHUXmfB0u7nMpcX1JR8aZ3ob9g6FMr+OVtjgA==
+  dependencies:
+    "@codemirror/rangeset" "^0.19.0"
+    "@codemirror/state" "^0.19.3"
+    "@codemirror/text" "^0.19.0"
+    style-mod "^4.0.0"
+    w3c-keyname "^2.2.4"
+
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz#9283c9ce5b289a3c4f61c12757469e59377f81f3"
@@ -606,6 +834,32 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@lezer/common@^0.15.0", "@lezer/common@^0.15.5":
+  version "0.15.8"
+  resolved "https://registry.yarnpkg.com/@lezer/common/-/common-0.15.8.tgz#e9d87b5f05c18feb51b7f04d74b124caea32a94b"
+  integrity sha512-zpS/xty48huX4uBidupmWDYCRBYpVtoTiFhzYhd6GsQwU67WsdSImdWzZJDrF/DhcQ462wyrZahHlo2grFB5ig==
+
+"@lezer/javascript@^0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@lezer/javascript/-/javascript-0.15.1.tgz#12794febbea8b9113edae46acae1994ff801805d"
+  integrity sha512-EnfO9MF2yDMpN2DEovPbKKdi4tj1phuolBxcEDC35cx+OUfToweMOEBZHr/nhHI79+6HkLMoCK2coch+PT+oBA==
+  dependencies:
+    "@lezer/lr" "^0.15.0"
+
+"@lezer/lr@^0.15.0":
+  version "0.15.4"
+  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-0.15.4.tgz#634670d7224040fddac1370af01211eecd9ac0a0"
+  integrity sha512-vwgG80sihEGJn6wJp6VijXrnzVai/KPva/OzYKaWvIx0IiXKjoMQ8UAwcgpSBwfS4Fbz3IKOX/cCNXU3r1FvpQ==
+  dependencies:
+    "@lezer/common" "^0.15.0"
+
+"@lezer/python@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@lezer/python/-/python-0.15.0.tgz#cdaff609efdba9586ed7e0b383edd570b18427f2"
+  integrity sha512-KkbNfjLZCs/Ibx+3mekGu31qz+zCVkXHL+oNftRxB/lsINlz25SURR5z6wb94JpJt0yDFCEtn/2siAUybLOXiA==
+  dependencies:
+    "@lezer/lr" "^0.15.0"
+
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
@@ -678,6 +932,13 @@
   integrity sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==
   dependencies:
     "@babel/types" "^7.3.0"
+
+"@types/codemirror@^5.60.5":
+  version "5.60.5"
+  resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-5.60.5.tgz#5b989a3b4bbe657458cf372c92b6bfda6061a2b7"
+  integrity sha512-TiECZmm8St5YxjFUp64LK0c8WU5bxMDt9YaAek1UqUb9swrSCoJhh92fWu1p3mTEqlHjhB5sY7OFBhWroJXZVg==
+  dependencies:
+    "@types/tern" "*"
 
 "@types/eslint-scope@^3.7.0":
   version "3.7.1"
@@ -786,6 +1047,13 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
+
+"@types/tern@*":
+  version "0.23.4"
+  resolved "https://registry.yarnpkg.com/@types/tern/-/tern-0.23.4.tgz#03926eb13dbeaf3ae0d390caf706b2643a0127fb"
+  integrity sha512-JAUw1iXGO1qaWwEOzxTKJZ/5JxVeON9kvGZ/osgZaJImBnyjyn0cjovPsf6FNLmyGY8Vw9DoXZCMlfMkMwHRWg==
+  dependencies:
+    "@types/estree" "*"
 
 "@types/yargs-parser@*":
   version "20.2.1"
@@ -1947,6 +2215,11 @@ cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
+
+crelt@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/crelt/-/crelt-1.0.5.tgz#57c0d52af8c859e354bace1883eb2e1eb182bb94"
+  integrity sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA==
 
 cross-spawn@^6.0.0:
   version "6.0.5"
@@ -6131,6 +6404,11 @@ style-loader@^3.3.1:
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.1.tgz#057dfa6b3d4d7c7064462830f9113ed417d38575"
   integrity sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==
 
+style-mod@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.0.0.tgz#97e7c2d68b592975f2ca7a63d0dd6fcacfe35a01"
+  integrity sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -6578,6 +6856,11 @@ w3c-hr-time@^1.0.2:
   integrity sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==
   dependencies:
     browser-process-hrtime "^1.0.0"
+
+w3c-keyname@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.4.tgz#4ade6916f6290224cdbd1db8ac49eab03d0eef6b"
+  integrity sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw==
 
 w3c-xmlserializer@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This pull request replaces the text area to enter code with an instance of [CodeMirror 6](https://codemirror.net/6/).

![codemirror-example](https://user-images.githubusercontent.com/53743234/143932708-72238cf4-cfe9-432e-9207-794f9fa3355d.PNG)

CM6 was chosen over alternatives such as Ace and Monaco because of its better documentation and extensibility.

![image](https://user-images.githubusercontent.com/481872/144223166-40d6b81d-7d94-4cdb-8dbd-827c2cb57e73.png)

For now, only basic features such as line numbers, auto-closing brackets and syntax highlighting are supported. It is possible to enable more advanced language features such as auto-complete and highlighting incorrect syntax, but they will be added in a later update as part of #46.


Closes #2 
Closes #34