### PR TITLE
Halt event publishing after interrupt/end

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dodona/papyros",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "private": false,
   "homepage": ".",
   "devDependencies": {


### PR DESCRIPTION
Halting event publishing should make messages come through more reliabily. It still sometimes takes a while for the interrupt to get through, but I'm not sure what causes that. 
Closes #158 