### PR TITLE
Allow configuring indent size

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@codemirror/lang-python": "^0.19.2",
     "@codemirror/rectangular-selection": "^0.19.1",
     "@codemirror/search": "^0.19.3",
+    "@codemirror/state": "^0.19.6",
     "comlink": "^4.3.1",
     "i18n-js": "^3.8.0"
   },

--- a/src/CodeEditor.ts
+++ b/src/CodeEditor.ts
@@ -1,28 +1,11 @@
+import { EditorState, basicSetup } from "@codemirror/basic-setup";
+import { EditorView, keymap } from "@codemirror/view";
 import { indentWithTab } from "@codemirror/commands";
 import { javascript } from "@codemirror/lang-javascript";
 import { ProgrammingLanguage } from "./ProgrammingLanguage";
 import { python } from "@codemirror/lang-python";
-import { LanguageSupport } from "@codemirror/language";
-import {
-    EditorView,
-    keymap, highlightSpecialChars,
-    drawSelection, highlightActiveLine
-}
-    from "@codemirror/view";
-import { EditorState, Extension } from "@codemirror/state";
-import { history, historyKeymap } from "@codemirror/history";
-import { foldGutter, foldKeymap } from "@codemirror/fold";
-import { indentOnInput } from "@codemirror/language";
-import { lineNumbers, highlightActiveLineGutter } from "@codemirror/gutter";
-import { defaultKeymap } from "@codemirror/commands";
-import { bracketMatching } from "@codemirror/matchbrackets";
-import { closeBrackets, closeBracketsKeymap } from "@codemirror/closebrackets";
-import { searchKeymap, highlightSelectionMatches } from "@codemirror/search";
-import { autocompletion, completionKeymap } from "@codemirror/autocomplete";
-import { commentKeymap } from "@codemirror/comment";
-import { rectangularSelection } from "@codemirror/rectangular-selection";
-import { defaultHighlightStyle } from "@codemirror/highlight";
-import { lintKeymap } from "@codemirror/lint";
+import { indentUnit, LanguageSupport } from "@codemirror/language";
+import { Compartment, Extension } from "@codemirror/state";
 
 function getLanguageSupport(language: ProgrammingLanguage): LanguageSupport {
     switch (language) {
@@ -37,93 +20,56 @@ function getLanguageSupport(language: ProgrammingLanguage): LanguageSupport {
         }
     }
 }
-/*
-*  - [syntax highlighting depending on the language](#getLanguageSupport)
-*  - [line numbers](#gutter.lineNumbers)
-*  - [special character highlighting](#view.highlightSpecialChars)
-*  - [the undo history](#history.history)
-*  - [a fold gutter](#fold.foldGutter)
-*  - [custom selection drawing](#view.drawSelection)
-*  - [multiple selections](#state.EditorState^allowMultipleSelections)
-*  - [reindentation on input](#language.indentOnInput)
-*  - [the default highlight style](#highlight.defaultHighlightStyle) (as fallback)
-*  - [bracket matching](#matchbrackets.bracketMatching)
-*  - [bracket closing](#closebrackets.closeBrackets)
-*  - [autocompletion](#autocomplete.autocompletion)
-*  - [rectangular selection](#rectangular-selection.rectangularSelection)
-*  - [active line highlighting](#view.highlightActiveLine)
-*  - [active line gutter highlighting](#gutter.highlightActiveLineGutter)
-*  - [selection match highlighting](#search.highlightSelectionMatches)
-* Keymaps:
-*  - [the default command bindings](#commands.defaultKeymap)
-*  - [search](#search.searchKeymap)
-*  - [commenting](#comment.commentKeymap)
-*  - [linting](#lint.lintKeymap)
-*  - [indenting with tab](#commands.indentWithTab)
-*/
-function getExtensions(language: ProgrammingLanguage): Array<Extension> {
-    return [
-        getLanguageSupport(language),
-        lineNumbers(),
-        highlightActiveLineGutter(),
-        highlightSpecialChars(),
-        history(),
-        foldGutter(),
-        drawSelection(),
-        EditorState.allowMultipleSelections.of(true),
-        indentOnInput(),
-        defaultHighlightStyle.fallback,
-        bracketMatching(),
-        closeBrackets(),
-        autocompletion(),
-        rectangularSelection(),
-        highlightActiveLine(),
-        highlightSelectionMatches(),
-        keymap.of([
-            ...closeBracketsKeymap,
-            ...defaultKeymap,
-            ...searchKeymap,
-            ...historyKeymap,
-            ...foldKeymap,
-            ...commentKeymap,
-            ...completionKeymap,
-            ...lintKeymap
-        ]),
-        keymap.of([indentWithTab])
-    ];
-}
 
 function getEditorView(parentElement: HTMLElement,
-    language: ProgrammingLanguage, initialCode?: string): EditorView {
+    initialCode = "", extensions?: Extension[]): EditorView {
     return new EditorView({
         state: EditorState.create({
-            doc: initialCode || "",
-            extensions: getExtensions(language)
+            doc: initialCode,
+            extensions: [
+                extensions || [],
+                basicSetup,
+                keymap.of([indentWithTab])
+            ]
         }),
         parent: parentElement
     });
 }
 
+function getIndentUnit(indentLength: number): string {
+    return new Array(indentLength).fill(" ").join("");
+}
+
 export class CodeEditor {
-    element: HTMLElement;
-    editorView: EditorView | undefined;
+    editorView: EditorView;
+    languageCompartment: Compartment;
+    indentCompartment: Compartment;
 
     constructor(element: HTMLElement, language: ProgrammingLanguage,
-        initialCode?: string) {
-        this.element = element;
-        this.setLanguage(language, initialCode);
+        initialCode?: string, indentLength = 4) {
+        this.languageCompartment = new Compartment();
+        this.indentCompartment = new Compartment();
+        this.editorView = getEditorView(element, initialCode,
+            [
+                this.languageCompartment.of(getLanguageSupport(language)),
+                this.indentCompartment.of(indentUnit.of(getIndentUnit(indentLength)))
+            ]);
+        element.replaceChildren(this.editorView.dom);
     }
 
-    setLanguage(language: ProgrammingLanguage, code?: string): void {
-        this.editorView = getEditorView(this.element, language, code);
-        this.element.replaceChildren(this.editorView.dom);
+    setLanguage(language: ProgrammingLanguage): void {
+        this.editorView.dispatch({
+            effects: this.languageCompartment.reconfigure(getLanguageSupport(language))
+        });
+    }
+
+    setIndentLength(indentLength: number): void {
+        this.editorView.dispatch({
+            effects: this.indentCompartment.reconfigure(indentUnit.of(getIndentUnit(indentLength)))
+        });
     }
 
     getCode(): string {
-        if (this.editorView) {
-            return this.editorView.state.doc.toString();
-        } else {
-            return "";
-        }
+        return this.editorView.state.doc.toString();
     }
 }

--- a/src/CodeEditor.ts
+++ b/src/CodeEditor.ts
@@ -1,11 +1,28 @@
-import { EditorState, basicSetup } from "@codemirror/basic-setup";
-import { EditorView, keymap } from "@codemirror/view";
 import { indentWithTab } from "@codemirror/commands";
 import { javascript } from "@codemirror/lang-javascript";
+import { indentUnit, LanguageSupport } from "@codemirror/language";
+import { Compartment, EditorState, Extension } from "@codemirror/state";
 import { ProgrammingLanguage } from "./ProgrammingLanguage";
 import { python } from "@codemirror/lang-python";
-import { indentUnit, LanguageSupport } from "@codemirror/language";
-import { Compartment, Extension } from "@codemirror/state";
+import {
+    EditorView,
+    keymap, highlightSpecialChars,
+    drawSelection, highlightActiveLine
+}
+    from "@codemirror/view";
+import { history, historyKeymap } from "@codemirror/history";
+import { foldGutter, foldKeymap } from "@codemirror/fold";
+import { indentOnInput } from "@codemirror/language";
+import { lineNumbers, highlightActiveLineGutter } from "@codemirror/gutter";
+import { defaultKeymap } from "@codemirror/commands";
+import { bracketMatching } from "@codemirror/matchbrackets";
+import { closeBrackets, closeBracketsKeymap } from "@codemirror/closebrackets";
+import { searchKeymap, highlightSelectionMatches } from "@codemirror/search";
+import { autocompletion, completionKeymap } from "@codemirror/autocomplete";
+import { commentKeymap } from "@codemirror/comment";
+import { rectangularSelection } from "@codemirror/rectangular-selection";
+import { defaultHighlightStyle } from "@codemirror/highlight";
+import { lintKeymap } from "@codemirror/lint";
 
 function getLanguageSupport(language: ProgrammingLanguage): LanguageSupport {
     switch (language) {
@@ -21,16 +38,67 @@ function getLanguageSupport(language: ProgrammingLanguage): LanguageSupport {
     }
 }
 
+/*
+*  - [syntax highlighting depending on the language](#getLanguageSupport)
+*  - [line numbers](#gutter.lineNumbers)
+*  - [special character highlighting](#view.highlightSpecialChars)
+*  - [the undo history](#history.history)
+*  - [a fold gutter](#fold.foldGutter)
+*  - [custom selection drawing](#view.drawSelection)
+*  - [multiple selections](#state.EditorState^allowMultipleSelections)
+*  - [reindentation on input](#language.indentOnInput)
+*  - [the default highlight style](#highlight.defaultHighlightStyle) (as fallback)
+*  - [bracket matching](#matchbrackets.bracketMatching)
+*  - [bracket closing](#closebrackets.closeBrackets)
+*  - [autocompletion](#autocomplete.autocompletion)
+*  - [rectangular selection](#rectangular-selection.rectangularSelection)
+*  - [active line highlighting](#view.highlightActiveLine)
+*  - [active line gutter highlighting](#gutter.highlightActiveLineGutter)
+*  - [selection match highlighting](#search.highlightSelectionMatches)
+* Keymaps:
+*  - [the default command bindings](#commands.defaultKeymap)
+*  - [search](#search.searchKeymap)
+*  - [commenting](#comment.commentKeymap)
+*  - [linting](#lint.lintKeymap)
+*  - [indenting with tab](#commands.indentWithTab)
+*/
+function getExtensions(): Array<Extension> {
+    return [
+        lineNumbers(),
+        highlightActiveLineGutter(),
+        highlightSpecialChars(),
+        history(),
+        foldGutter(),
+        drawSelection(),
+        EditorState.allowMultipleSelections.of(true),
+        indentOnInput(),
+        defaultHighlightStyle.fallback,
+        bracketMatching(),
+        closeBrackets(),
+        autocompletion(),
+        rectangularSelection(),
+        highlightActiveLine(),
+        highlightSelectionMatches(),
+        keymap.of([
+            ...closeBracketsKeymap,
+            ...defaultKeymap,
+            ...searchKeymap,
+            ...historyKeymap,
+            ...foldKeymap,
+            ...commentKeymap,
+            ...completionKeymap,
+            ...lintKeymap
+        ]),
+        keymap.of([indentWithTab])
+    ];
+}
+
 function getEditorView(parentElement: HTMLElement,
-    initialCode = "", extensions?: Extension[]): EditorView {
+    initialCode = "", extensions: Extension[] = []): EditorView {
     return new EditorView({
         state: EditorState.create({
             doc: initialCode,
-            extensions: [
-                extensions || [],
-                basicSetup,
-                keymap.of([indentWithTab])
-            ]
+            extensions: extensions
         }),
         parent: parentElement
     });
@@ -52,7 +120,9 @@ export class CodeEditor {
         this.editorView = getEditorView(element, initialCode,
             [
                 this.languageCompartment.of(getLanguageSupport(language)),
-                this.indentCompartment.of(indentUnit.of(getIndentUnit(indentLength)))
+                this.indentCompartment.of(indentUnit.of(getIndentUnit(indentLength))),
+                keymap.of([indentWithTab]),
+                ...getExtensions()
             ]);
         element.replaceChildren(this.editorView.dom);
     }

--- a/src/Papyros.ts
+++ b/src/Papyros.ts
@@ -5,11 +5,7 @@ import { Backend } from "./Backend";
 import { getBackend, stopBackend } from "./BackendManager";
 import { CodeEditor } from "./CodeEditor";
 import {
-<<<<<<< HEAD
     APPLICATION_STATE_TEXT_ID, EDITOR_WRAPPER_ID, DEFAULT_LOCALE, DEFAULT_PROGRAMMING_LANGUAGE, INPUT_RELATIVE_URL,
-=======
-    APPLICATION_STATE_TEXT_ID, CODE_TA_ID, DEFAULT_LOCALE, DEFAULT_PROGRAMMING_LANGUAGE, INPUT_RELATIVE_URL,
->>>>>>> Add support for rendering from a given element with I18n
     INPUT_TA_ID, LANGUAGE_SELECT_ID, OUTPUT_TA_ID,
     RUN_BTN_ID, STATE_SPINNER_ID, TERMINATE_BTN_ID
 } from "./Constants";
@@ -20,7 +16,6 @@ import { LogType, papyrosLog } from "./util/Logging";
 
 function loadTranslations(): void {
     for (const [language, translations] of Object.entries(TRANSLATIONS)) {
-<<<<<<< HEAD
         // Add keys to already existing translations if they exist
         I18n.translations[language] = Object.assign((I18n.translations[language] || {}), translations);
     }
@@ -182,170 +177,6 @@ export class Papyros {
         this.stateManager.runButton.addEventListener("click", () => this.runCode());
         this.stateManager.terminateButton.addEventListener("click", () => this.terminate());
 
-=======
-        I18n.translations[language] = translations;
-    }
-}
-
-const t = I18n.t;
-
-function renderPapyros(parent: HTMLElement, programmingLanguage: ProgrammingLanguage): void {
-    const options = PROGRAMMING_LANGUAGES.map(pl => {
-        const selected = programmingLanguage === pl ? "selected" : "";
-        return `<option ${selected}} value="${pl}">${t(pl)}</option>`;
-    }).join("\n");
-    parent.innerHTML =
-        `
-    <div id="papyros" class="max-h-screen h-full overflow-y-hidden">
-    <div class="bg-blue-500 text-white text-lg p-4">
-      ${t("Papyros")}
-    </div>
-    <div class="m-10">
-      <!-- Header -->
-      <div class="flex flex-row items-center">
-        <label for="language-select">Programming language</label>
-        <select id="language-select" class="m-2 border-2">
-          ${options}
-        </select>
-        <button id="run-code-btn" type="button"
-          class="text-white bg-blue-500 border-2 m-3 px-4 inset-y-2 rounded-lg justify-items-center">
-            ${t("run")}
-        </button>
-        <button id="terminate-btn" type="button" class="mr-1 btn btn-danger" hidden>
-            ${t("terminate")}
-        </button>
-        <div class="flex flex-row items-center">
-          <svg id="state-spinner" class="animate-spin mr-3 h-5 w-5 text-white"
-           xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" display="none">
-          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="red" stroke-width="4"></circle>
-          <path class="opacity-75" fill="red"
-          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z">
-            </path>
-          </svg>
-          <div id="application-state-text">${t("loading")}</div>
-        </div>
-      </div>
-
-      <!--Body of the application-->
-      <div class="grid grid-cols-2 gap-4 box-border max-h-full">
-        <!--Left code section-->
-        <div class="col-span-1">
-          <h1>${t("enter code")}:</h1>
-          <div id="code-area" class="overflow-auto max-h-full"></div>
-        </div>
-        <!--Right user input and output section-->
-        <div class="col-span-1">
-          <h1>${t("enter input")}:</h1>
-          <textarea id="code-input-area" class="border-2 h-auto w-full max-h-1/4 overflow-auto" rows="5"></textarea>
-          <h1>${t("code output")}:</h1>
-          <textarea id="code-output-area" readonly class="border-2 w-full min-h-1/5 max-h-3/5 overflow-auto"></textarea>
-        </div>
-      </div>
-    </div>
-  </div>
-    `;
-}
-
-
-enum PapyrosState {
-    Loading = "loading",
-    Running = "running",
-    AwaitingInput = "awaiting input",
-    Terminating = "terminating",
-    Ready = "ready"
-}
-
-class PapyrosStateManager {
-    state: PapyrosState;
-    stateSpinner: HTMLElement;
-    stateText: HTMLElement;
-
-    constructor(state: PapyrosState) {
-        this.stateSpinner = document.getElementById(STATE_SPINNER_ID) as HTMLElement;
-        this.stateText = document.getElementById(APPLICATION_STATE_TEXT_ID) as HTMLElement;
-        this.state = state;
-    }
-
-    setState(state: PapyrosState): void {
-        if (state !== this.state) {
-            this.state = state;
-            if (state === PapyrosState.Ready) {
-                this.stateSpinner.style.display = "none";
-                this.stateText.innerText = "";
-            } else {
-                this.stateSpinner.style.display = "";
-                this.stateText.innerText = t(state);
-            }
-        }
-    }
-}
-
-interface PapyrosCodeState {
-    programmingLanguage: ProgrammingLanguage;
-    editor: CodeEditor;
-    backend: Remote<Backend>;
-    languageSelect: HTMLSelectElement;
-    codeElement: HTMLInputElement;
-    runId: number;
-    runButton: HTMLButtonElement;
-    terminateButton: HTMLButtonElement;
-    outputArea: HTMLInputElement;
-}
-
-interface PapyrosInputState {
-    lineNr: number;
-    textEncoder: TextEncoder;
-    inputArea: HTMLInputElement;
-    inputTextArray?: Uint8Array;
-    inputMetaData?: Int32Array;
-}
-
-export class Papyros {
-    stateManager: PapyrosStateManager;
-    codeState: PapyrosCodeState;
-    inputState: PapyrosInputState;
-
-    constructor(parent: HTMLElement, locale: string, programmingLanguage: ProgrammingLanguage,
-        inputTextArray?: Uint8Array, inputMetaData?: Int32Array) {
-        this.stateManager = new PapyrosStateManager(PapyrosState.Loading);
-        this.codeState = {
-            programmingLanguage: programmingLanguage,
-            editor: new CodeEditor(
-                document.getElementById(CODE_TA_ID) as HTMLInputElement, programmingLanguage),
-            backend: {} as Remote<Backend>,
-            languageSelect: document.getElementById(LANGUAGE_SELECT_ID) as HTMLSelectElement,
-            codeElement: document.getElementById(CODE_TA_ID) as HTMLInputElement,
-            outputArea: document.getElementById(OUTPUT_TA_ID) as HTMLInputElement,
-            runId: 0,
-            runButton: document.getElementById(RUN_BTN_ID) as HTMLButtonElement,
-            terminateButton: document.getElementById(TERMINATE_BTN_ID) as HTMLButtonElement,
-        };
-
-        this.inputState = {
-            lineNr: 0,
-            textEncoder: new TextEncoder(),
-            inputArea: document.getElementById(INPUT_TA_ID) as HTMLInputElement,
-            inputTextArray: inputTextArray,
-            inputMetaData: inputMetaData
-        };
-    }
-
-    async launch(): Promise<Papyros> {
-        this.codeState.languageSelect.addEventListener("change",
-            async () => {
-                const {
-                    languageSelect, editor, backend
-                } = this.codeState;
-                const language = plFromString(languageSelect.value);
-                stopBackend(backend);
-                editor.setLanguage(language, editor.getCode());
-                await this.startBackend();
-            }
-        );
-        this.codeState.runButton.addEventListener("click", () => this.runCode());
-        this.codeState.terminateButton.addEventListener("click", () => this.terminate());
-
->>>>>>> Add support for rendering from a given element with I18n
         this.inputState.inputArea.onkeydown = e => {
             papyrosLog(LogType.Debug, "Key down in inputArea", e);
             if (this.stateManager.state === PapyrosState.AwaitingInput &&
@@ -354,7 +185,6 @@ export class Papyros {
                 this.sendInput();
             }
         };
-<<<<<<< HEAD
         await this.startBackend();
         return this;
     }
@@ -371,54 +201,23 @@ export class Papyros {
     async startBackend(): Promise<void> {
         const {
             programmingLanguage
-=======
-
-        return this;
-    }
-
-    setProgrammingLanguage(programmingLanguage: ProgrammingLanguage): void {
-        if (this.codeState.programmingLanguage !== programmingLanguage) {
-            stopBackend(this.codeState.backend);
-            this.codeState.programmingLanguage = programmingLanguage;
-            this.codeState.editor.setLanguage(programmingLanguage);
-        }
-    }
-
-    async startBackend(): Promise<void> {
-        const {
-            runButton, programmingLanguage
->>>>>>> Add support for rendering from a given element with I18n
         } = this.codeState;
         const {
             inputTextArray, inputMetaData
         } = this.inputState;
         this.stateManager.setState(PapyrosState.Loading);
-<<<<<<< HEAD
         const backend = getBackend(programmingLanguage);
         await backend.launch(proxy(e => this.onMessage(e)), inputTextArray, inputMetaData);
         this.codeState.backend = backend;
         this.stateManager.setState(PapyrosState.Ready);
-=======
-        runButton.disabled = true;
-        const backend = getBackend(programmingLanguage);
-        await backend.launch(proxy(e => this.onMessage(e)), inputTextArray, inputMetaData);
-        runButton.disabled = false;
-        this.stateManager.setState(PapyrosState.Ready);
-        return Promise.resolve();
->>>>>>> Add support for rendering from a given element with I18n
     }
 
     static fromElement(parent: HTMLElement, locale = DEFAULT_LOCALE, programmingLanguage = DEFAULT_PROGRAMMING_LANGUAGE,
         inputTextArray?: Uint8Array, inputMetaData?: Int32Array): Promise<Papyros> {
         loadTranslations();
-<<<<<<< HEAD
+        renderPapyros(parent, programmingLanguage);
         I18n.locale = locale;
-        renderPapyros(parent, programmingLanguage);
         return new Papyros(programmingLanguage, inputTextArray, inputMetaData).launch();
-=======
-        renderPapyros(parent, programmingLanguage);
-        return new Papyros(parent, locale, programmingLanguage, inputTextArray, inputMetaData).launch();
->>>>>>> Add support for rendering from a given element with I18n
     }
 
 
@@ -487,19 +286,11 @@ export class Papyros {
     async runCode(): Promise<void> {
         this.codeState.runId += 1;
         this.stateManager.setState(PapyrosState.Running);
-<<<<<<< HEAD
         this.codeState.outputArea.value = "";
-=======
-        this.codeState.runButton.disabled = true;
-        this.inputState.lineNr = 0;
-        this.codeState.outputArea.value = "";
-        this.codeState.terminateButton.hidden = false;
->>>>>>> Add support for rendering from a given element with I18n
         papyrosLog(LogType.Debug, "Running code in Papyros, sending to backend");
-        // const start = new Date().getTime();
+        const start = new Date().getTime();
         try {
             await this.codeState.backend.runCode(
-<<<<<<< HEAD
                 this.codeState.editor.getCode(), this.codeState.runId);
         } catch (error: any) {
             this.onError(error);
@@ -508,17 +299,6 @@ export class Papyros {
             this.stateManager.setState(PapyrosState.Ready, t("Papyros.finished", { time: end - start }));
             this.inputState.inputArea.value = "";
             this.inputState.lineNr = 0;
-=======
-                this.codeState.codeElement.value, this.codeState.runId);
-        } catch (error: any) {
-            this.onError(error);
-        } finally {
-            // const end = new Date().getTime();
-            this.stateManager.setState(PapyrosState.Ready);
-            // stateText.innerText = `Code executed in ${end - start} ms`;
-            // terminateButton.hidden = true;
-            // runButton.disabled = false;
->>>>>>> Add support for rendering from a given element with I18n
         }
     }
 
@@ -526,10 +306,6 @@ export class Papyros {
         papyrosLog(LogType.Debug, "Called terminate, stopping backend!");
         this.codeState.runId += 1; // ignore messages coming from last run
         this.stateManager.setState(PapyrosState.Terminating);
-<<<<<<< HEAD
-=======
-        // terminateButton.hidden = true;
->>>>>>> Add support for rendering from a given element with I18n
         stopBackend(this.codeState.backend);
         return this.startBackend();
     }

--- a/src/Papyros.ts
+++ b/src/Papyros.ts
@@ -5,7 +5,11 @@ import { Backend } from "./Backend";
 import { getBackend, stopBackend } from "./BackendManager";
 import { CodeEditor } from "./CodeEditor";
 import {
+<<<<<<< HEAD
     APPLICATION_STATE_TEXT_ID, EDITOR_WRAPPER_ID, DEFAULT_LOCALE, DEFAULT_PROGRAMMING_LANGUAGE, INPUT_RELATIVE_URL,
+=======
+    APPLICATION_STATE_TEXT_ID, CODE_TA_ID, DEFAULT_LOCALE, DEFAULT_PROGRAMMING_LANGUAGE, INPUT_RELATIVE_URL,
+>>>>>>> Add support for rendering from a given element with I18n
     INPUT_TA_ID, LANGUAGE_SELECT_ID, OUTPUT_TA_ID,
     RUN_BTN_ID, STATE_SPINNER_ID, TERMINATE_BTN_ID
 } from "./Constants";
@@ -16,6 +20,7 @@ import { LogType, papyrosLog } from "./util/Logging";
 
 function loadTranslations(): void {
     for (const [language, translations] of Object.entries(TRANSLATIONS)) {
+<<<<<<< HEAD
         // Add keys to already existing translations if they exist
         I18n.translations[language] = Object.assign((I18n.translations[language] || {}), translations);
     }
@@ -177,6 +182,170 @@ export class Papyros {
         this.stateManager.runButton.addEventListener("click", () => this.runCode());
         this.stateManager.terminateButton.addEventListener("click", () => this.terminate());
 
+=======
+        I18n.translations[language] = translations;
+    }
+}
+
+const t = I18n.t;
+
+function renderPapyros(parent: HTMLElement, programmingLanguage: ProgrammingLanguage): void {
+    const options = PROGRAMMING_LANGUAGES.map(pl => {
+        const selected = programmingLanguage === pl ? "selected" : "";
+        return `<option ${selected}} value="${pl}">${t(pl)}</option>`;
+    }).join("\n");
+    parent.innerHTML =
+        `
+    <div id="papyros" class="max-h-screen h-full overflow-y-hidden">
+    <div class="bg-blue-500 text-white text-lg p-4">
+      ${t("Papyros")}
+    </div>
+    <div class="m-10">
+      <!-- Header -->
+      <div class="flex flex-row items-center">
+        <label for="language-select">Programming language</label>
+        <select id="language-select" class="m-2 border-2">
+          ${options}
+        </select>
+        <button id="run-code-btn" type="button"
+          class="text-white bg-blue-500 border-2 m-3 px-4 inset-y-2 rounded-lg justify-items-center">
+            ${t("run")}
+        </button>
+        <button id="terminate-btn" type="button" class="mr-1 btn btn-danger" hidden>
+            ${t("terminate")}
+        </button>
+        <div class="flex flex-row items-center">
+          <svg id="state-spinner" class="animate-spin mr-3 h-5 w-5 text-white"
+           xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" display="none">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="red" stroke-width="4"></circle>
+          <path class="opacity-75" fill="red"
+          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z">
+            </path>
+          </svg>
+          <div id="application-state-text">${t("loading")}</div>
+        </div>
+      </div>
+
+      <!--Body of the application-->
+      <div class="grid grid-cols-2 gap-4 box-border max-h-full">
+        <!--Left code section-->
+        <div class="col-span-1">
+          <h1>${t("enter code")}:</h1>
+          <div id="code-area" class="overflow-auto max-h-full"></div>
+        </div>
+        <!--Right user input and output section-->
+        <div class="col-span-1">
+          <h1>${t("enter input")}:</h1>
+          <textarea id="code-input-area" class="border-2 h-auto w-full max-h-1/4 overflow-auto" rows="5"></textarea>
+          <h1>${t("code output")}:</h1>
+          <textarea id="code-output-area" readonly class="border-2 w-full min-h-1/5 max-h-3/5 overflow-auto"></textarea>
+        </div>
+      </div>
+    </div>
+  </div>
+    `;
+}
+
+
+enum PapyrosState {
+    Loading = "loading",
+    Running = "running",
+    AwaitingInput = "awaiting input",
+    Terminating = "terminating",
+    Ready = "ready"
+}
+
+class PapyrosStateManager {
+    state: PapyrosState;
+    stateSpinner: HTMLElement;
+    stateText: HTMLElement;
+
+    constructor(state: PapyrosState) {
+        this.stateSpinner = document.getElementById(STATE_SPINNER_ID) as HTMLElement;
+        this.stateText = document.getElementById(APPLICATION_STATE_TEXT_ID) as HTMLElement;
+        this.state = state;
+    }
+
+    setState(state: PapyrosState): void {
+        if (state !== this.state) {
+            this.state = state;
+            if (state === PapyrosState.Ready) {
+                this.stateSpinner.style.display = "none";
+                this.stateText.innerText = "";
+            } else {
+                this.stateSpinner.style.display = "";
+                this.stateText.innerText = t(state);
+            }
+        }
+    }
+}
+
+interface PapyrosCodeState {
+    programmingLanguage: ProgrammingLanguage;
+    editor: CodeEditor;
+    backend: Remote<Backend>;
+    languageSelect: HTMLSelectElement;
+    codeElement: HTMLInputElement;
+    runId: number;
+    runButton: HTMLButtonElement;
+    terminateButton: HTMLButtonElement;
+    outputArea: HTMLInputElement;
+}
+
+interface PapyrosInputState {
+    lineNr: number;
+    textEncoder: TextEncoder;
+    inputArea: HTMLInputElement;
+    inputTextArray?: Uint8Array;
+    inputMetaData?: Int32Array;
+}
+
+export class Papyros {
+    stateManager: PapyrosStateManager;
+    codeState: PapyrosCodeState;
+    inputState: PapyrosInputState;
+
+    constructor(parent: HTMLElement, locale: string, programmingLanguage: ProgrammingLanguage,
+        inputTextArray?: Uint8Array, inputMetaData?: Int32Array) {
+        this.stateManager = new PapyrosStateManager(PapyrosState.Loading);
+        this.codeState = {
+            programmingLanguage: programmingLanguage,
+            editor: new CodeEditor(
+                document.getElementById(CODE_TA_ID) as HTMLInputElement, programmingLanguage),
+            backend: {} as Remote<Backend>,
+            languageSelect: document.getElementById(LANGUAGE_SELECT_ID) as HTMLSelectElement,
+            codeElement: document.getElementById(CODE_TA_ID) as HTMLInputElement,
+            outputArea: document.getElementById(OUTPUT_TA_ID) as HTMLInputElement,
+            runId: 0,
+            runButton: document.getElementById(RUN_BTN_ID) as HTMLButtonElement,
+            terminateButton: document.getElementById(TERMINATE_BTN_ID) as HTMLButtonElement,
+        };
+
+        this.inputState = {
+            lineNr: 0,
+            textEncoder: new TextEncoder(),
+            inputArea: document.getElementById(INPUT_TA_ID) as HTMLInputElement,
+            inputTextArray: inputTextArray,
+            inputMetaData: inputMetaData
+        };
+    }
+
+    async launch(): Promise<Papyros> {
+        this.codeState.languageSelect.addEventListener("change",
+            async () => {
+                const {
+                    languageSelect, editor, backend
+                } = this.codeState;
+                const language = plFromString(languageSelect.value);
+                stopBackend(backend);
+                editor.setLanguage(language, editor.getCode());
+                await this.startBackend();
+            }
+        );
+        this.codeState.runButton.addEventListener("click", () => this.runCode());
+        this.codeState.terminateButton.addEventListener("click", () => this.terminate());
+
+>>>>>>> Add support for rendering from a given element with I18n
         this.inputState.inputArea.onkeydown = e => {
             papyrosLog(LogType.Debug, "Key down in inputArea", e);
             if (this.stateManager.state === PapyrosState.AwaitingInput &&
@@ -185,6 +354,7 @@ export class Papyros {
                 this.sendInput();
             }
         };
+<<<<<<< HEAD
         await this.startBackend();
         return this;
     }
@@ -201,24 +371,55 @@ export class Papyros {
     async startBackend(): Promise<void> {
         const {
             programmingLanguage
+=======
+
+        return this;
+    }
+
+    setProgrammingLanguage(programmingLanguage: ProgrammingLanguage): void {
+        if (this.codeState.programmingLanguage !== programmingLanguage) {
+            stopBackend(this.codeState.backend);
+            this.codeState.programmingLanguage = programmingLanguage;
+            this.codeState.editor.setLanguage(programmingLanguage);
+        }
+    }
+
+    async startBackend(): Promise<void> {
+        const {
+            runButton, programmingLanguage
+>>>>>>> Add support for rendering from a given element with I18n
         } = this.codeState;
         const {
             inputTextArray, inputMetaData
         } = this.inputState;
         this.stateManager.setState(PapyrosState.Loading);
+<<<<<<< HEAD
         const backend = getBackend(programmingLanguage);
         await backend.launch(proxy(e => this.onMessage(e)), inputTextArray, inputMetaData);
         this.codeState.backend = backend;
         this.stateManager.setState(PapyrosState.Ready);
+=======
+        runButton.disabled = true;
+        const backend = getBackend(programmingLanguage);
+        await backend.launch(proxy(e => this.onMessage(e)), inputTextArray, inputMetaData);
+        runButton.disabled = false;
+        this.stateManager.setState(PapyrosState.Ready);
+        return Promise.resolve();
+>>>>>>> Add support for rendering from a given element with I18n
     }
 
     static fromElement(parent: HTMLElement, locale = DEFAULT_LOCALE, programmingLanguage = DEFAULT_PROGRAMMING_LANGUAGE,
         inputTextArray?: Uint8Array, inputMetaData?: Int32Array): Promise<Papyros> {
         loadTranslations();
+<<<<<<< HEAD
         I18n.locale = locale;
         I18n.defaultLocale = DEFAULT_LOCALE;
         renderPapyros(parent, programmingLanguage);
         return new Papyros(programmingLanguage, inputTextArray, inputMetaData).launch();
+=======
+        renderPapyros(parent, programmingLanguage);
+        return new Papyros(parent, locale, programmingLanguage, inputTextArray, inputMetaData).launch();
+>>>>>>> Add support for rendering from a given element with I18n
     }
 
 
@@ -287,11 +488,19 @@ export class Papyros {
     async runCode(): Promise<void> {
         this.codeState.runId += 1;
         this.stateManager.setState(PapyrosState.Running);
+<<<<<<< HEAD
         this.codeState.outputArea.value = "";
+=======
+        this.codeState.runButton.disabled = true;
+        this.inputState.lineNr = 0;
+        this.codeState.outputArea.value = "";
+        this.codeState.terminateButton.hidden = false;
+>>>>>>> Add support for rendering from a given element with I18n
         papyrosLog(LogType.Debug, "Running code in Papyros, sending to backend");
-        const start = new Date().getTime();
+        // const start = new Date().getTime();
         try {
             await this.codeState.backend.runCode(
+<<<<<<< HEAD
                 this.codeState.editor.getCode(), this.codeState.runId);
         } catch (error: any) {
             this.onError(error);
@@ -300,6 +509,17 @@ export class Papyros {
             this.stateManager.setState(PapyrosState.Ready, t("Papyros.finished", { time: end - start }));
             this.inputState.inputArea.value = "";
             this.inputState.lineNr = 0;
+=======
+                this.codeState.codeElement.value, this.codeState.runId);
+        } catch (error: any) {
+            this.onError(error);
+        } finally {
+            // const end = new Date().getTime();
+            this.stateManager.setState(PapyrosState.Ready);
+            // stateText.innerText = `Code executed in ${end - start} ms`;
+            // terminateButton.hidden = true;
+            // runButton.disabled = false;
+>>>>>>> Add support for rendering from a given element with I18n
         }
     }
 
@@ -307,6 +527,10 @@ export class Papyros {
         papyrosLog(LogType.Debug, "Called terminate, stopping backend!");
         this.codeState.runId += 1; // ignore messages coming from last run
         this.stateManager.setState(PapyrosState.Terminating);
+<<<<<<< HEAD
+=======
+        // terminateButton.hidden = true;
+>>>>>>> Add support for rendering from a given element with I18n
         stopBackend(this.codeState.backend);
         return this.startBackend();
     }

--- a/src/Papyros.ts
+++ b/src/Papyros.ts
@@ -413,7 +413,6 @@ export class Papyros {
         loadTranslations();
 <<<<<<< HEAD
         I18n.locale = locale;
-        I18n.defaultLocale = DEFAULT_LOCALE;
         renderPapyros(parent, programmingLanguage);
         return new Papyros(programmingLanguage, inputTextArray, inputMetaData).launch();
 =======

--- a/src/Papyros.ts
+++ b/src/Papyros.ts
@@ -3,9 +3,14 @@ import { proxy, Remote } from "comlink";
 import I18n from "i18n-js";
 import { Backend } from "./Backend";
 import { getBackend, stopBackend } from "./BackendManager";
+<<<<<<< HEAD
 import { CodeEditor } from "./CodeEditor";
 import {
     APPLICATION_STATE_TEXT_ID, EDITOR_WRAPPER_ID, DEFAULT_LOCALE, DEFAULT_PROGRAMMING_LANGUAGE, INPUT_RELATIVE_URL,
+=======
+import {
+    APPLICATION_STATE_TEXT_ID, CODE_TA_ID, DEFAULT_PROGRAMMING_LANGUAGE, INPUT_RELATIVE_URL,
+>>>>>>> Add ProgrammingLanguage enum
     INPUT_TA_ID, LANGUAGE_SELECT_ID, OUTPUT_TA_ID,
     RUN_BTN_ID, STATE_SPINNER_ID, TERMINATE_BTN_ID
 } from "./Constants";

--- a/src/Papyros.ts
+++ b/src/Papyros.ts
@@ -3,14 +3,9 @@ import { proxy, Remote } from "comlink";
 import I18n from "i18n-js";
 import { Backend } from "./Backend";
 import { getBackend, stopBackend } from "./BackendManager";
-<<<<<<< HEAD
 import { CodeEditor } from "./CodeEditor";
 import {
     APPLICATION_STATE_TEXT_ID, EDITOR_WRAPPER_ID, DEFAULT_LOCALE, DEFAULT_PROGRAMMING_LANGUAGE, INPUT_RELATIVE_URL,
-=======
-import {
-    APPLICATION_STATE_TEXT_ID, CODE_TA_ID, DEFAULT_PROGRAMMING_LANGUAGE, INPUT_RELATIVE_URL,
->>>>>>> Add ProgrammingLanguage enum
     INPUT_TA_ID, LANGUAGE_SELECT_ID, OUTPUT_TA_ID,
     RUN_BTN_ID, STATE_SPINNER_ID, TERMINATE_BTN_ID
 } from "./Constants";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3493,6 +3493,11 @@ hsla-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
 
+htl@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/htl/-/htl-0.3.1.tgz#13c5a32fa46434f33b84d4553dd37e58a80e8d8a"
+  integrity sha512-1LBtd+XhSc+++jpOOt0lCcEycXs/zTQSupOISnVAUmvGBpV7DH+C2M6hwV7zWYfpTMMg9ch4NO0lHiOTAMHdVA==
+
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -400,7 +400,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+<<<<<<< HEAD
 "@codemirror/autocomplete@^0.19.0", "@codemirror/autocomplete@^0.19.8":
+=======
+"@codemirror/autocomplete@^0.19.0":
+>>>>>>> Add CodeMirror dependency and setup
   version "0.19.8"
   resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-0.19.8.tgz#a4a886089f0248a0d1ccdc11d9f8560c0b2c2abd"
   integrity sha512-o4I1pRlFjhBHOYab+QfpKcW0B8FqAH+2pdmCYrkTz3bm1djVwhlMEhv1s/aTKhdjLtkfZFUbdHBi+8xe22wUCA==
@@ -412,6 +416,30 @@
     "@codemirror/view" "^0.19.0"
     "@lezer/common" "^0.15.0"
 
+<<<<<<< HEAD
+=======
+"@codemirror/basic-setup@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/basic-setup/-/basic-setup-0.19.0.tgz#dc84dd735c8a88dd38c9dcc80cbfefa31d7e8f20"
+  integrity sha512-Yhrf7fIz8+INHWOhpWeRwbs8fpc0KsydX9baD7TyYqniLVWyTi0Hwm52mr0f5O+k4YaJPeHAgT3x9gzDXZIvOw==
+  dependencies:
+    "@codemirror/autocomplete" "^0.19.0"
+    "@codemirror/closebrackets" "^0.19.0"
+    "@codemirror/commands" "^0.19.0"
+    "@codemirror/comment" "^0.19.0"
+    "@codemirror/fold" "^0.19.0"
+    "@codemirror/gutter" "^0.19.0"
+    "@codemirror/highlight" "^0.19.0"
+    "@codemirror/history" "^0.19.0"
+    "@codemirror/language" "^0.19.0"
+    "@codemirror/lint" "^0.19.0"
+    "@codemirror/matchbrackets" "^0.19.0"
+    "@codemirror/rectangular-selection" "^0.19.0"
+    "@codemirror/search" "^0.19.0"
+    "@codemirror/state" "^0.19.0"
+    "@codemirror/view" "^0.19.0"
+
+>>>>>>> Add CodeMirror dependency and setup
 "@codemirror/closebrackets@^0.19.0":
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/@codemirror/closebrackets/-/closebrackets-0.19.0.tgz#69fdcee85779d638a00a42becd9f53a33a26d77f"
@@ -423,7 +451,11 @@
     "@codemirror/text" "^0.19.0"
     "@codemirror/view" "^0.19.0"
 
+<<<<<<< HEAD
 "@codemirror/commands@^0.19.5":
+=======
+"@codemirror/commands@^0.19.0":
+>>>>>>> Add CodeMirror dependency and setup
   version "0.19.5"
   resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-0.19.5.tgz#2607b5c12c5c96df2cabce2e43f6285c07cfaf11"
   integrity sha512-8PZOtx7d/GbKhFYA88zs2wINDtaUgj3pEjLYScKTd/Vsyw8qOp86tJQQNnMFTRZj/ISQl9Lbg3aAmHvroMqspw==
@@ -444,7 +476,11 @@
     "@codemirror/text" "^0.19.0"
     "@codemirror/view" "^0.19.0"
 
+<<<<<<< HEAD
 "@codemirror/fold@^0.19.1":
+=======
+"@codemirror/fold@^0.19.0":
+>>>>>>> Add CodeMirror dependency and setup
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@codemirror/fold/-/fold-0.19.1.tgz#52000ff329ab69c4ba32e94401777941e29d8ad0"
   integrity sha512-3GwQpxgv03urb8BPBvX1JSjl+uMXKqngRG6qHZXSM2FefxFKvTuyL44MCb35aodtfKjGwoxizk+7b6CbAOLyOw==
@@ -555,7 +591,11 @@
   dependencies:
     "@codemirror/state" "^0.19.0"
 
+<<<<<<< HEAD
 "@codemirror/rectangular-selection@^0.19.1":
+=======
+"@codemirror/rectangular-selection@^0.19.0":
+>>>>>>> Add CodeMirror dependency and setup
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@codemirror/rectangular-selection/-/rectangular-selection-0.19.1.tgz#5a88ece4fb68ce5682539497db8a64fc015aae63"
   integrity sha512-9ElnqOg3mpZIWe0prPRd1SZ48Q9QB3bR8Aocq8UtjboJSUG8ABhRrbuTZMW/rMqpBPSjVpCe9xkCCkEQMYQVmw==
@@ -564,6 +604,7 @@
     "@codemirror/text" "^0.19.4"
     "@codemirror/view" "^0.19.0"
 
+<<<<<<< HEAD
 "@codemirror/search@^0.19.3":
   version "0.19.3"
   resolved "https://registry.yarnpkg.com/@codemirror/search/-/search-0.19.3.tgz#9c81f89e965e708a5095aeebb4a181c463d37f17"
@@ -572,6 +613,16 @@
     "@codemirror/panel" "^0.19.0"
     "@codemirror/rangeset" "^0.19.0"
     "@codemirror/state" "^0.19.3"
+=======
+"@codemirror/search@^0.19.0":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/search/-/search-0.19.2.tgz#d549c3daa527e17c173cdfc90b7c1b02deab1502"
+  integrity sha512-TrRxUxyJ/a7HXtUvMZhgkOUbKE1xO33UhXjn1XACEHKWhgovw1vEeEEti9dZejN8/QOOFJed39InUxmp7oQ8HA==
+  dependencies:
+    "@codemirror/panel" "^0.19.0"
+    "@codemirror/rangeset" "^0.19.0"
+    "@codemirror/state" "^0.19.2"
+>>>>>>> Add CodeMirror dependency and setup
     "@codemirror/text" "^0.19.0"
     "@codemirror/view" "^0.19.0"
     crelt "^1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -400,11 +400,7 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-<<<<<<< HEAD
 "@codemirror/autocomplete@^0.19.0", "@codemirror/autocomplete@^0.19.8":
-=======
-"@codemirror/autocomplete@^0.19.0":
->>>>>>> Add CodeMirror dependency and setup
   version "0.19.8"
   resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-0.19.8.tgz#a4a886089f0248a0d1ccdc11d9f8560c0b2c2abd"
   integrity sha512-o4I1pRlFjhBHOYab+QfpKcW0B8FqAH+2pdmCYrkTz3bm1djVwhlMEhv1s/aTKhdjLtkfZFUbdHBi+8xe22wUCA==
@@ -416,30 +412,6 @@
     "@codemirror/view" "^0.19.0"
     "@lezer/common" "^0.15.0"
 
-<<<<<<< HEAD
-=======
-"@codemirror/basic-setup@^0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@codemirror/basic-setup/-/basic-setup-0.19.0.tgz#dc84dd735c8a88dd38c9dcc80cbfefa31d7e8f20"
-  integrity sha512-Yhrf7fIz8+INHWOhpWeRwbs8fpc0KsydX9baD7TyYqniLVWyTi0Hwm52mr0f5O+k4YaJPeHAgT3x9gzDXZIvOw==
-  dependencies:
-    "@codemirror/autocomplete" "^0.19.0"
-    "@codemirror/closebrackets" "^0.19.0"
-    "@codemirror/commands" "^0.19.0"
-    "@codemirror/comment" "^0.19.0"
-    "@codemirror/fold" "^0.19.0"
-    "@codemirror/gutter" "^0.19.0"
-    "@codemirror/highlight" "^0.19.0"
-    "@codemirror/history" "^0.19.0"
-    "@codemirror/language" "^0.19.0"
-    "@codemirror/lint" "^0.19.0"
-    "@codemirror/matchbrackets" "^0.19.0"
-    "@codemirror/rectangular-selection" "^0.19.0"
-    "@codemirror/search" "^0.19.0"
-    "@codemirror/state" "^0.19.0"
-    "@codemirror/view" "^0.19.0"
-
->>>>>>> Add CodeMirror dependency and setup
 "@codemirror/closebrackets@^0.19.0":
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/@codemirror/closebrackets/-/closebrackets-0.19.0.tgz#69fdcee85779d638a00a42becd9f53a33a26d77f"
@@ -451,11 +423,7 @@
     "@codemirror/text" "^0.19.0"
     "@codemirror/view" "^0.19.0"
 
-<<<<<<< HEAD
-"@codemirror/commands@^0.19.5":
-=======
-"@codemirror/commands@^0.19.0":
->>>>>>> Add CodeMirror dependency and setup
+codemirror/commands@^0.19.5":
   version "0.19.5"
   resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-0.19.5.tgz#2607b5c12c5c96df2cabce2e43f6285c07cfaf11"
   integrity sha512-8PZOtx7d/GbKhFYA88zs2wINDtaUgj3pEjLYScKTd/Vsyw8qOp86tJQQNnMFTRZj/ISQl9Lbg3aAmHvroMqspw==
@@ -476,11 +444,7 @@
     "@codemirror/text" "^0.19.0"
     "@codemirror/view" "^0.19.0"
 
-<<<<<<< HEAD
 "@codemirror/fold@^0.19.1":
-=======
-"@codemirror/fold@^0.19.0":
->>>>>>> Add CodeMirror dependency and setup
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@codemirror/fold/-/fold-0.19.1.tgz#52000ff329ab69c4ba32e94401777941e29d8ad0"
   integrity sha512-3GwQpxgv03urb8BPBvX1JSjl+uMXKqngRG6qHZXSM2FefxFKvTuyL44MCb35aodtfKjGwoxizk+7b6CbAOLyOw==
@@ -591,11 +555,7 @@
   dependencies:
     "@codemirror/state" "^0.19.0"
 
-<<<<<<< HEAD
 "@codemirror/rectangular-selection@^0.19.1":
-=======
-"@codemirror/rectangular-selection@^0.19.0":
->>>>>>> Add CodeMirror dependency and setup
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@codemirror/rectangular-selection/-/rectangular-selection-0.19.1.tgz#5a88ece4fb68ce5682539497db8a64fc015aae63"
   integrity sha512-9ElnqOg3mpZIWe0prPRd1SZ48Q9QB3bR8Aocq8UtjboJSUG8ABhRrbuTZMW/rMqpBPSjVpCe9xkCCkEQMYQVmw==
@@ -604,7 +564,6 @@
     "@codemirror/text" "^0.19.4"
     "@codemirror/view" "^0.19.0"
 
-<<<<<<< HEAD
 "@codemirror/search@^0.19.3":
   version "0.19.3"
   resolved "https://registry.yarnpkg.com/@codemirror/search/-/search-0.19.3.tgz#9c81f89e965e708a5095aeebb4a181c463d37f17"
@@ -613,16 +572,6 @@
     "@codemirror/panel" "^0.19.0"
     "@codemirror/rangeset" "^0.19.0"
     "@codemirror/state" "^0.19.3"
-=======
-"@codemirror/search@^0.19.0":
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/@codemirror/search/-/search-0.19.2.tgz#d549c3daa527e17c173cdfc90b7c1b02deab1502"
-  integrity sha512-TrRxUxyJ/a7HXtUvMZhgkOUbKE1xO33UhXjn1XACEHKWhgovw1vEeEEti9dZejN8/QOOFJed39InUxmp7oQ8HA==
-  dependencies:
-    "@codemirror/panel" "^0.19.0"
-    "@codemirror/rangeset" "^0.19.0"
-    "@codemirror/state" "^0.19.2"
->>>>>>> Add CodeMirror dependency and setup
     "@codemirror/text" "^0.19.0"
     "@codemirror/view" "^0.19.0"
     crelt "^1.0.5"
@@ -3492,11 +3441,6 @@ hsla-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
-
-htl@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/htl/-/htl-0.3.1.tgz#13c5a32fa46434f33b84d4553dd37e58a80e8d8a"
-  integrity sha512-1LBtd+XhSc+++jpOOt0lCcEycXs/zTQSupOISnVAUmvGBpV7DH+C2M6hwV7zWYfpTMMg9ch4NO0lHiOTAMHdVA==
 
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -576,7 +576,7 @@ codemirror/commands@^0.19.5":
     "@codemirror/view" "^0.19.0"
     crelt "^1.0.5"
 
-"@codemirror/state@^0.19.0", "@codemirror/state@^0.19.2", "@codemirror/state@^0.19.3", "@codemirror/state@^0.19.4":
+"@codemirror/state@^0.19.0", "@codemirror/state@^0.19.2", "@codemirror/state@^0.19.3", "@codemirror/state@^0.19.4", "@codemirror/state@^0.19.6":
   version "0.19.6"
   resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-0.19.6.tgz#d631f041d39ce41b7891b099fca26cb1fdb9763e"
   integrity sha512-sqIQZE9VqwQj7D4c2oz9mfLhlT1ElAzGB5lO1lE33BPyrdNy1cJyCIOecT4cn4VeJOFrnjOeu+IftZ3zqdFETw==


### PR DESCRIPTION
Depends on #43 
Closes #37 
By using a Compartment, changes to extensions in the CodeEditor can be done without recreating the entire editor. 

I used this approach for both the LanguageSupport and the indentUnit facets, allowing both to be updated more easily. This would allow us to let the user choose the amount of used spaces (with the default being 4). 