### PR TITLE
Show modules being loaded

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -25,3 +25,5 @@ export const DEFAULT_LOCALE = "nl";
 
 export const INPUT_RELATIVE_URL = "__papyros_input";
 
+export const INSTALLATION_FINISHED = "__installation_finished";
+

--- a/src/PapyrosEvent.ts
+++ b/src/PapyrosEvent.ts
@@ -1,6 +1,6 @@
 export interface PapyrosEvent {
-    type: "input" | "output" | "script" | "success" | "error";
+    type: "input" | "output" | "script" | "success" | "error" | "loading";
     data: string;
-    runId: number;
+    runId?: number;
     content?: string;
 }

--- a/src/StatusPanel.ts
+++ b/src/StatusPanel.ts
@@ -23,7 +23,7 @@ export class StatusPanel {
 
     render(options: RenderOptions): HTMLElement {
         return renderWithOptions(options,
-            `<div class="grid grid-cols-2 items-center">
+            `<div class="grid grid-cols-3 items-center">
             <div class="col-span-1 flex flex-row">
                 <button id="${RUN_BTN_ID}" type="button" 
                 class="text-white bg-blue-500 border-2 m-1 px-4 inset-y-2 rounded-lg
@@ -36,7 +36,7 @@ export class StatusPanel {
                 ${t("Papyros.stop")}
                 </button>
             </div>
-            <div class="col-span-1 flex flex-row-reverse">
+            <div class="col-span-2 flex flex-row-reverse">
                 <div id="${APPLICATION_STATE_TEXT_ID}"></div>
                 ${svgCircle(STATE_SPINNER_ID, "red")}
             </div>

--- a/src/Translations.js
+++ b/src/Translations.js
@@ -39,7 +39,8 @@ const ENGLISH_TRANSLATION = {
         "switch_to_batch": "Switch to batch input"
     },
     "enter": "Enter",
-    "examples": "Examples"
+    "examples": "Examples",
+    "installing": "Installing %{package}"
 };
 
 const DUTCH_TRANSLATION = {
@@ -79,7 +80,8 @@ const DUTCH_TRANSLATION = {
         "switch_to_batch": "Geef invoer vooraf in"
     },
     "enter": "Enter",
-    "examples": "Voorbeelden"
+    "examples": "Voorbeelden",
+    "installing": "Bezig met installeren van %{package}"
 };
 
 const TRANSLATIONS = {

--- a/src/util/HTMLShapes.ts
+++ b/src/util/HTMLShapes.ts
@@ -2,7 +2,7 @@
 /* eslint-disable max-len */
 export const svgCircle = (id: string, color: string): string => {
     return (
-`<svg id="${id}" class="animate-spin mr-3 h-5 w-5 text-white"
+`<svg id="${id}" class="animate-spin mr-3 h-5 w-5"
 xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="${color}" stroke-width="4">
     </circle>

--- a/src/workers/python/Pyodide.ts
+++ b/src/workers/python/Pyodide.ts
@@ -1,8 +1,8 @@
 export interface Pyodide {
     runPython: (code: string, globals?: any) => any;
     runPythonAsync: (code: string) => Promise<void>;
-    loadPackagesFromImports: (code: string) => Promise<void>;
-    loadPackage: (names: string | string[]) => Promise<void>;
+    loadPackagesFromImports: (code: string, mCb?: (m: string) => void) => Promise<void>;
+    loadPackage: (names: string | string[], mCb?: (m: string) => void) => Promise<void>;
     globals: Map<string, any>;
 }
 


### PR DESCRIPTION
Depends on #101 

Adds an idicator to which package is currently being installed.
![papyros-installing](https://user-images.githubusercontent.com/53743234/155222293-25c91c1f-a897-472a-ba2b-4a11310da286.png)

Downside: some modules require many packages (of which some are quite small) which might cause flashing in text. Especially notable in the matplotlib example @pdawyndt 

Fixes #98 
