### PR TITLE
Use python_runner

### DIFF
--- a/src/Papyros.css
+++ b/src/Papyros.css
@@ -13,7 +13,3 @@ body {
 .cm-content, #code-output-area {
   font-family: Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace;
 }
-
-#code-output-area {
-  white-space: pre;
-}

--- a/src/Papyros.ts
+++ b/src/Papyros.ts
@@ -70,7 +70,7 @@ function renderPapyros(parent: HTMLElement, standAlone: boolean,
         <div class="col-span-1">
           <h1>${t("Papyros.output")}:</h1>
           <div id="${OUTPUT_TA_ID}" title="${t("Papyros.output_placeholder")}"
-           class="border-2 w-full min-h-1/4 max-h-3/5 overflow-auto px-1"></div>
+           class="border-2 w-full min-h-1/4 max-h-3/5 overflow-auto px-1 whitespace-pre"></div>
           <h1>${t("Papyros.input")}:</h1>
           <div id="${INPUT_AREA_WRAPPER_ID}">
           </div>
@@ -164,7 +164,9 @@ export class Papyros {
     async launch(): Promise<Papyros> {
         this.stateManager.runButton.addEventListener("click", () => this.runCode());
         this.stateManager.stopButton.addEventListener("click", () => this.stop());
+        const start = new Date().getTime();
         await this.startBackend();
+        papyrosLog(LogType.Important, `Finished loading backend after ${new Date().getTime() - start} ms`);
         this.codeState.editor.focus();
         return this;
     }

--- a/src/examples/PythonExamples.ts
+++ b/src/examples/PythonExamples.ts
@@ -108,7 +108,8 @@ def find_bitonic_query(numbers, query, start, stop, comp):
     "Unicode":
         `import random
 emoji = '🎅🤶👪🦌🌟❄️☃️🔥🎄🎁🧦🔔🎶🕯️🦆'
-print(''.join(random.choice(emoji) for _ in range(512)))
+for _ in range(10):
+    print(''.join(random.choice(emoji) for _ in range(30)))
 `,
     "Files":
         `with open("names.txt", "w") as out_file:

--- a/src/workers/python/init.py
+++ b/src/workers/python/init.py
@@ -1,82 +1,26 @@
-from pyodide import to_js, eval_code_async
-from js import console
-import sys
-import ast
 import json
-import html
-import types
-import os
+from pyodide import to_js
+
 import micropip
+
+await micropip.install("python_runner")
+import python_runner
+
 ft = micropip.install('friendly_traceback')
 
 papyros = None
 
-class Papyros():
-    def __init__(self, cb):
-        self.cb = cb
-        self.line = ""
-        self.override_builtins()
 
-    def message(self, data):
-        return self.cb(to_js(data))
-
-    def override_builtins(self):
-        self.override_output()
-        self.override_input()
-        self.override_matplotlib()
-
-    def override_output(self):
-        class OutputWriter:
-            def __init__(self, type, on_write, original):
-                self.encoding = "utf-8"
-                self.type = type
-                self.on_write = on_write
-                self.original = original
-                
-            def write(self, s):
-                if isinstance(s, bytes):
-                    s = s.decode("utf8", "replace")
-                self.on_write(dict(type=self.type, data=s))
-
-            def flush(self):
-                pass # Given data is always immediately written
-
-            def __getattr__(self, item):
-                return getattr(self.original, item)
-
-        on_write = lambda d: self.message(d)
-        sys.stdout = OutputWriter("output", on_write, sys.stdout)
-        sys.stderr = OutputWriter("error", on_write, sys.stderr)
-
-    def readline(self, n=-1, prompt=""):
-        if not self.line:
-            self.line = self.message(dict(type="input", data=prompt)) + "\\n"
-        if n < 0 or n > len(self.line):
-            n = len(self.line)
-        to_return = self.line[0:n]
-        self.line = self.line[n:]
-        return to_return
-
-    def globals(self, filename):
-        mod = types.ModuleType("__main__")
-        mod.__file__ = filename
-        sys.modules["__main__"] = mod
-        return mod.__dict__
-
-    def override_input(self):
-        sys.stdin.readline = self.readline
-        import builtins
-        builtins.input = lambda prompt="": self.readline(prompt=prompt)[:-1] # Remove newline
-
+class Papyros(python_runner.PatchedStdinRunner):
     def override_matplotlib(self):
         # workaround from https://github.com/pyodide/pyodide/issues/1518
         import base64
         import os
-        
+
         from io import BytesIO
-    
+
         os.environ['MPLBACKEND'] = 'AGG'
-        
+
         import matplotlib.pyplot
         def show():
             buf = BytesIO()
@@ -85,51 +29,92 @@ class Papyros():
             # encode to a base64 str
             img = base64.b64encode(buf.read()).decode('utf-8')
             matplotlib.pyplot.clf()
-            self.message(dict(type="output", content="img", data=img))
-        
+            self.output("img", img)
+
         matplotlib.pyplot.show = show
 
-def format_exception(filename, exc):
-    from friendly_traceback.core import FriendlyTraceback
-    fr = FriendlyTraceback(type(exc), exc, exc.__traceback__)
-    fr.assign_generic()
-    fr.assign_cause()
-    tb = fr.info.get("shortened_traceback", "")
-    info = fr.info.get("generic", "")
-    why = fr.info.get("cause", "")
-    what = fr.info.get("message", "")
-    user_start = 0
-    tb_lines = tb.split("\\n")
-    while user_start < len(tb_lines) and filename not in tb_lines[user_start]:
-        user_start += 1
-    name = type(exc).__name__
-    user_end = user_start + 1
-    while user_end < len(tb_lines) and name not in tb_lines[user_end]:
-        user_end += 1
-    where = "\\n".join(tb_lines[user_start:user_end]) or ""
-    return json.dumps(
-        dict(
-            name=name,
-            traceback=tb,
-            info=info,
-            why=why,
-            where=where,
-            what=what
-        )
-    )
+    async def run_async(self, source_code, mode="exec", top_level_await=True):
+        """
+        Mostly a copy of the parent `run_async` with `await ft` in case of an exception,
+        because `serialize_traceback` isn't async.
+        """
+        code_obj = self.pre_run(source_code, mode, top_level_await=top_level_await)
+        with self._execute_context(source_code):
+            if code_obj:
+                try:
+                    return await self.execute(code_obj, source_code, mode)
+                except:
+                    await ft
+                    # Let `_execute_context` and `serialize_traceback`
+                    # handle the exception
+                    raise
 
-def init_papyros(cb):
+    def serialize_traceback(self, exc, source_code):
+        import friendly_traceback
+        from friendly_traceback.core import FriendlyTraceback
+
+        friendly_traceback.source_cache.cache.add(self.filename, source_code)
+
+        fr = FriendlyTraceback(type(exc), exc, exc.__traceback__)
+        fr.assign_generic()
+        fr.assign_cause()
+        tb = fr.info.get("shortened_traceback", "")
+        info = fr.info.get("generic", "")
+        why = fr.info.get("cause", "")
+        what = fr.info.get("message", "")
+        user_start = 0
+        tb_lines = tb.split("\n")
+        while user_start < len(tb_lines) and self.filename not in tb_lines[user_start]:
+            user_start += 1
+        name = type(exc).__name__
+        user_end = user_start + 1
+        while user_end < len(tb_lines) and name not in tb_lines[user_end]:
+            user_end += 1
+        where = "\n".join(tb_lines[user_start:user_end]) or ""
+        return dict(
+            text=json.dumps(
+                dict(
+                    name=name,
+                    traceback=tb,
+                    info=info,
+                    why=why,
+                    where=where,
+                    what=what
+                )
+            )
+        )
+
+
+def init_papyros(eventCallback):
     global papyros
-    papyros = Papyros(cb)
+    def runner_callback(event_type, data):
+        def cb(typ, dat, **kwargs):
+            return eventCallback(to_js(dict(type=typ, data=dat, **kwargs)))
+
+        # Translate python_runner events to papyros events
+        if event_type == "output":
+            for part in data["parts"]:
+                if part["type"] in ["stderr", "traceback", "syntax_error"]:
+                    cb("error", part["text"])
+                elif part["type"] == "stdout":
+                    cb("output", part["text"])
+                elif part["type"] == "img":
+                    cb("output", part["text"], content="img")
+                elif part["type"] in ["input", "input_prompt"]:
+                    continue
+                else:
+                    raise ValueError(f"Unknown output part type {part['type']}")
+        elif event_type == "input":
+            return cb("input", data["prompt"])
+        else:
+            raise ValueError(f"Unknown event type {event_type}")
+
+    papyros = Papyros(callback=runner_callback)
+    papyros.override_matplotlib()
+
 
 async def process_code(code, filename="my_code.py"):
     with open(filename, "w") as f:
         f.write(code)
-    try:
-        await eval_code_async(code, papyros.globals(filename),
-                filename=filename, return_mode="none")
-    except Exception as e:
-        await ft
-        import friendly_traceback
-        friendly_traceback.source_cache.cache.add(filename, code)
-        papyros.message(dict(type="error", data=format_exception(filename, e)))
+    papyros.filename = filename
+    await papyros.run_async(code)


### PR DESCRIPTION
Part 1 of #63. Uses https://github.com/alexmojaki/python_runner which takes care of things like input and output and is used by futurecoder.

`python_runner` buffers output internally which helps a lot with #17.

Also in this PR:

- Replace `\\n` (introduced in my previous PR #92) with `\n`
- Only install `matplotlib` when it's imported by the user's code, greatly speeding up startup.