### PR TITLE
Correct batch input handling

### DIFF
--- a/src/CodeRunner.ts
+++ b/src/CodeRunner.ts
@@ -404,6 +404,11 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
             if (this.state === RunState.Stopping) {
                 // Was interrupted, End message already published
                 interrupted = true;
+            } else {
+                BackendManager.publish({
+                    type: BackendEventType.End,
+                    data: "RunError", contentType: "text/plain"
+                });
             }
             this.setState(RunState.Ready, t(
                 interrupted ? "Papyros.interrupted" : "Papyros.finished",

--- a/src/CodeRunner.ts
+++ b/src/CodeRunner.ts
@@ -399,16 +399,15 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
                     data: JSON.stringify(error),
                     contentType: "text/json"
                 });
+                BackendManager.publish({
+                    type: BackendEventType.End,
+                    data: "RunError", contentType: "text/plain"
+                });
             }
         } finally {
             if (this.state === RunState.Stopping) {
                 // Was interrupted, End message already published
                 interrupted = true;
-            } else {
-                BackendManager.publish({
-                    type: BackendEventType.End,
-                    data: "RunError", contentType: "text/plain"
-                });
             }
             this.setState(RunState.Ready, t(
                 interrupted ? "Papyros.interrupted" : "Papyros.finished",

--- a/src/editor/BatchInputEditor.ts
+++ b/src/editor/BatchInputEditor.ts
@@ -92,24 +92,7 @@ export class BatchInputEditor extends CodeMirrorEditor {
      * Data in the last line that is not terminated by a newline is omitted
      */
     public getLines(): Array<string> {
-        const lines = [];
-        // Always need to call next atleast once
-        // Use iter to have line-separating information
-        let lineIterator = this.editorView.state.doc.iter().next();
-        while (!lineIterator.done) {
-            lines.push(lineIterator.value);
-            lineIterator = lineIterator.next();
-        }
-        // Filter lines based on presence of line separators
-        let last = lines.length - 1;
-        while (last >= 0) {
-            const removed = lines.splice(last, 1)[0];
-            if (removed === "\n") { // Line followed by separator
-                last -= 2;
-            } else { // Last line without separator, omit it
-                last -= 1;
-            }
-        }
-        return lines;
+        const lines = this.editorView.state.doc.toString().split("\n");
+        return lines.slice(0, lines.length - 1);
     }
 }


### PR DESCRIPTION
By simplifying the code that handles the supplied lines in batch mode, empty lines should not be misinterpreted. Issue was caused by older code that was written when lines were handled as DOM elements instead.
Closes #254 