### PR TITLE
Add stand alone mode

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -13,7 +13,7 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
   <link rel="manifest" href="manifest.json" />
-
+  <link href="https://cdn.jsdelivr.net/npm/@mdi/font@5.x/css/materialdesignicons.min.css" rel="stylesheet" type="text/css">
   <!-- Wait with running the script until the elements are loaded as they are needed immediately -->
   <script src="./bundle.js" defer></script>
 

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -12,9 +12,10 @@ export const APPLICATION_STATE_TEXT_ID = "application-state-text";
 export const RUN_BTN_ID = "run-code-btn";
 export const TERMINATE_BTN_ID = "terminate-btn";
 
-export const LANGUAGE_SELECT_ID = "language-select";
-
+export const PROGRAMMING_LANGUAGE_SELECT_ID = "programming-language-select";
 export const DEFAULT_PROGRAMMING_LANGUAGE = ProgrammingLanguage.Python;
+
+export const LOCALE_SELECT_ID = "locale-select";
 export const DEFAULT_LOCALE = "nl";
 
 export const INPUT_RELATIVE_URL = "/__papyros_input";

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ function startPapyros(): void {
     const language = plFromString(urlParams.get("language") || DEFAULT_PROGRAMMING_LANGUAGE);
     const locale = urlParams.get("locale") || DEFAULT_LOCALE;
     Papyros.fromElement(rootElement, {
-        standAlone: false,
+        standAlone: true,
         programmingLanguage: language,
         locale: locale,
         inputTextArray: inputTextArray,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import "bootstrap/dist/css/bootstrap.css";
 import "./App.css";
-import { DEFAULT_PROGRAMMING_LANGUAGE, MAIN_APP_ID } from "./Constants";
+import { DEFAULT_LOCALE, DEFAULT_PROGRAMMING_LANGUAGE, MAIN_APP_ID } from "./Constants";
 import { Papyros } from "./Papyros";
 import { papyrosLog, LogType } from "./util/Logging";
 import { plFromString } from "./ProgrammingLanguage";
@@ -48,5 +48,11 @@ function startPapyros(): void {
     const rootElement = document.getElementById("root")!;
     const language = plFromString(new URLSearchParams(window.location.search).get("language") ||
         DEFAULT_PROGRAMMING_LANGUAGE);
-    Papyros.fromElement(rootElement, "nl", language, inputTextArray, inputMetaData);
+    Papyros.fromElement(rootElement, {
+        standAlone: false,
+        programmingLanguage: language,
+        locale: DEFAULT_LOCALE,
+        inputTextArray: inputTextArray,
+        inputMetaData: inputMetaData
+    });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,12 +46,13 @@ function startPapyros(): void {
         papyrosLog(LogType.Important, "Using serviceWorker for input");
     }
     const rootElement = document.getElementById("root")!;
-    const language = plFromString(new URLSearchParams(window.location.search).get("language") ||
-        DEFAULT_PROGRAMMING_LANGUAGE);
+    const urlParams = new URLSearchParams(window.location.search);
+    const language = plFromString(urlParams.get("language") || DEFAULT_PROGRAMMING_LANGUAGE);
+    const locale = urlParams.get("locale") || DEFAULT_LOCALE;
     Papyros.fromElement(rootElement, {
         standAlone: false,
         programmingLanguage: language,
-        locale: DEFAULT_LOCALE,
+        locale: locale,
         inputTextArray: inputTextArray,
         inputMetaData: inputMetaData
     });


### PR DESCRIPTION
This PR adds a config object to Papyros, with a new addition called standAlone. This boolean option tells Papyros to work in stand-alone mode, meaning it is its own application and not part of something bigger (such as Dodona).  This allows for conditional styling and rendering, as not every feature is relevant when not in stand-alone mode (such as a selector for the programming language, as this is most likely fixed and provided by the caller). The bar above the editor would then look like this:
![stand-alone-papyros](https://user-images.githubusercontent.com/53743234/144488470-d56da129-8517-4787-ac52-8d3bf5929423.PNG).

The current usage is disabling/enabling the header (containing the title and the language select) and the programming language select.
The stand-alone mode can thus now dynamically be translated by using urlParams, as follows.
![stand-alone-papyros](https://user-images.githubusercontent.com/53743234/144596298-d372162b-4e73-44e8-9308-e01691bd95e2.PNG)

This option could be used la

ter on to disable/enable other features or more agressive HTML-class changes if needed.



Depends on #45 
Closes #50 .