### PR TITLE
Show terminate button only when appropriate

### DIFF
--- a/src/Papyros.ts
+++ b/src/Papyros.ts
@@ -82,7 +82,7 @@ function renderPapyros(parent: HTMLElement, programmingLanguage: ProgrammingLang
         </button>
         <button id="terminate-btn" type="button" 
             class="text-white bg-red-500 border-2 m-3 px-4 inset-y-2 rounded-lg
-            disabled:opacity-50 disabled:cursor-wait" hidden>
+            disabled:opacity-50 disabled:cursor-wait">
             ${t("Papyros.terminate")}
         </button>
         <div class="flex flex-row items-center">
@@ -144,7 +144,7 @@ class PapyrosStateManager {
     setState(state: PapyrosState, message?: string): void {
         if (state !== this.state) {
             this.state = state;
-            this.terminateButton.hidden = [PapyrosState.Ready, PapyrosState.Loading].includes(state);
+            this.terminateButton.disabled = [PapyrosState.Ready, PapyrosState.Loading].includes(state);
             if (state === PapyrosState.Ready) {
                 this.stateSpinner.style.display = "none";
                 this.runButton.disabled = false;


### PR DESCRIPTION
This PR adds finer control over when the terminate button is visible. The original code only compared to Ready, whereas Loading is also a state that should be preserved.

As a bonus, I added logs and  early returns when runCode/terminate are called from states when they shouldn't be callable. This should only occur when a user tampers with the DOM, but might also protect against coding errors.

Closes #61 