### PR TITLE
feat: Add keybind to run code

### DIFF
--- a/src/CodeEditor.ts
+++ b/src/CodeEditor.ts
@@ -6,7 +6,7 @@ import {
     CompletionSource, autocompletion,
     closeBrackets, closeBracketsKeymap, completionKeymap
 } from "@codemirror/autocomplete";
-import { defaultKeymap, historyKeymap, indentWithTab, history } from "@codemirror/commands";
+import { defaultKeymap, historyKeymap, indentWithTab, history, insertBlankLine } from "@codemirror/commands";
 import { javascript } from "@codemirror/lang-javascript";
 import { python } from "@codemirror/lang-python";
 import {
@@ -54,10 +54,11 @@ export class CodeEditor extends Renderable {
 
     /**
      * Construct a new CodeEditor
+     * @param {Function} onRunRequest Callback for when the user wants to run the code
      * @param {string} initialCode The initial code to display
      * @param {number} indentLength The length in spaces for the indent unit
      */
-    constructor(initialCode = "", indentLength = 4) {
+    constructor(onRunRequest: () => void, initialCode = "", indentLength = 4) {
         super();
         this.compartments = new Map(OPTIONS.map(opt => [opt, new Compartment()]));
         const configurableExtensions = [...this.compartments.values()]
@@ -69,6 +70,18 @@ export class CodeEditor extends Renderable {
                     extensions:
                         [
                             ...configurableExtensions,
+                            keymap.of([
+                                {
+                                    key: "Mod-Enter", run: () => {
+                                        onRunRequest();
+                                        return true;
+                                    }
+                                },
+                                // The original Ctrl-Enter keybind gets assigned to Shift-Enter
+                                {
+                                    key: "Shift-Enter", run: insertBlankLine
+                                }
+                            ]),
                             ...CodeEditor.getExtensions()
                         ]
                 })

--- a/src/CodeRunner.ts
+++ b/src/CodeRunner.ts
@@ -88,7 +88,11 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
     constructor(programmingLanguage: ProgrammingLanguage) {
         super();
         this.programmingLanguage = programmingLanguage;
-        this.editor = new CodeEditor(() => this.runCode(this.editor.getCode()));
+        this.editor = new CodeEditor(() => {
+            if (this.state === RunState.Ready) {
+                this.runCode(this.editor.getCode());
+            }
+        });
         this.inputManager = new InputManager(async (input: string) => {
             const backend = await this.backend;
             backend.writeMessage(input);

--- a/src/CodeRunner.ts
+++ b/src/CodeRunner.ts
@@ -88,7 +88,7 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
     constructor(programmingLanguage: ProgrammingLanguage) {
         super();
         this.programmingLanguage = programmingLanguage;
-        this.editor = new CodeEditor();
+        this.editor = new CodeEditor(() => this.runCode(this.editor.getCode()));
         this.inputManager = new InputManager(async (input: string) => {
             const backend = await this.backend;
             backend.writeMessage(input);

--- a/test/__tests__/CodeEditor.test.ts
+++ b/test/__tests__/CodeEditor.test.ts
@@ -6,7 +6,9 @@ import { EDITOR_WRAPPER_ID } from "../../src/Constants";
 
 describe("CodeEditor", () => {
     document.body.innerHTML = `<div id=${EDITOR_WRAPPER_ID}></div>`;
-    const editor = new CodeEditor();
+    const editor = new CodeEditor(() => {
+        /* No need to run code*/
+    });
     editor.render({
         parentElementId: EDITOR_WRAPPER_ID
     });


### PR DESCRIPTION
This PR changes some keybinds.
Ctrl-Enter can now be used to run the code without needing to click the button
The original keybinding (insertBlankLine) is now assigned to Shift-Enter, similar to how other editors handle this (like the GitHub comment window here)

Closes #36 