### PR TITLE
Fix callback return value

### DIFF
--- a/src/Backend.ts
+++ b/src/Backend.ts
@@ -36,7 +36,7 @@ function getInputCallback(inputTextArray?: Uint8Array, inputMetaData?: Int32Arra
 }
 
 export abstract class Backend {
-    onEvent: (e: PapyrosEvent) => void;
+    onEvent: (e: PapyrosEvent) => any;
     runId: number;
 
     constructor() {

--- a/src/Papyros.ts
+++ b/src/Papyros.ts
@@ -299,7 +299,6 @@ export class Papyros {
         } finally {
             const end = new Date().getTime();
             this.stateManager.setState(PapyrosState.Ready, t("Papyros.finished", { time: end - start }));
-            this.inputState.inputArea.value = "";
             this.inputState.lineNr = 0;
         }
     }

--- a/src/Papyros.ts
+++ b/src/Papyros.ts
@@ -194,6 +194,7 @@ export class Papyros {
             stopBackend(this.codeState.backend);
             this.codeState.programmingLanguage = programmingLanguage;
             this.codeState.editor.setLanguage(programmingLanguage);
+            this.codeState.outputArea.value = "";
             await this.startBackend();
         }
     }

--- a/src/workers/python/PythonWorker.worker.ts
+++ b/src/workers/python/PythonWorker.worker.ts
@@ -39,7 +39,7 @@ class PythonWorker extends Backend {
         // Python calls our function with a dict, which must be converted to a PapyrosEvent
         const eventCallback = (data: any): void => {
             const jsEvent: PapyrosEvent = "toJs" in data ? data.toJs() : Object.fromEntries(data);
-            this.onEvent(jsEvent);
+            return this.onEvent(jsEvent);
         };
         this.pyodide.globals.get("__override_builtins")(eventCallback);
         this.globals = new Map((this.pyodide.globals as any).toJs());


### PR DESCRIPTION
This PR restores the functionality of input() in Python. The callback returned void, causing input to never receive a value and thus printing None. This is tied to the fact that I always print the value that the user gave. In a terminal, after calling input, the user is expected to type something and hit enter. This behaviour is emulated in the output window, by printing the prompt and then the obtained value. I noticed this causes some confusion, so this might only be desirable in an explicit REPL environment. The question is thus whether this extra print should also be removed as part of this PR.

Closes #56 
Can close #27  @pdawyndt ?