### PR TITLE
Main and dev GitHub-pages

### DIFF
--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -15,7 +15,7 @@ jobs:
       name: production
       url: https://docs.dodona.be/papyros/
     steps:
-      - name: Checkout
+      - name: Checkout branch
         uses: actions/checkout@v2.3.1
       - name: Install and Build 🔧
         # Last step ensures public files are available when hosting the web application
@@ -23,6 +23,16 @@ jobs:
           yarn install
           yarn build:app
           cp -r public/* dist
+          mv dist devdist
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: main
+        run: |
+          yarn install
+          yarn build:app
+          cp -r public/* dist
+          mv devdist dist/dev
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.5
         with:

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -16,8 +16,8 @@ jobs:
       url: https://docs.dodona.be/papyros/
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2.3.1
-      - name: Install and Build 🔧
+        uses: actions/checkout@v3
+      - name: Install and build branch
         # Last step ensures public files are available when hosting the web application
         run: |
           yarn install
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: main
+      - name: Install and build main
         run: |
           yarn install
           yarn build:app


### PR DESCRIPTION
This PR provides support for deploying two versions of Papyros: the main branch that aligns with the current release, and a dev version to try things out in the browser.
Two URLs are now supported:
main version on https://papyros.dodona.be
dev version (current branch): https://papyros.dodona.be/dev/  (the trailing slash is imported to be routed to index.html, unclear why no automatic redirect is done)
Finishes a task of #133 