### PR TITLE
Preserve whitespace in output area

### DIFF
--- a/src/OutputManager.ts
+++ b/src/OutputManager.ts
@@ -11,10 +11,6 @@ export interface FriendlyError {
     where?: string;
 }
 
-function newLine(): string {
-    return "\n";
-}
-
 export class OutputManager {
     outputArea: HTMLElement;
     constructor(outputWrapperId: string) {
@@ -26,20 +22,22 @@ export class OutputManager {
     }
 
     spanify(text: string, ignoreEmpty = false): string {
-        if (text.includes("\n") && text !== "\n") {
-            text = text.endsWith("\n") ? text.substring(0, text.length - 1) : text;
-            text = text.split("\n")
+        let spanText = text;
+        if (spanText.includes("\n") && spanText !== "\n") {
+            spanText = spanText.endsWith("\n") ?
+                spanText.substring(0, spanText.length - 1) : spanText;
+            spanText = spanText.split("\n")
                 .filter(line => !ignoreEmpty || line.trim().length > 0)
                 .join("\n");
         }
-        return `<span>${escapeHTML(text)}</span>`;
+        return `<span>${escapeHTML(spanText)}</span>`;
     }
 
     showOutput(output: PapyrosEvent): void {
         if (output.content === "img") {
             this.renderNextElement(`<img src="data:image/png;base64, ${output.data}"></img>`);
         } else {
-            this.renderNextElement(this.spanify(output.data));
+            this.renderNextElement(this.spanify(output.data, false));
         }
     }
 
@@ -55,19 +53,19 @@ export class OutputManager {
             }
         }
         if (Object.keys(errorObject).length > 0) {
-            const shortTraceback = (errorObject.where || errorObject.traceback || "").trim();
+            let shortTraceback = (errorObject.where || errorObject.traceback || "").trim();
+            // Prepend a bit of indentation, so every part has indentation
+            shortTraceback = this.spanify("  " + shortTraceback, true);
             errorHTML +=
-                // This HTML mustn't contain extra whitespace because it will be rendered literally
-                `<div class="text-red-500 text-bold">` +
-                    `${inCircle("?", errorObject.info)}${errorObject.name} traceback:` +
-                    `${this.spanify(shortTraceback, true)}` +
-                `</div>`;
-            errorHTML += newLine();
+`<div class="text-red-500 text-bold">
+${inCircle("?", errorObject.info)}${errorObject.name} traceback:
+${shortTraceback}
+</div>\n`;
             if (errorObject.what) {
-                errorHTML += this.spanify(errorObject.what.trim(), true) + newLine();
+                errorHTML += this.spanify(errorObject.what.trim(), true) + "\n";
             }
             if (errorObject.why) {
-                errorHTML += this.spanify(errorObject.why.trim(), true) + newLine();
+                errorHTML += this.spanify(errorObject.why.trim(), true) + "\n";
             }
         }
 

--- a/src/OutputManager.ts
+++ b/src/OutputManager.ts
@@ -12,7 +12,7 @@ export interface FriendlyError {
 }
 
 function newLine(): string {
-    return "<br/>";
+    return "\n";
 }
 
 export class OutputManager {
@@ -25,22 +25,14 @@ export class OutputManager {
         this.outputArea.insertAdjacentHTML("beforeend", html);
     }
 
-    newLine(): void {
-        this.renderNextElement("<br/>");
-    }
-
     spanify(text: string, ignoreEmpty = false): string {
-        if (text === "\n") {
-            return newLine();
-        } else if (text.includes("\n")) {
-            const actualText = text.endsWith("\n") ? text.substring(0, text.length - 1) : text;
-            return actualText.split("\n")
+        if (text.includes("\n") && text !== "\n") {
+            text = text.endsWith("\n") ? text.substring(0, text.length - 1) : text;
+            text = text.split("\n")
                 .filter(line => !ignoreEmpty || line.trim().length > 0)
-                .map(line => `<span>${escapeHTML(line)}</span><br/>`)
                 .join("\n");
-        } else {
-            return `<span>${escapeHTML(text)}</span>`;
         }
+        return `<span>${escapeHTML(text)}</span>`;
     }
 
     showOutput(output: PapyrosEvent): void {
@@ -65,10 +57,11 @@ export class OutputManager {
         if (Object.keys(errorObject).length > 0) {
             const shortTraceback = (errorObject.where || errorObject.traceback || "").trim();
             errorHTML +=
-                `<div class="text-red-500 text-bold">
-                    ${inCircle("?", errorObject.info)}${errorObject.name} traceback: <br/>
-                    ${this.spanify(shortTraceback, true)}
-                </div>`;
+                // This HTML mustn't contain extra whitespace because it will be rendered literally
+                `<div class="text-red-500 text-bold">` +
+                    `${inCircle("?", errorObject.info)}${errorObject.name} traceback:` +
+                    `${this.spanify(shortTraceback, true)}` +
+                `</div>`;
             errorHTML += newLine();
             if (errorObject.what) {
                 errorHTML += this.spanify(errorObject.what.trim(), true) + newLine();

--- a/src/OutputManager.ts
+++ b/src/OutputManager.ts
@@ -56,11 +56,9 @@ export class OutputManager {
             let shortTraceback = (errorObject.where || errorObject.traceback || "").trim();
             // Prepend a bit of indentation, so every part has indentation
             shortTraceback = this.spanify("  " + shortTraceback, true);
-            errorHTML +=
-`<div class="text-red-500 text-bold">
-${inCircle("?", errorObject.info)}${errorObject.name} traceback:
-${shortTraceback}
-</div>\n`;
+            errorHTML += "<div class=\"text-red-500 text-bold\">";
+            errorHTML += `${inCircle("?", errorObject.info)}${errorObject.name} traceback:\n`;
+            errorHTML += shortTraceback + "</div>\n";
             if (errorObject.what) {
                 errorHTML += this.spanify(errorObject.what.trim(), true) + "\n";
             }

--- a/src/Papyros.css
+++ b/src/Papyros.css
@@ -13,3 +13,7 @@ body {
 .cm-content {
   font-family: Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace;
 }
+
+#code-output-area {
+  white-space: pre;
+}

--- a/src/Papyros.css
+++ b/src/Papyros.css
@@ -10,7 +10,7 @@ body {
 .cm-scroller, .cm-gutters { /* Min height of the editor via both gutter and scroller */
   min-height: 20vh !important;
 }
-.cm-content {
+.cm-content, #code-output-area {
   font-family: Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace;
 }
 


### PR DESCRIPTION
Examples:

![Screenshot from 2022-01-17 16-26-09](https://user-images.githubusercontent.com/3627481/149787741-c5e9938c-580c-41e6-9feb-5c13c4121d37.png)
![Screenshot from 2022-01-17 16-25-18](https://user-images.githubusercontent.com/3627481/149787748-90a49cd4-20f3-4b55-a0be-56f8db26962b.png)

As you can see this is especially important for indicating the location of syntax errors.

Related:

- #39
- #58