### PR TITLE
Validate translations

### DIFF
--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -29,6 +29,5 @@ jobs:
       - name: Remove deploy label
         uses: buildsville/add-remove-label@v1
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
           label: deploy
           type: remove

--- a/.github/workflows/validate-translations.yaml
+++ b/.github/workflows/validate-translations.yaml
@@ -27,6 +27,7 @@ jobs:
       with:
         check_name: validate_translations
         linter_output_path: translationIssues.txt
+        regex: '^(?<filename>.*?):(?<lineNumber>\d+):(?<columnNumber>\d+): (?<errorCode>\w\d+) (?<errorDesc>[\s|\w|.]*)'
         commit_sha: ${{ github.sha }}
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/validate-translations.yaml
+++ b/.github/workflows/validate-translations.yaml
@@ -5,11 +5,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  javascript:
-    name: JavaScript
+  validate_translations:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
     - name: Set up Node
       uses: actions/setup-node@v2
       with:
@@ -21,6 +21,7 @@ jobs:
     - name: Check translations
       run: |
           yarn run validate:translations
+    - name: Add annotations
       uses: pytorch/add-annotations-github-action@master
       with:
         check_name: Check translations

--- a/.github/workflows/validate-translations.yaml
+++ b/.github/workflows/validate-translations.yaml
@@ -21,6 +21,7 @@ jobs:
     - name: Check translations
       run: |
           yarn run validate:translations
+          cat translationIssues.txt
     - name: Add annotations
       uses: pytorch/add-annotations-github-action@master
       with:

--- a/.github/workflows/validate-translations.yaml
+++ b/.github/workflows/validate-translations.yaml
@@ -28,4 +28,4 @@ jobs:
         linter_output_path: translationIssues.txt
         commit_sha: ${{ github.event.pull_request.head.sha }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-translations.yaml
+++ b/.github/workflows/validate-translations.yaml
@@ -17,6 +17,13 @@ jobs:
     - name: Install dependencies
       run: |
         yarn install
-    - name: Lint
-      run: |
-        yarn run validate:translations
+    - name: Check translations
+      - run: |
+          yarn run validate:translations
+      - uses: pytorch/add-annotations-github-action@master
+        with:
+          check_name: Check translations
+          linter_output_path: translationIssues.txt
+          commit_sha: ${{ github.event.pull_request.head.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-translations.yaml
+++ b/.github/workflows/validate-translations.yaml
@@ -27,5 +27,5 @@ jobs:
         check_name: Check translations
         linter_output_path: translationIssues.txt
         commit_sha: ${{ github.event.pull_request.head.sha }}
-        env:
-          token: ${{secrets.GITHUB_TOKEN}}
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/validate-translations.yaml
+++ b/.github/workflows/validate-translations.yaml
@@ -26,6 +26,6 @@ jobs:
       with:
         check_name: Check translations
         linter_output_path: translationIssues.txt
-        commit_sha: ${{ github.event.pull_request.head.sha }}
+        commit_sha: ${{ github.sha }}
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/validate-translations.yaml
+++ b/.github/workflows/validate-translations.yaml
@@ -27,5 +27,5 @@ jobs:
         check_name: Check translations
         linter_output_path: translationIssues.txt
         commit_sha: ${{ github.event.pull_request.head.sha }}
-        env:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{secrets.GITHUB_TOKEN}}
+

--- a/.github/workflows/validate-translations.yaml
+++ b/.github/workflows/validate-translations.yaml
@@ -19,9 +19,9 @@ jobs:
       run: |
         yarn install
     - name: Check translations
-    - run: |
+      run: |
           yarn run validate:translations
-    - uses: pytorch/add-annotations-github-action@master
+      uses: pytorch/add-annotations-github-action@master
       with:
         check_name: Check translations
         linter_output_path: translationIssues.txt

--- a/.github/workflows/validate-translations.yaml
+++ b/.github/workflows/validate-translations.yaml
@@ -21,10 +21,10 @@ jobs:
     - name: Check translations
     - run: |
           yarn run validate:translations
-     - uses: pytorch/add-annotations-github-action@master
-       with:
-         check_name: Check translations
-         linter_output_path: translationIssues.txt
-         commit_sha: ${{ github.event.pull_request.head.sha }}
-         env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: pytorch/add-annotations-github-action@master
+      with:
+        check_name: Check translations
+        linter_output_path: translationIssues.txt
+        commit_sha: ${{ github.event.pull_request.head.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-translations.yaml
+++ b/.github/workflows/validate-translations.yaml
@@ -27,5 +27,5 @@ jobs:
         check_name: Check translations
         linter_output_path: translationIssues.txt
         commit_sha: ${{ github.event.pull_request.head.sha }}
-        token: ${{secrets.GITHUB_TOKEN}}
-
+        env:
+          token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/validate-translations.yaml
+++ b/.github/workflows/validate-translations.yaml
@@ -18,12 +18,12 @@ jobs:
       run: |
         yarn install
     - name: Check translations
-      - run: |
+    - run: |
           yarn run validate:translations
-      - uses: pytorch/add-annotations-github-action@master
-        with:
-          check_name: Check translations
-          linter_output_path: translationIssues.txt
-          commit_sha: ${{ github.event.pull_request.head.sha }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+     - uses: pytorch/add-annotations-github-action@master
+       with:
+         check_name: Check translations
+         linter_output_path: translationIssues.txt
+         commit_sha: ${{ github.event.pull_request.head.sha }}
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-translations.yaml
+++ b/.github/workflows/validate-translations.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Add annotations
       uses: pytorch/add-annotations-github-action@master
       with:
-        check_name: Check translations
+        check_name: validate_translations
         linter_output_path: translationIssues.txt
         commit_sha: ${{ github.sha }}
       env:

--- a/.github/workflows/validate-translations.yaml
+++ b/.github/workflows/validate-translations.yaml
@@ -1,0 +1,22 @@
+name: Validate translations
+
+on:
+  push:
+
+jobs:
+  javascript:
+    name: JavaScript
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: 12.x
+        cache: yarn
+    - name: Install dependencies
+      run: |
+        yarn install
+    - name: Lint
+      run: |
+        yarn run validate:translations

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ yarn-debug.log*
 yarn-error.log*
 
 .eslintcache
+
+# script outputs
+translationIssues.txt

--- a/ValidateTranslations.js
+++ b/ValidateTranslations.js
@@ -4,12 +4,13 @@ const translations = require("./src/Translations.js");
 const usedKeys = extract.extractFromFiles([
     "src/*.ts"
 ], {
-    marker: "t",
+    marker: "t", // renamed I18n.t to t for convenience
     parser: "typescript",
 });
 let validTranslations = true;
 for (const locale of Object.keys(translations)) {
     const missing = extract.findMissing(
+        // requires flattening as the translations object uses the Papyros-scope
         extract.flatten(translations[locale]),
         usedKeys
     );

--- a/ValidateTranslations.js
+++ b/ValidateTranslations.js
@@ -1,0 +1,26 @@
+const extract = require("i18n-extract");
+const translations = require("./src/Translations.js");
+
+const usedKeys = extract.extractFromFiles([
+    "src/*.ts"
+], {
+    marker: "t",
+    parser: "typescript",
+});
+let validTranslations = true;
+for (const locale of Object.keys(translations)) {
+    const missing = extract.findMissing(
+        extract.flatten(translations[locale]),
+        usedKeys
+    );
+    if (missing.length > 0) {
+        console.log(`Found missing keys for locale: ${locale}`);
+        validTranslations = false;
+    }
+}
+if (!validTranslations) {
+    process.exit(1);
+} else {
+    console.log("All translation keys present.");
+}
+

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     ]
   },
   "compilerOptions": {
-    "esModuleInterop": true,
     "allowJs": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "build": "webpack build --mode production",
     "test": "echo No tests defined yet",
     "lint": "eslint  --ext '.js' --ext '.ts' src",
-    "validate:translations": "node ValidateTranslations.js"
+    "validate:translations": "node scripts/ValidateTranslations.js"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "homepage": ".",
   "devDependencies": {
+    "@babel/traverse": "^7.16.3",
     "@codemirror/language": "^0.19.5",
     "@types/codemirror": "^5.60.5",
     "@types/i18n-js": "^3.8.2",
@@ -19,6 +20,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^25.2.4",
     "eslint-webpack-plugin": "^2.5.2",
+    "i18n-extract": "^0.6.7",
     "jest": "^27.3.1",
     "jest-junit": "^13.0.0",
     "postcss": "^8.3.11",
@@ -52,11 +54,16 @@
     "start": "webpack serve",
     "build": "webpack build --mode production",
     "test": "echo No tests defined yet",
-    "lint": "eslint  --ext '.js' --ext '.ts' src"
+    "lint": "eslint  --ext '.js' --ext '.ts' src",
+    "validate:translations": "node ValidateTranslations.js"
   },
   "babel": {
     "presets": [
       "@babel/preset-typescript"
     ]
+  },
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "allowJs": true
   }
 }

--- a/scripts/ValidateTranslations.js
+++ b/scripts/ValidateTranslations.js
@@ -15,7 +15,8 @@ for (const locale of Object.keys(translations)) {
         usedKeys
     );
     if (missing.length > 0) {
-        console.log(`Found missing keys for locale: ${locale}`);
+        console.log(`Found ${missing.length} missing keys for locale: ${locale}.`);
+        console.log(missing)
         validTranslations = false;
     }
 }

--- a/scripts/ValidateTranslations.js
+++ b/scripts/ValidateTranslations.js
@@ -21,14 +21,11 @@ const criteria = {
     "missing": extract.findMissing,
     "unused": extract.findUnused,
     "duplicate": extract.findDuplicated,
-    // disallow dynamic keys as otherwise this script has no use (static analysis)
-    "dynamic": extract.forbidDynamic
 };
 let validTranslations = true;
 for (const locale of Object.keys(translations)) {
     // requires flattening as the translations object uses the Papyros-scope
     const localeKeys = extract.flatten(translations[locale]);
-    console.log(localeKeys, translations[locale]);
     for (const [criterium, check] of Object.entries(criteria)) {
         // not &&= to ensure checkReport is actually executed
         validTranslations = checkReport(

--- a/scripts/ValidateTranslations.js
+++ b/scripts/ValidateTranslations.js
@@ -39,11 +39,15 @@ function checkReport(report, type, locale) {
     if (!valid) {
         const errorNumber = checks.map(c => c.type).indexOf(type);
         for (const issue of report) {
-            const {
-                line, column
-            } = issue.loc.start;
+            let line = "";
+            let column = "";
+            if (issue.loc && issue.loc.start) {
+                line = issue.loc.start.line;
+                column = issue.loc.start.column;
+            }
+            const file = issue.file || "src/Translations.js";
             const errorMsg = `R${errorNumber} ${type} key ${issue.key} for locale ${locale}`;
-            fs.writeFileSync(outputFile, `${issue.file}:${line}:${column}: ${errorMsg}\n`);
+            fs.writeFileSync(outputFile, `${file}:${line}:${column}: ${errorMsg}\n`);
         }
     }
     return valid;

--- a/scripts/ValidateTranslations.js
+++ b/scripts/ValidateTranslations.js
@@ -39,8 +39,8 @@ function checkReport(report, type, locale) {
     if (!valid) {
         const errorNumber = checks.map(c => c.type).indexOf(type);
         for (const issue of report) {
-            let line = "0";
-            let column = "0";
+            let line = "1";
+            let column = "1";
             if (issue.loc && issue.loc.start) {
                 line = issue.loc.start.line;
                 column = issue.loc.start.column;

--- a/scripts/ValidateTranslations.js
+++ b/scripts/ValidateTranslations.js
@@ -1,28 +1,45 @@
 const extract = require("i18n-extract");
 const translations = require("../src/Translations.js");
 
+function checkReport(report, type, locale) {
+    const valid = report.length === 0;
+    if (!valid) {
+        console.log(`Found ${report.length} ${type} keys for locale: ${locale}.`);
+        console.log(report);
+    }
+    return valid;
+}
+
 const usedKeys = extract.extractFromFiles([
     "src/*.ts"
 ], {
     marker: "t", // renamed I18n.t to t for convenience
     parser: "typescript",
 });
+
+const criteria = {
+    "missing": extract.findMissing,
+    "unused": extract.findUnused,
+    "duplicate": extract.findDuplicated,
+    // disallow dynamic keys as otherwise this script has no use (static analysis)
+    "dynamic": extract.forbidDynamic
+};
 let validTranslations = true;
 for (const locale of Object.keys(translations)) {
-    const missing = extract.findMissing(
-        // requires flattening as the translations object uses the Papyros-scope
-        extract.flatten(translations[locale]),
-        usedKeys
-    );
-    if (missing.length > 0) {
-        console.log(`Found ${missing.length} missing keys for locale: ${locale}.`);
-        console.log(missing)
-        validTranslations = false;
+    // requires flattening as the translations object uses the Papyros-scope
+    const localeKeys = extract.flatten(translations[locale]);
+    console.log(localeKeys, translations[locale]);
+    for (const [criterium, check] of Object.entries(criteria)) {
+        // not &&= to ensure checkReport is actually executed
+        validTranslations = checkReport(
+            check(localeKeys, usedKeys),
+            criterium, locale
+        ) && validTranslations;
     }
 }
 if (!validTranslations) {
     process.exit(1);
 } else {
-    console.log("All translation keys present.");
+    console.log("All translation operations are valid.");
 }
 

--- a/scripts/ValidateTranslations.js
+++ b/scripts/ValidateTranslations.js
@@ -1,5 +1,5 @@
 const extract = require("i18n-extract");
-const translations = require("./src/Translations.js");
+const translations = require("../src/Translations.js");
 
 const usedKeys = extract.extractFromFiles([
     "src/*.ts"

--- a/scripts/ValidateTranslations.js
+++ b/scripts/ValidateTranslations.js
@@ -1,11 +1,21 @@
 const extract = require("i18n-extract");
 const translations = require("../src/Translations.js");
+const fs = require("fs");
 
+const outputFile = fs.openSync("translationIssues.txt", "w");
 function checkReport(report, type, locale) {
     const valid = report.length === 0;
     if (!valid) {
         console.log(`Found ${report.length} ${type} keys for locale: ${locale}.`);
         console.log(report);
+        console.log(JSON.stringify(report));
+        for (const issue of report) {
+            const {
+                line, column
+            } = issue.loc.start;
+            const errorMsg = `${type} key ${issue.key} for locale ${locale}`;
+            fs.writeFileSync(outputFile, `${issue.file}:${line}:${column}: ${errorMsg}\n`);
+        }
     }
     return valid;
 }
@@ -36,7 +46,8 @@ const checks = [
     {
         "type": "dynamic",
         "check": extract.forbidDynamic,
-        "allowed": ["Papyros.programming_languages.*", "Papyros.locales.*", "Papyros.states.*"]
+        // "allowed": ["Papyros.programming_languages.*", "Papyros.locales.*", "Papyros.states.*"]
+        "allowed": []
     }
 ];
 

--- a/scripts/ValidateTranslations.js
+++ b/scripts/ValidateTranslations.js
@@ -3,22 +3,6 @@ const translations = require("../src/Translations.js");
 const fs = require("fs");
 
 const outputFile = fs.openSync("translationIssues.txt", "w");
-function checkReport(report, type, locale) {
-    const valid = report.length === 0;
-    if (!valid) {
-        console.log(`Found ${report.length} ${type} keys for locale: ${locale}.`);
-        console.log(report);
-        console.log(JSON.stringify(report));
-        for (const issue of report) {
-            const {
-                line, column
-            } = issue.loc.start;
-            const errorMsg = `${type} key ${issue.key} for locale ${locale}`;
-            fs.writeFileSync(outputFile, `${issue.file}:${line}:${column}: ${errorMsg}\n`);
-        }
-    }
-    return valid;
-}
 
 const usedKeys = extract.extractFromFiles([
     "src/*.ts"
@@ -46,10 +30,24 @@ const checks = [
     {
         "type": "dynamic",
         "check": extract.forbidDynamic,
-        // "allowed": ["Papyros.programming_languages.*", "Papyros.locales.*", "Papyros.states.*"]
-        "allowed": []
+        "allowed": ["Papyros.programming_languages.*", "Papyros.locales.*", "Papyros.states.*"]
     }
 ];
+
+function checkReport(report, type, locale) {
+    const valid = report.length === 0;
+    if (!valid) {
+        const errorNumber = checks.map(c => c.type).indexOf(type);
+        for (const issue of report) {
+            const {
+                line, column
+            } = issue.loc.start;
+            const errorMsg = `R${errorNumber} ${type} key ${issue.key} for locale ${locale}`;
+            fs.writeFileSync(outputFile, `${issue.file}:${line}:${column}: ${errorMsg}\n`);
+        }
+    }
+    return valid;
+}
 
 
 let validTranslations = true;

--- a/scripts/ValidateTranslations.js
+++ b/scripts/ValidateTranslations.js
@@ -39,8 +39,8 @@ function checkReport(report, type, locale) {
     if (!valid) {
         const errorNumber = checks.map(c => c.type).indexOf(type);
         for (const issue of report) {
-            let line = "";
-            let column = "";
+            let line = "0";
+            let column = "0";
             if (issue.loc && issue.loc.start) {
                 line = issue.loc.start.line;
                 column = issue.loc.start.column;

--- a/scripts/ValidateTranslations.js
+++ b/scripts/ValidateTranslations.js
@@ -53,22 +53,15 @@ function checkReport(report, type, locale) {
     return valid;
 }
 
-
-let validTranslations = true;
 for (const locale of Object.keys(translations)) {
     // requires flattening as the translations object uses the Papyros-scope
     const localeKeys = extract.flatten(translations[locale]);
     for (const check of checks) {
         // not &&= to ensure checkReport is actually executed
-        validTranslations = checkReport(
+        checkReport(
             check.check(localeKeys, usedKeys).filter(k => !check.allowed.includes(k.key)),
             check.type, locale
-        ) && validTranslations;
+        );
     }
-}
-if (!validTranslations) {
-    process.exit(1);
-} else {
-    console.log("All translation operations are valid.");
 }
 

--- a/scripts/ValidateTranslations.js
+++ b/scripts/ValidateTranslations.js
@@ -17,20 +17,39 @@ const usedKeys = extract.extractFromFiles([
     parser: "typescript",
 });
 
-const criteria = {
-    "missing": extract.findMissing,
-    "unused": extract.findUnused,
-    "duplicate": extract.findDuplicated,
-};
+const checks = [
+    {
+        "type": "missing",
+        "check": extract.findMissing,
+        "allowed": []
+    },
+    {
+        "type": "unused",
+        "check": extract.findUnused,
+        "allowed": []
+    },
+    {
+        "type": "duplicate",
+        "check": extract.findDuplicated,
+        "allowed": []
+    },
+    {
+        "type": "dynamic",
+        "check": extract.forbidDynamic,
+        "allowed": ["Papyros.programming_languages.*", "Papyros.locales.*", "Papyros.states.*"]
+    }
+];
+
+
 let validTranslations = true;
 for (const locale of Object.keys(translations)) {
     // requires flattening as the translations object uses the Papyros-scope
     const localeKeys = extract.flatten(translations[locale]);
-    for (const [criterium, check] of Object.entries(criteria)) {
+    for (const check of checks) {
         // not &&= to ensure checkReport is actually executed
         validTranslations = checkReport(
-            check(localeKeys, usedKeys),
-            criterium, locale
+            check.check(localeKeys, usedKeys).filter(k => !check.allowed.includes(k.key)),
+            check.type, locale
         ) && validTranslations;
     }
 }

--- a/src/Papyros.ts
+++ b/src/Papyros.ts
@@ -367,7 +367,6 @@ export class Papyros {
     async terminate(): Promise<void> {
         if (![PapyrosState.Running, PapyrosState.AwaitingInput].includes(this.state)) {
             papyrosLog(LogType.Error, `Terminate called from invalid state: ${this.state}`);
-            papyrosLog(LogType.Debug, t("Papyros.invalid_terminate"));
             return;
         }
         papyrosLog(LogType.Debug, "Called terminate, stopping backend!");

--- a/src/Papyros.ts
+++ b/src/Papyros.ts
@@ -11,7 +11,7 @@ import {
 } from "./Constants";
 import { PapyrosEvent } from "./PapyrosEvent";
 import { plFromString, ProgrammingLanguage } from "./ProgrammingLanguage";
-import { TRANSLATIONS } from "./Translations";
+import * as TRANSLATIONS from "./Translations";
 import { LogType, papyrosLog } from "./util/Logging";
 
 function loadTranslations(): void {
@@ -141,7 +141,7 @@ class PapyrosStateManager {
         this.state = PapyrosState.Ready;
     }
 
-    setState(state: PapyrosState, message?: string): void {
+    setState(state: PapyrosState, message: string): void {
         if (state !== this.state) {
             this.state = state;
             this.terminateButton.disabled = [PapyrosState.Ready, PapyrosState.Loading].includes(state);
@@ -152,7 +152,7 @@ class PapyrosStateManager {
                 this.stateSpinner.style.display = "";
                 this.runButton.disabled = true;
             }
-            this.stateText.innerText = message || t(`Papyros.${state}`);
+            this.stateText.innerText = message;
         }
     }
 }
@@ -244,11 +244,11 @@ export class Papyros {
         const {
             inputTextArray, inputMetaData
         } = this.inputState;
-        this.stateManager.setState(PapyrosState.Loading);
+        this.stateManager.setState(PapyrosState.Loading, t("Papyros.loading"));
         const backend = getBackend(programmingLanguage);
         await backend.launch(proxy(e => this.onMessage(e)), inputTextArray, inputMetaData);
         this.codeState.backend = backend;
-        this.stateManager.setState(PapyrosState.Ready);
+        this.stateManager.setState(PapyrosState.Ready, t("Papyros.ready"));
     }
 
     static fromElement(parent: HTMLElement, config: PapyrosConfig): Promise<Papyros> {
@@ -308,7 +308,7 @@ export class Papyros {
                 Atomics.store(inputMetaData, 0, 1);
             }
             this.inputState.lineNr += 1;
-            this.stateManager.setState(PapyrosState.Running);
+            this.stateManager.setState(PapyrosState.Running, t("Papyros.running"));
             return true;
         } else {
             papyrosLog(LogType.Debug, "Had no input to send, still waiting!");
@@ -319,11 +319,11 @@ export class Papyros {
     async onInput(e: PapyrosEvent): Promise<void> {
         papyrosLog(LogType.Debug, "Received onInput event in Papyros: ", e);
         if (!await this.sendInput()) {
-            this.stateManager.setState(PapyrosState.AwaitingInput);
+            this.stateManager.setState(PapyrosState.AwaitingInput, t("Papyros.awaiting_input"));
             // stateText.innerText = "Awaiting input for: " + e.data;
             papyrosLog(LogType.Debug, "User needs to enter input before code can continue");
         } else {
-            this.stateManager.setState(PapyrosState.Running);
+            this.stateManager.setState(PapyrosState.Running, t("Papyros.running"));
         }
     }
 
@@ -348,7 +348,7 @@ export class Papyros {
             return;
         }
         this.codeState.runId += 1;
-        this.stateManager.setState(PapyrosState.Running);
+        this.stateManager.setState(PapyrosState.Running, t("Papyros.running"));
         this.codeState.outputArea.value = "";
         papyrosLog(LogType.Debug, "Running code in Papyros, sending to backend");
         const start = new Date().getTime();
@@ -371,7 +371,7 @@ export class Papyros {
         }
         papyrosLog(LogType.Debug, "Called terminate, stopping backend!");
         this.codeState.runId += 1; // ignore messages coming from last run
-        this.stateManager.setState(PapyrosState.Terminating);
+        this.stateManager.setState(PapyrosState.Terminating, t("Papyros.terminating"));
         stopBackend(this.codeState.backend);
         return this.startBackend();
     }

--- a/src/Papyros.ts
+++ b/src/Papyros.ts
@@ -365,8 +365,9 @@ export class Papyros {
     }
 
     async terminate(): Promise<void> {
-        if (this.state !== PapyrosState.Running) {
+        if (![PapyrosState.Running, PapyrosState.AwaitingInput].includes(this.state)) {
             papyrosLog(LogType.Error, `Terminate called from invalid state: ${this.state}`);
+            papyrosLog(LogType.Debug, t("Papyros.invalid_terminate"));
             return;
         }
         papyrosLog(LogType.Debug, "Called terminate, stopping backend!");

--- a/src/Papyros.ts
+++ b/src/Papyros.ts
@@ -23,12 +23,12 @@ function loadTranslations(): void {
 
 const t = I18n.t;
 
-function getSelectOptions<T>(options: Array<T>, selected: T, translationPrefix: string): string {
+function getSelectOptions<T>(options: Array<T>, selected: T, optionText: (option: T) => string): string {
     return options.map(option => {
         const selectedValue = selected === option ? "selected" : "";
         return `
             <option ${selectedValue} value="${option}">
-                ${t(`Papyros.${translationPrefix}.${option}`)}
+                ${optionText(option)}
             </option>
         `;
     }).join("\n");
@@ -41,7 +41,7 @@ function renderPapyros(parent: HTMLElement, programmingLanguage: ProgrammingLang
         <div class="mr-2">
             <label for="programming-language-select">${t("Papyros.programming_language")}</label>
             <select id="programming-language-select" class="m-2 border-2">
-                ${getSelectOptions(PROGRAMMING_LANGUAGES, programmingLanguage, "programming_languages")} 
+                ${getSelectOptions(PROGRAMMING_LANGUAGES, programmingLanguage, l => t(`Papyros.programming_languages.${l}`))} 
             </select>
         </div>
         ` : "";
@@ -51,7 +51,7 @@ function renderPapyros(parent: HTMLElement, programmingLanguage: ProgrammingLang
         <div class="flex flex-row-reverse">
             <!-- row-reverse to start at the right, so put elements in order of display -->
             <select id="locale-select" class="m-2 border-2">
-                ${getSelectOptions(locales, locale, "locales")}
+                ${getSelectOptions(locales, locale, l => t(`Papyros.locales.${l}`))}
             </select>
             <i class="mdi mdi-web text-4xl text-white"></i>
         </div>
@@ -153,7 +153,7 @@ class PapyrosStateManager {
                 this.stateSpinner.style.display = "";
                 this.runButton.disabled = true;
             }
-            this.stateText.innerText = message || t(`Papyros.state.${state}`);
+            this.stateText.innerText = message || t(`Papyros.states.${state}`);
         }
     }
 }

--- a/src/Translations.js
+++ b/src/Translations.js
@@ -35,6 +35,7 @@ const DUTCH_TRANSLATION = {
 };
 
 // JS exports to allow use in TS and JS files
+// eslint-disable-next-line no-undef
 module.exports = {
     en: { "Papyros": ENGLISH_TRANSLATION },
     nl: { "Papyros": DUTCH_TRANSLATION }

--- a/src/Translations.js
+++ b/src/Translations.js
@@ -8,15 +8,24 @@ const ENGLISH_TRANSLATION = {
     "code_output": "Code output",
     "run": "Run",
     "terminate": "Terminate",
-    "running": "Running",
-    "terminating": "Terminating",
-    "loading": "Loading",
-    "awaiting_input": "Awaiting input",
-    "ready": " ",
+
     "finished": "Code executed in %{time} ms",
+    "states": {
+        "running": "Running",
+        "terminating": "Terminating",
+        "loading": "Loading",
+        "awaiting_input": "Awaiting input",
+        "ready": " ",
+    },
     "programming_language": "Programming language",
-    "Python": "Python",
-    "JavaScript": "JavaScript"
+    "programming_languages": {
+        "Python": "Python",
+        "JavaScript": "JavaScript"
+    },
+    "locales": {
+        "en": "English",
+        "nl": "Nederlands"
+    }
 };
 
 const DUTCH_TRANSLATION = {
@@ -26,15 +35,23 @@ const DUTCH_TRANSLATION = {
     "code_output": "Resultaat van de code",
     "run": "Voer uit",
     "terminate": "Stop uitvoering",
-    "running": "Aan het uitvoeren",
-    "terminating": "Aan het stoppen",
-    "loading": "Aan het laden",
-    "awaiting_input": "Aan het wachten op invoer",
-    "ready": " ",
+    "states": {
+        "running": "Aan het uitvoeren",
+        "terminating": "Aan het stoppen",
+        "loading": "Aan het laden",
+        "awaiting_input": "Aan het wachten op invoer",
+        "ready": " ",
+    },
     "finished": "Code uitgevoerd in %{time} ms",
     "programming_language": "Programmeertaal",
-    "Python": "Python",
-    "JavaScript": "JavaScript"
+    "programming_languages": {
+        "Python": "Python",
+        "JavaScript": "JavaScript"
+    },
+    "locales": {
+        "en": "English",
+        "nl": "Nederlands"
+    }
 };
 
 // JS exports to allow use in TS and JS files

--- a/src/Translations.js
+++ b/src/Translations.js
@@ -34,6 +34,7 @@ const DUTCH_TRANSLATION = {
     "JavaScript": "JavaScript"
 };
 
+// JS exports to allow use in TS and JS files
 module.exports = {
     en: { "Papyros": ENGLISH_TRANSLATION },
     nl: { "Papyros": DUTCH_TRANSLATION }

--- a/src/Translations.js
+++ b/src/Translations.js
@@ -1,3 +1,6 @@
+// Empty strings are considered missing by i18n-extract
+// Therefore the ready-key is an explicit space now, which is still invisible
+
 const ENGLISH_TRANSLATION = {
     "Papyros": "Papyros",
     "enter_code": "Enter your code here",
@@ -9,7 +12,7 @@ const ENGLISH_TRANSLATION = {
     "terminating": "Terminating",
     "loading": "Loading",
     "awaiting_input": "Awaiting input",
-    "ready": "",
+    "ready": " ",
     "finished": "Code executed in %{time} ms",
     "programming_language": "Programming language",
     "Python": "Python",
@@ -27,7 +30,7 @@ const DUTCH_TRANSLATION = {
     "terminating": "Aan het stoppen",
     "loading": "Aan het laden",
     "awaiting_input": "Aan het wachten op invoer",
-    "ready": "",
+    "ready": " ",
     "finished": "Code uitgevoerd in %{time} ms",
     "programming_language": "Programmeertaal",
     "Python": "Python",

--- a/src/Translations.js
+++ b/src/Translations.js
@@ -8,7 +8,6 @@ const ENGLISH_TRANSLATION = {
     "code_output": "Code output",
     "run": "Run",
     "terminate": "Terminate",
-
     "finished": "Code executed in %{time} ms",
     "states": {
         "running": "Running",
@@ -25,7 +24,8 @@ const ENGLISH_TRANSLATION = {
     "locales": {
         "en": "English",
         "nl": "Nederlands"
-    }
+    },
+    "myUnusedKey": "testing"
 };
 
 const DUTCH_TRANSLATION = {

--- a/src/Translations.js
+++ b/src/Translations.js
@@ -34,7 +34,7 @@ const DUTCH_TRANSLATION = {
     "JavaScript": "JavaScript"
 };
 
-export const TRANSLATIONS = {
+module.exports = {
     en: { "Papyros": ENGLISH_TRANSLATION },
     nl: { "Papyros": DUTCH_TRANSLATION }
 };

--- a/src/Translations.js
+++ b/src/Translations.js
@@ -25,7 +25,6 @@ const ENGLISH_TRANSLATION = {
         "en": "English",
         "nl": "Nederlands"
     },
-    "myUnusedKey": "testing"
 };
 
 const DUTCH_TRANSLATION = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,7 +28,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.16.0.tgz#ea269d7f78deb3a7826c39a4048eecda541ebdaa"
   integrity sha512-DGjt2QZse5SGd9nfOSqO4WLJ8NN/oHkijbXbPrxuoJO3oIPJL3TciZs9FX+cOHNiY9E9l0opL8g7BmLe3T+9ew==
 
-"@babel/core@^7.1.0", "@babel/core@^7.12.3", "@babel/core@^7.7.2", "@babel/core@^7.7.5":
+"@babel/core@^7.1.0", "@babel/core@^7.12.3", "@babel/core@^7.4.0", "@babel/core@^7.7.2", "@babel/core@^7.7.5":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.16.0.tgz#c4ff44046f5fe310525cc9eb4ef5147f0c5374d4"
   integrity sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==
@@ -67,6 +67,13 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
+"@babel/helper-annotate-as-pure@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.0.tgz#9a1f0ebcda53d9a2d00108c4ceace6a5d5f1f08d"
+  integrity sha512-ItmYF9vR4zA8cByDocY05o0LGUkp1zhbTQOH1NFyl5xXEqlTJQCEJjieriw+aFpxo16swMxUnUiKS7a/r4vtHg==
+  dependencies:
+    "@babel/types" "^7.16.0"
+
 "@babel/helper-compilation-targets@^7.16.0":
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.3.tgz#5b480cd13f68363df6ec4dc8ac8e2da11363cbf0"
@@ -76,6 +83,18 @@
     "@babel/helper-validator-option" "^7.14.5"
     browserslist "^4.17.5"
     semver "^6.3.0"
+
+"@babel/helper-create-class-features-plugin@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.0.tgz#090d4d166b342a03a9fec37ef4fd5aeb9c7c6a4b"
+  integrity sha512-XLwWvqEaq19zFlF5PTgOod4bUA+XbkR4WLQBct1bkzmxJGB0ZEJaoKF4c8cgH9oBtCDuYJ8BP5NB9uFiEgO5QA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.16.0"
+    "@babel/helper-function-name" "^7.16.0"
+    "@babel/helper-member-expression-to-functions" "^7.16.0"
+    "@babel/helper-optimise-call-expression" "^7.16.0"
+    "@babel/helper-replace-supers" "^7.16.0"
+    "@babel/helper-split-export-declaration" "^7.16.0"
 
 "@babel/helper-function-name@^7.12.13":
   version "7.12.13"
@@ -239,6 +258,23 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.17.tgz#bc85d2d47db38094e5bb268fc761716e7d693848"
   integrity sha512-r1yKkiUTYMQ8LiEI0UcQx5ETw5dpTLn9wijn9hk6KkTtOK95FndDN10M+8/s6k/Ymlbivw0Av9q4SlgF80PtHg==
 
+"@babel/plugin-proposal-class-properties@^7.4.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.16.0.tgz#c029618267ddebc7280fa286e0f8ca2a278a2d1a"
+  integrity sha512-mCF3HcuZSY9Fcx56Lbn+CGdT44ioBMMvjNVldpKtj8tpniETdLjnxdHI1+sDWXIM1nNt+EanJOZ3IG9lzVjs7A==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.16.0"
+    "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-proposal-decorators@^7.4.0":
+  version "7.16.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.16.4.tgz#9b35ce0716425a93b978e79099e5f7ba217c1364"
+  integrity sha512-RESBNX16eNqnBeEVR5sCJpnW0mHiNLNNvGA8PrRuK/4ZJ4TO+6bHleRUuGQYDERVySOKtOhSya/C4MIhwAMAgg==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.16.0"
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/plugin-syntax-decorators" "^7.16.0"
+
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz#a983fb1aeb2ec3f6ed042a210f640e90e786fe0d"
@@ -259,6 +295,20 @@
   integrity sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
+
+"@babel/plugin-syntax-decorators@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.16.0.tgz#eb8d811cdd1060f6ac3c00956bf3f6335505a32f"
+  integrity sha512-nxnnngZClvlY13nHJAIDow0S7Qzhq64fQ/NlqS+VER3kjW/4F0jLhXjeL8jcwSwz6Ca3rotT5NJD2T9I7lcv7g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-syntax-dynamic-import@^7.2.0":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz#62bf98b2da3cd21d626154fc96ee5b3cb68eacb3"
+  integrity sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
 
 "@babel/plugin-syntax-import-meta@^7.8.3":
   version "7.10.4"
@@ -330,6 +380,17 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/register@^7.4.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.16.0.tgz#f5d2aa14df37cf7146b9759f7c53818360f24ec6"
+  integrity sha512-lzl4yfs0zVXnooeLE0AAfYaT7F3SPA8yB2Bj4W1BiZwLbMS3MZH35ZvCWSRHvneUugwuM+Wsnrj7h0F7UmU3NQ==
+  dependencies:
+    clone-deep "^4.0.1"
+    find-cache-dir "^2.0.0"
+    make-dir "^2.1.0"
+    pirates "^4.0.0"
+    source-map-support "^0.5.16"
+
 "@babel/template@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -348,7 +409,7 @@
     "@babel/parser" "^7.16.0"
     "@babel/types" "^7.16.0"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.16.0", "@babel/traverse@^7.16.3", "@babel/traverse@^7.7.2":
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.16.0", "@babel/traverse@^7.16.3", "@babel/traverse@^7.4.0", "@babel/traverse@^7.7.2":
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.16.3.tgz#f63e8a938cc1b780f66d9ed3c54f532ca2d14787"
   integrity sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==
@@ -2110,6 +2171,11 @@ commander@^7.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+  integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
+
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -2537,6 +2603,13 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
+
+encoding@^0.1.12:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
+  integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
+  dependencies:
+    iconv-lite "^0.6.2"
 
 end-of-stream@^1.1.0:
   version "1.4.4"
@@ -3085,6 +3158,15 @@ finalhandler@~1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
+find-cache-dir@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
+  integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^2.0.0"
+    pkg-dir "^3.0.0"
+
 find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
@@ -3238,6 +3320,15 @@ get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
+
+gettext-parser@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/gettext-parser/-/gettext-parser-3.1.1.tgz#f2455f7cc402087a0ee5289fcca204702b7fe240"
+  integrity sha512-vNhWcqXEtZPs5Ft1ReA34g7ByWotpcOIeJvXVy2jF3/G2U9v6W0wG4Z4hXzcU8R//jArqkgHcVCGgGqa4vxVlQ==
+  dependencies:
+    encoding "^0.1.12"
+    readable-stream "^3.2.0"
+    safe-buffer "^5.1.2"
 
 glob-parent@^3.1.0:
   version "3.1.0"
@@ -3547,6 +3638,20 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+i18n-extract@^0.6.7:
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/i18n-extract/-/i18n-extract-0.6.7.tgz#90f0ee830e2e3d0c2767b72cc09dcbbc807aaf55"
+  integrity sha512-rwuQ/mXTSg6/8IrN9nUBTj2IOTqsWP49uxz8ZhUvhj9ojrqRxdwCvHQg9bLCgz7GZ1ocW0alvWP1eagbhFoWgQ==
+  dependencies:
+    "@babel/core" "^7.4.0"
+    "@babel/plugin-proposal-class-properties" "^7.4.0"
+    "@babel/plugin-proposal-decorators" "^7.4.0"
+    "@babel/plugin-syntax-dynamic-import" "^7.2.0"
+    "@babel/register" "^7.4.0"
+    "@babel/traverse" "^7.4.0"
+    gettext-parser "^3.1.1"
+    glob "^7.1.3"
+
 i18n-js@^3.8.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/i18n-js/-/i18n-js-3.8.0.tgz#b8fd6b12e1d88cb71f9806c29bca7c31c012e504"
@@ -3558,6 +3663,13 @@ iconv-lite@0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+iconv-lite@^0.6.2:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 icss-utils@^5.0.0, icss-utils@^5.1.0:
   version "5.1.0"
@@ -4672,6 +4784,14 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+make-dir@^2.0.0, make-dir@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
+  integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
+  dependencies:
+    pify "^4.0.1"
+    semver "^5.6.0"
+
 make-dir@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
@@ -5340,7 +5460,7 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
-pirates@^4.0.1:
+pirates@^4.0.0, pirates@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
   integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
@@ -5667,7 +5787,7 @@ readable-stream@^2.0.1, readable-stream@^2.0.2:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.6:
+readable-stream@^3.0.6, readable-stream@^3.2.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -5861,7 +5981,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
+safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -5873,7 +5993,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3":
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -5924,7 +6044,7 @@ selfsigned@^1.10.8:
   dependencies:
     node-forge "^0.10.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.5.0:
+"semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -6155,6 +6275,14 @@ source-map-resolve@^0.5.0:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
+
+source-map-support@^0.5.16:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
 
 source-map-support@^0.5.6, source-map-support@~0.5.20:
   version "0.5.20"


### PR DESCRIPTION
This PR adds a JS script called ValidateTranslations that checks whether the provided translations are valid. A GitHub action is also defined to call this script on pushes to any branch.

The script is written in JavaScript as running it as a stand-alone TS file never fully worked. On the one hand, i18n-extract does not provide proper typing, requiring some hacks to get it into TypeScript (e.g. including the source code directly as it required some manual editing to even run). On the other hand, importing other modules did not work out of the box.
The JavaScript file can easily be run through Node, but the Translations.ts file had to be converted to JS for it to be imported. This isn't an impactful change, as they are simple objects where typing is quite irrelevant.

The current checks are: detecting any unused, missing, duplicated or dynamic keys, and failing if any of these are present (with failing only once all checks have been done to prevent rerunning often). Explictly empty keys (such as Papyros.ready) are considered as missing, but this is a special case so whitespace also does the trick.

Closes #53