### PR TITLE
Add clearer debug state for editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dodona/papyros",
-  "version": "2.3.0-beta.2",
+  "version": "2.3.0-beta.3",
   "private": false,
   "homepage": ".",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dodona/papyros",
-  "version": "2.3.0-beta.1",
+  "version": "2.3.0-beta.2",
   "private": false,
   "homepage": ".",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dodona/papyros",
-  "version": "2.2.0",
+  "version": "2.3.0-beta.0",
   "private": false,
   "homepage": ".",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dodona/papyros",
-  "version": "2.3.0-beta.3",
+  "version": "2.3.0-beta.4",
   "private": false,
   "homepage": ".",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dodona/papyros",
-  "version": "2.3.0-beta.0",
+  "version": "2.3.0-beta.1",
   "private": false,
   "homepage": ".",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dodona/papyros",
-  "version": "2.3.0-beta.4",
+  "version": "2.3.0-beta.5",
   "private": false,
   "homepage": ".",
   "devDependencies": {

--- a/scripts/ValidateTranslations.js
+++ b/scripts/ValidateTranslations.js
@@ -8,7 +8,16 @@ const usedKeys = extract.extractFromFiles([
     "src/**/*.ts"
 ], {
     marker: "t", // renamed I18n.t to t for convenience
-    parser: "typescript",
+    babelOptions: {
+        ast: true,
+        parserOpts: {
+            sourceType: 'module',
+            plugins: [
+                'decorators',
+                'typescript'
+            ],
+        }
+    }
 });
 
 const checks = [

--- a/src/CodeRunner.ts
+++ b/src/CodeRunner.ts
@@ -213,7 +213,6 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
 
     private set debugMode(debugMode: boolean) {
         this._debugMode = debugMode;
-        this.setState(this.state);
         this.renderButtons();
 
         if (this.inputManager.getInputMode() === InputMode.Batch) {
@@ -350,12 +349,6 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
     public setState(state: RunState, message?: string): void {
         const stateElement = getElement(APPLICATION_STATE_TEXT_ID);
         stateElement.innerText = message || t(`Papyros.states.${state}`);
-        if ( this.debugMode ) {
-            if ( stateElement.innerText.length > 0 ) {
-                stateElement.innerText += "  -";
-            }
-            stateElement.innerText += "  " + t("Papyros.debug.active");
-        }
         stateElement.parentElement?.classList.toggle("show", stateElement.innerText.length > 0);
         if (state !== this.state) {
             this.previousState = this.state;

--- a/src/CodeRunner.ts
+++ b/src/CodeRunner.ts
@@ -1,9 +1,9 @@
-import {proxy} from "comlink";
-import {SyncClient} from "comsync";
-import {Backend, RunMode} from "./Backend";
-import {BackendEvent, BackendEventType} from "./BackendEvent";
-import {BackendManager} from "./BackendManager";
-import {CodeEditor} from "./editor/CodeEditor";
+import { proxy } from "comlink";
+import { SyncClient } from "comsync";
+import { Backend, RunMode } from "./Backend";
+import { BackendEvent, BackendEventType } from "./BackendEvent";
+import { BackendManager } from "./BackendManager";
+import { CodeEditor } from "./editor/CodeEditor";
 import {
     addPapyrosPrefix,
     APPLICATION_STATE_TEXT_ID,
@@ -13,10 +13,10 @@ import {
     STATE_SPINNER_ID,
     STOP_BTN_ID
 } from "./Constants";
-import {InputManager, InputManagerRenderOptions, InputMode} from "./InputManager";
-import {ProgrammingLanguage} from "./ProgrammingLanguage";
-import {renderSpinningCircle} from "./util/HTMLShapes";
-import {addListener, downloadResults, getElement, parseData, t} from "./util/Util";
+import { InputManager, InputManagerRenderOptions, InputMode } from "./InputManager";
+import { ProgrammingLanguage } from "./ProgrammingLanguage";
+import { renderSpinningCircle } from "./util/HTMLShapes";
+import { addListener, downloadResults, getElement, parseData, t } from "./util/Util";
 import {
     appendClasses,
     ButtonOptions,
@@ -25,9 +25,9 @@ import {
     RenderOptions,
     renderWithOptions
 } from "./util/Rendering";
-import {OutputManager} from "./OutputManager";
-import {Debugger} from "./Debugger";
-import {BatchInputHandler} from "./input/BatchInputHandler";
+import { OutputManager } from "./OutputManager";
+import { Debugger } from "./Debugger";
+import { BatchInputHandler } from "./input/BatchInputHandler";
 
 const MODE_ICONS: Record<RunMode, string> = {
     "debug": "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"18px\" viewBox=\"0 0 24 24\" width=\"18px\" fill=\"currentColor\"><path d=\"M19 7H16.19C15.74 6.2 15.12 5.5 14.37 5L16 3.41L14.59 2L12.42 4.17C11.96 4.06 11.5 4 11 4S10.05 4.06 9.59 4.17L7.41 2L6 3.41L7.62 5C6.87 5.5 6.26 6.21 5.81 7H3V9H5.09C5.03 9.33 5 9.66 5 10V11H3V13H5V14C5 14.34 5.03 14.67 5.09 15H3V17H5.81C7.26 19.5 10.28 20.61 13 19.65V19C13 18.43 13.09 17.86 13.25 17.31C12.59 17.76 11.8 18 11 18C8.79 18 7 16.21 7 14V10C7 7.79 8.79 6 11 6S15 7.79 15 10V14C15 14.19 15 14.39 14.95 14.58C15.54 14.04 16.24 13.62 17 13.35V13H19V11H17V10C17 9.66 16.97 9.33 16.91 9H19V7M13 9V11H9V9H13M13 13V15H9V13H13M17 16V22L22 19L17 16Z\"></path></svg>",

--- a/src/CodeRunner.ts
+++ b/src/CodeRunner.ts
@@ -226,6 +226,7 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
         if (!this._debugMode) {
             this.traceViewer.reset();
             this.outputManager.reset();
+            this.inputManager.inputHandler.reset();
         }
     }
 

--- a/src/CodeRunner.ts
+++ b/src/CodeRunner.ts
@@ -410,7 +410,7 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
      * @return {DynamicButton} A list of buttons to interact with the code according to the current state
      */
     private getCodeActionButtons(): DynamicButton[] {
-        if ([RunState.Ready, RunState.Loading].includes(this.state)) {
+        if (this.state === RunState.Ready) {
             if (this.debugMode) {
                 return [{
                     id: "stop-debug-btn",

--- a/src/CodeRunner.ts
+++ b/src/CodeRunner.ts
@@ -111,6 +111,23 @@ class ButtonArray extends Array<DynamicButton> {
     }
 }
 
+/*
+ * class function decorator that adds a delay,
+ * so that the function is only called after the delay has passed
+ *
+ * If it is called again before the delay has passed, the previous call is cancelled
+ */
+function delay(delay: number) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    return function (original: any, context: ClassMethodDecoratorContext) {
+        let timeout: NodeJS.Timeout | undefined;
+        return function (this: any, ...args: any[]) {
+            clearTimeout(timeout);
+            timeout = setTimeout(() => original.apply(this, args), delay);
+        };
+    };
+}
+
 /**
  * Helper component to manage and visualize the current RunState
  */
@@ -444,6 +461,7 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
      * @param {DynamicButton[]} buttons The buttons to render
      * @param {string} id The id of the element to render the buttons in
      */
+    @delay(100) // Delay to prevent flickering
     private renderButtons(buttons: DynamicButton[] | undefined = undefined, id = RUN_BUTTONS_WRAPPER_ID): void {
         const btns = buttons || this.getCodeActionButtons();
         getElement(id).innerHTML =

--- a/src/CodeRunner.ts
+++ b/src/CodeRunner.ts
@@ -214,6 +214,9 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
         this._debugMode = debugMode;
         this.setState(this.state);
         this.renderButtons();
+        if (!this._debugMode) {
+            this.traceViewer.reset();
+        }
     }
 
     private get debugMode(): boolean {

--- a/src/CodeRunner.ts
+++ b/src/CodeRunner.ts
@@ -222,6 +222,7 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
             handler.debugMode = debugMode;
         }
         this.outputManager.debugMode = debugMode;
+        this.editor.debugMode = debugMode;
 
         if (!this._debugMode) {
             this.traceViewer.reset();

--- a/src/CodeRunner.ts
+++ b/src/CodeRunner.ts
@@ -158,6 +158,8 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
      * Time at which the setState call occurred
      */
     private runStartTime: number;
+    // True while running or viewing with debugger
+    private debugMode = false;
 
     /**
      * Construct a new RunStateManager with the given listeners
@@ -321,6 +323,12 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
     public setState(state: RunState, message?: string): void {
         const stateElement = getElement(APPLICATION_STATE_TEXT_ID);
         stateElement.innerText = message || t(`Papyros.states.${state}`);
+        if ( this.debugMode ) {
+            if ( stateElement.innerText.length > 0 ) {
+                stateElement.innerText += "  -";
+            }
+            stateElement.innerText += "  " + t("Papyros.debug_mode_active");
+        }
         stateElement.parentElement?.classList.toggle("show", stateElement.innerText.length > 0);
         if (state !== this.state) {
             this.previousState = this.state;
@@ -429,6 +437,8 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
      * @return {Promise<void>} Promise of running the code
      */
     public async runCode(mode?: RunMode): Promise<void> {
+        this.debugMode = mode === RunMode.Debug;
+
         const code = this.editor.getCode();
         // Setup pre-run
         this.setState(RunState.Loading);

--- a/src/CodeRunner.ts
+++ b/src/CodeRunner.ts
@@ -227,6 +227,7 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
             this.outputManager.reset();
             this.inputManager.inputHandler.reset();
         }
+        this.dispatchEvent(new CustomEvent("debug-mode", { detail: debugMode }));
     }
 
     private get debugMode(): boolean {

--- a/src/CodeRunner.ts
+++ b/src/CodeRunner.ts
@@ -215,14 +215,17 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
         this._debugMode = debugMode;
         this.setState(this.state);
         this.renderButtons();
-        if (!this._debugMode) {
-            this.traceViewer.reset();
-        }
 
         if (this.inputManager.getInputMode() === InputMode.Batch) {
             console.log("Setting debug mode");
             const handler = this.inputManager.inputHandler as BatchInputHandler;
             handler.debugMode = debugMode;
+        }
+        this.outputManager.debugMode = debugMode;
+
+        if (!this._debugMode) {
+            this.traceViewer.reset();
+            this.outputManager.reset();
         }
     }
 

--- a/src/CodeRunner.ts
+++ b/src/CodeRunner.ts
@@ -1,9 +1,9 @@
-import { proxy } from "comlink";
-import { SyncClient } from "comsync";
-import { Backend, RunMode } from "./Backend";
-import { BackendEvent, BackendEventType } from "./BackendEvent";
-import { BackendManager } from "./BackendManager";
-import { CodeEditor } from "./editor/CodeEditor";
+import {proxy} from "comlink";
+import {SyncClient} from "comsync";
+import {Backend, RunMode} from "./Backend";
+import {BackendEvent, BackendEventType} from "./BackendEvent";
+import {BackendManager} from "./BackendManager";
+import {CodeEditor} from "./editor/CodeEditor";
 import {
     addPapyrosPrefix,
     APPLICATION_STATE_TEXT_ID,
@@ -13,10 +13,10 @@ import {
     STATE_SPINNER_ID,
     STOP_BTN_ID
 } from "./Constants";
-import { InputManager, InputManagerRenderOptions, InputMode } from "./InputManager";
-import { ProgrammingLanguage } from "./ProgrammingLanguage";
-import { renderSpinningCircle } from "./util/HTMLShapes";
-import { addListener, downloadResults, getElement, parseData, t } from "./util/Util";
+import {InputManager, InputManagerRenderOptions, InputMode} from "./InputManager";
+import {ProgrammingLanguage} from "./ProgrammingLanguage";
+import {renderSpinningCircle} from "./util/HTMLShapes";
+import {addListener, downloadResults, getElement, parseData, t} from "./util/Util";
 import {
     appendClasses,
     ButtonOptions,
@@ -25,8 +25,9 @@ import {
     RenderOptions,
     renderWithOptions
 } from "./util/Rendering";
-import { OutputManager } from "./OutputManager";
-import { Debugger } from "./Debugger";
+import {OutputManager} from "./OutputManager";
+import {Debugger} from "./Debugger";
+import {BatchInputHandler} from "./input/BatchInputHandler";
 
 const MODE_ICONS: Record<RunMode, string> = {
     "debug": "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"18px\" viewBox=\"0 0 24 24\" width=\"18px\" fill=\"currentColor\"><path d=\"M19 7H16.19C15.74 6.2 15.12 5.5 14.37 5L16 3.41L14.59 2L12.42 4.17C11.96 4.06 11.5 4 11 4S10.05 4.06 9.59 4.17L7.41 2L6 3.41L7.62 5C6.87 5.5 6.26 6.21 5.81 7H3V9H5.09C5.03 9.33 5 9.66 5 10V11H3V13H5V14C5 14.34 5.03 14.67 5.09 15H3V17H5.81C7.26 19.5 10.28 20.61 13 19.65V19C13 18.43 13.09 17.86 13.25 17.31C12.59 17.76 11.8 18 11 18C8.79 18 7 16.21 7 14V10C7 7.79 8.79 6 11 6S15 7.79 15 10V14C15 14.19 15 14.39 14.95 14.58C15.54 14.04 16.24 13.62 17 13.35V13H19V11H17V10C17 9.66 16.97 9.33 16.91 9H19V7M13 9V11H9V9H13M13 13V15H9V13H13M17 16V22L22 19L17 16Z\"></path></svg>",
@@ -216,6 +217,12 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
         this.renderButtons();
         if (!this._debugMode) {
             this.traceViewer.reset();
+        }
+
+        if (this.inputManager.getInputMode() === InputMode.Batch) {
+            console.log("Setting debug mode");
+            const handler = this.inputManager.inputHandler as BatchInputHandler;
+            handler.debugMode = debugMode;
         }
     }
 

--- a/src/CodeRunner.ts
+++ b/src/CodeRunner.ts
@@ -382,37 +382,33 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
      * @return {DynamicButton} A list of buttons to interact with the code according to the current state
      */
     private getCodeActionButtons(): DynamicButton[] {
-        const result: DynamicButton[] = [];
         if ([RunState.Ready, RunState.Loading].includes(this.state)) {
-            result.push(...this.runButtons);
-        } else {
-            const buttonOptions = {
-                id: STOP_BTN_ID,
-                buttonText: t("Papyros.stop"),
-                classNames: "btn-danger",
-                icon: "<i class=\"mdi mdi-stop\"></i>"
-            };
-
-            result.push({
-                id: buttonOptions.id,
-                buttonHTML: renderButton(buttonOptions),
-                onClick: () => this.stop()
-            });
-        }
-        if (this.debugMode) {
-            result.push({
-                id: "stop-debug-btn",
-                buttonHTML: renderButton({
+            if (this.debugMode) {
+                return [{
                     id: "stop-debug-btn",
-                    buttonText: t("Papyros.debug.stop"),
+                    buttonHTML: renderButton({
+                        id: "stop-debug-btn",
+                        buttonText: t("Papyros.debug.stop"),
+                        classNames: "btn-secondary",
+                        icon: DEBUG_STOP_ICON
+                    }),
+                    onClick: () => this.debugMode = false
+                }];
+            } else {
+                return this.runButtons;
+            }
+        } else {
+            return [{
+                id: STOP_BTN_ID,
+                buttonHTML: renderButton({
+                    id: STOP_BTN_ID,
+                    buttonText: t("Papyros.stop"),
                     classNames: "btn-danger",
-                    icon: DEBUG_STOP_ICON
+                    icon: "<i class=\"mdi mdi-stop\"></i>"
                 }),
-                onClick: () => this.debugMode = false
-            });
+                onClick: () => this.stop()
+            }];
         }
-
-        return result;
     }
 
     /**

--- a/src/CodeRunner.ts
+++ b/src/CodeRunner.ts
@@ -34,6 +34,8 @@ const MODE_ICONS: Record<RunMode, string> = {
     "run": "<i class=\"mdi mdi-play\"></i>"
 };
 
+const DEBUG_STOP_ICON = "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"18px\" viewBox=\"0 0 24 24\" width=\"18px\" fill=\"currentColor\"><path d=\"M19 7H16.19C15.74 6.2 15.12 5.5 14.37 5L16 3.41L14.59 2L12.42 4.17C11.96 4.06 11.5 4 11 4S10.05 4.06 9.59 4.17L7.41 2L6 3.41L7.62 5C6.87 5.5 6.26 6.21 5.81 7H3V9H5.09C5.03 9.33 5 9.66 5 10V11H3V13H5V14C5 14.34 5.03 14.67 5.09 15H3V17H5.81C7.26 19.5 10.28 20.61 13 19.65V19C13 18.43 13.09 17.86 13.25 17.31C12.59 17.76 11.8 18 11 18C8.79 18 7 16.21 7 14V10C7 7.79 8.79 6 11 6S15 7.79 15 10V14C15 14.19 15 14.39 14.95 14.58C15.54 14.04 16.24 13.62 17 13.35V13H19V11H17V10C17 9.66 16.97 9.33 16.91 9H19V7M13 9V11H9V9H13M13 13V15H9V13H13M16 16H22V22H16V16Z\" /></svg>";
+
 interface DynamicButton {
     id: string;
     buttonHTML: string;
@@ -159,7 +161,7 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
      */
     private runStartTime: number;
     // True while running or viewing with debugger
-    private debugMode = false;
+    private _debugMode = false;
 
     /**
      * Construct a new RunStateManager with the given listeners
@@ -206,6 +208,16 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
         this.runStartTime = new Date().getTime();
         this.state = RunState.Ready;
         this.traceViewer = new Debugger();
+    }
+
+    private set debugMode(debugMode: boolean) {
+        this._debugMode = debugMode;
+        this.setState(this.state);
+        this.renderButtons();
+    }
+
+    private get debugMode(): boolean {
+        return this._debugMode;
     }
 
     private updateRunButtons(modes: Array<RunMode>): void {
@@ -327,7 +339,7 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
             if ( stateElement.innerText.length > 0 ) {
                 stateElement.innerText += "  -";
             }
-            stateElement.innerText += "  " + t("Papyros.debug_mode_active");
+            stateElement.innerText += "  " + t("Papyros.debug.active");
         }
         stateElement.parentElement?.classList.toggle("show", stateElement.innerText.length > 0);
         if (state !== this.state) {
@@ -370,23 +382,37 @@ export class CodeRunner extends Renderable<CodeRunnerRenderOptions> {
      * @return {DynamicButton} A list of buttons to interact with the code according to the current state
      */
     private getCodeActionButtons(): DynamicButton[] {
-        let buttonOptions: ButtonOptions;
+        const result: DynamicButton[] = [];
         if ([RunState.Ready, RunState.Loading].includes(this.state)) {
-            return this.runButtons;
+            result.push(...this.runButtons);
         } else {
-            buttonOptions = {
+            const buttonOptions = {
                 id: STOP_BTN_ID,
                 buttonText: t("Papyros.stop"),
                 classNames: "btn-danger",
                 icon: "<i class=\"mdi mdi-stop\"></i>"
             };
 
-            return [{
+            result.push({
                 id: buttonOptions.id,
                 buttonHTML: renderButton(buttonOptions),
                 onClick: () => this.stop()
-            }];
+            });
         }
+        if (this.debugMode) {
+            result.push({
+                id: "stop-debug-btn",
+                buttonHTML: renderButton({
+                    id: "stop-debug-btn",
+                    buttonText: t("Papyros.debug.stop"),
+                    classNames: "btn-danger",
+                    icon: DEBUG_STOP_ICON
+                }),
+                onClick: () => this.debugMode = false
+            });
+        }
+
+        return result;
     }
 
     /**

--- a/src/Debugger.ts
+++ b/src/Debugger.ts
@@ -37,15 +37,6 @@ export class Debugger extends Renderable<RenderOptions> {
 
         BackendManager.subscribe(BackendEventType.Start, () => {
             this.reset();
-
-            BackendManager.publish({
-                type: BackendEventType.FrameChange,
-                data: {
-                    line: 0,
-                    outputs: 0,
-                    inputs: 0
-                }
-            });
         });
         BackendManager.subscribe(BackendEventType.Output, () => {
             this.currentOutputs++;

--- a/src/OutputManager.ts
+++ b/src/OutputManager.ts
@@ -61,6 +61,12 @@ export class OutputManager extends Renderable {
      */
     private downloadCallback: (() => void) | null;
 
+    private _debugMode = false;
+    public set debugMode(value: boolean) {
+        this.outputArea.classList.toggle("papyros-debug", value);
+        this._debugMode = value;
+    }
+
     constructor() {
         super();
         this.content = [];
@@ -75,11 +81,7 @@ export class OutputManager extends Renderable {
             const outputElements = this.outputArea.children;
             for (let i = 0; i < outputElements.length; i++) {
                 const outputElement = outputElements[i];
-                if (i < outputsToHighlight) {
-                    outputElement.setAttribute("style", "opacity: inherit;");
-                } else {
-                    outputElement.setAttribute("style", "opacity: 0.1;");
-                }
+                outputElement.classList.toggle("papyros-highlight-debugged", i < outputsToHighlight);
             }
         });
     }
@@ -204,7 +206,7 @@ export class OutputManager extends Renderable {
     <div id=${OUTPUT_AREA_ID} class="_tw-border-2 _tw-w-full _tw-min-h-1/4
      _tw-max-h-3/5 _tw-overflow-auto papyros-font-family
     _tw-py-1 _tw-px-2 _tw-whitespace-pre _tw-rounded-lg dark:_tw-border-dark-mode-content
-    with-placeholder" data-placeholder="${t("Papyros.output_placeholder")}"></div>
+    with-placeholder ${this._debugMode ? "papyros-debug" : ""}" data-placeholder="${t("Papyros.output_placeholder")}"></div>
     `);
         // Restore previously rendered items
         this.content.forEach(html => this.renderNextElement(html, false));

--- a/src/Papyros.css
+++ b/src/Papyros.css
@@ -262,3 +262,11 @@ Removes the default spacing and border for appropriate elements.
 #__papyros-code-output-area.papyros-debug > .papyros-highlight-debugged {
   opacity: 1;
 }
+
+.papyros-code-editor .cm-content[contenteditable="false"] {
+  cursor: default;
+}
+
+.papyros-code-editor .cm-gutters {
+  cursor: default;
+}

--- a/src/Papyros.css
+++ b/src/Papyros.css
@@ -262,3 +262,11 @@ Removes the default spacing and border for appropriate elements.
   right: 0;
   height: 4px;
 }
+
+#__papyros-code-output-area.papyros-debug > * {
+  opacity: 0.1;
+}
+
+#__papyros-code-output-area.papyros-debug > .papyros-highlight-debugged {
+  opacity: 1;
+}

--- a/src/Papyros.css
+++ b/src/Papyros.css
@@ -191,14 +191,6 @@ Removes the default spacing and border for appropriate elements.
   vertical-align: middle;
 }
 
-.cm-gutter.cm-debugline-gutter {
-  display: none !important;
-}
-
-.cm-gutter.cm-debugline-gutter.show {
-  display: flex !important;
-}
-
 .papyros-test-code {
   background-color: rgba(143, 182, 130, 0.1);
 }

--- a/src/Papyros.ts
+++ b/src/Papyros.ts
@@ -322,9 +322,10 @@ export class Papyros extends Renderable<PapyrosRenderOptions> {
                 history.pushState(null, "", `?locale=${locale}&language=${this.codeRunner.getProgrammingLanguage()}`);
                 this.setLocale(locale);
             }, "change", "value");
-            addListener(EXAMPLE_SELECT_ID, name => {
+            addListener(EXAMPLE_SELECT_ID, async name => {
                 this.config.example = name;
                 const code = getCodeForExample(this.codeRunner.getProgrammingLanguage(), name);
+                await this.codeRunner.reset();
                 this.setCode(code);
             }, "change", "value");
             // If example is null, it removes the selection

--- a/src/Translations.js
+++ b/src/Translations.js
@@ -66,7 +66,10 @@ const ENGLISH_TRANSLATION = {
             "remove": "Remove"
         }
     },
-    "debug_mode_active": "Debug mode active",
+    "debug": {
+        "active": "Debug mode active",
+        "stop": "Stop debugging"
+    },
 };
 
 const DUTCH_TRANSLATION = {
@@ -133,7 +136,10 @@ const DUTCH_TRANSLATION = {
             "remove": "Verwijder"
         }
     },
-    "debug_mode_active": "Debugmodus actief",
+    "debug": {
+        "active": "Debugmodus actief",
+        "stop": "Stop met debuggen"
+    },
 };
 
 // Override some default English phrases to also use capitalized text

--- a/src/Translations.js
+++ b/src/Translations.js
@@ -65,7 +65,8 @@ const ENGLISH_TRANSLATION = {
             "edit": "Edit",
             "remove": "Remove"
         }
-    }
+    },
+    "debug_mode_active": "Debug mode active",
 };
 
 const DUTCH_TRANSLATION = {
@@ -131,7 +132,8 @@ const DUTCH_TRANSLATION = {
             "edit": "Bewerk",
             "remove": "Verwijder"
         }
-    }
+    },
+    "debug_mode_active": "Debugmodus actief",
 };
 
 // Override some default English phrases to also use capitalized text

--- a/src/Translations.js
+++ b/src/Translations.js
@@ -136,7 +136,7 @@ const DUTCH_TRANSLATION = {
         }
     },
     "debug": {
-        "stop": "Stop met debuggen"
+        "stop": "Stop debugger"
     },
 };
 

--- a/src/Translations.js
+++ b/src/Translations.js
@@ -67,7 +67,6 @@ const ENGLISH_TRANSLATION = {
         }
     },
     "debug": {
-        "active": "Debug mode active",
         "stop": "Stop debugging"
     },
 };
@@ -137,7 +136,6 @@ const DUTCH_TRANSLATION = {
         }
     },
     "debug": {
-        "active": "Debugmodus actief",
         "stop": "Stop met debuggen"
     },
 };

--- a/src/editor/CodeEditor.ts
+++ b/src/editor/CodeEditor.ts
@@ -47,6 +47,7 @@ export class CodeEditor extends CodeMirrorEditor {
     public static PANEL = "panel";
     public static AUTOCOMPLETION = "autocompletion";
     public static LINTING = "linting";
+    public static READONLY = "readonly";
 
     private debugLineGutter: DebugLineGutter;
     private testCodeExtension: TestCodeExtension;
@@ -60,7 +61,7 @@ export class CodeEditor extends CodeMirrorEditor {
     constructor(onRunRequest: () => void, initialCode: string = "", indentLength: number = 4) {
         super(new Set([
             CodeEditor.PROGRAMMING_LANGUAGE, CodeEditor.INDENTATION,
-            CodeEditor.PANEL, CodeEditor.AUTOCOMPLETION, CodeEditor.LINTING
+            CodeEditor.PANEL, CodeEditor.AUTOCOMPLETION, CodeEditor.LINTING, CodeEditor.READONLY
         ]), {
             classes: ["papyros-code-editor", "_tw-overflow-auto",
                 "_tw-border-solid", "_tw-border-gray-200", "_tw-border-2",
@@ -103,6 +104,7 @@ export class CodeEditor extends CodeMirrorEditor {
         if (value) {
             this.debugLineGutter.markLine(this.editorView, 1);
         }
+        this.reconfigure([CodeEditor.READONLY, EditorState.readOnly.of(value)]);
     }
 
     public set testCode(code: string) {

--- a/src/editor/CodeEditor.ts
+++ b/src/editor/CodeEditor.ts
@@ -98,6 +98,13 @@ export class CodeEditor extends CodeMirrorEditor {
         this.addExtension(this.testCodeExtension.toExtension());
     }
 
+    public set debugMode(value: boolean) {
+        this.debugLineGutter.toggle(value);
+        if (value) {
+            this.debugLineGutter.markLine(this.editorView, 1);
+        }
+    }
+
     public set testCode(code: string) {
         this.testCodeExtension.testCode = code;
     }

--- a/src/editor/CodeEditor.ts
+++ b/src/editor/CodeEditor.ts
@@ -32,11 +32,8 @@ import {
 import { Diagnostic, linter, lintGutter, lintKeymap } from "@codemirror/lint";
 import { CodeMirrorEditor } from "./CodeMirrorEditor";
 import { darkTheme } from "./DarkTheme";
-import { DebugLineGutter } from "./Gutters";
-import { BackendManager } from "../BackendManager";
-import { BackendEventType } from "../BackendEvent";
 import { TestCodeExtension } from "./TestCodeExtension";
-import {DebugExtension} from "./DebugExtension";
+import { DebugExtension } from "./DebugExtension";
 
 
 /**

--- a/src/editor/CodeEditor.ts
+++ b/src/editor/CodeEditor.ts
@@ -97,7 +97,7 @@ export class CodeEditor extends CodeMirrorEditor {
 
     public set debugMode(value: boolean) {
         this.debugExtension.toggle(value);
-        this.reconfigure([CodeEditor.READONLY, EditorState.readOnly.of(value)]);
+        this.reconfigure([CodeEditor.READONLY, EditorView.editable.of(!value)]);
         // Hide the active line if the editor is in debug mode
         if (!value) {
             this.reconfigure([CodeEditor.ACTIVE_LINE, [highlightActiveLineGutter(), highlightActiveLine()]]);

--- a/src/editor/CodeEditor.ts
+++ b/src/editor/CodeEditor.ts
@@ -36,6 +36,7 @@ import { DebugLineGutter } from "./Gutters";
 import { BackendManager } from "../BackendManager";
 import { BackendEventType } from "../BackendEvent";
 import { TestCodeExtension } from "./TestCodeExtension";
+import {DebugExtension} from "./DebugExtension";
 
 
 /**
@@ -49,7 +50,7 @@ export class CodeEditor extends CodeMirrorEditor {
     public static LINTING = "linting";
     public static READONLY = "readonly";
 
-    private debugLineGutter: DebugLineGutter;
+    private debugExtension: DebugExtension;
     private testCodeExtension: TestCodeExtension;
 
     /**
@@ -70,7 +71,7 @@ export class CodeEditor extends CodeMirrorEditor {
             maxHeight: "72vh",
             theme: {}
         });
-        this.debugLineGutter = new DebugLineGutter();
+        this.debugExtension = new DebugExtension(this.editorView);
         this.addExtension([
             keymap.of([
                 {
@@ -84,26 +85,18 @@ export class CodeEditor extends CodeMirrorEditor {
                     key: "Shift-Enter", run: insertBlankLine
                 }
             ]),
-            this.debugLineGutter.toExtension(),
+            this.debugExtension.toExtension(),
             ...CodeEditor.getExtensions()
         ]);
         this.setText(initialCode);
         this.setIndentLength(indentLength);
-
-        BackendManager.subscribe(BackendEventType.FrameChange, e => {
-            const line = e.data.line;
-            this.debugLineGutter.markLine(this.editorView, line);
-        });
 
         this.testCodeExtension = new TestCodeExtension(this.editorView);
         this.addExtension(this.testCodeExtension.toExtension());
     }
 
     public set debugMode(value: boolean) {
-        this.debugLineGutter.toggle(value);
-        if (value) {
-            this.debugLineGutter.markLine(this.editorView, 1);
-        }
+        this.debugExtension.toggle(value);
         this.reconfigure([CodeEditor.READONLY, EditorState.readOnly.of(value)]);
     }
 

--- a/src/editor/DebugExtension.ts
+++ b/src/editor/DebugExtension.ts
@@ -9,9 +9,9 @@ const activeLineDecoration = Decoration.line({ class: "cm-activeLine" });
 const activeLineGutterMarker = new class extends GutterMarker {
     elementClass = "cm-activeLineGutter";
 };
-const markLine = StateEffect.define<number>()
-const markedLine = StateField.define<number>({
-    create: () => 1,
+const markLine = StateEffect.define<number|undefined>();
+const markedLine = StateField.define<number|undefined>({
+    create: () => undefined,
     update(value, tr) {
         for (const effect of tr.effects) {
             if (effect.is(markLine)) {
@@ -22,7 +22,11 @@ const markedLine = StateField.define<number>({
     }
 });
 const markedLineGutterHighlighter = gutterLineClass.compute([markedLine], state => {
-    const linePos = state.doc.line(state.field(markedLine)).from;
+    if (state.field(markedLine) === undefined) {
+        return RangeSet.empty;
+    }
+
+    const linePos = state.doc.line(state.field(markedLine) as number).from;
     return RangeSet.of([activeLineGutterMarker.range(linePos)]);
 });
 
@@ -49,6 +53,8 @@ export class DebugExtension {
 
         if (show) {
             this.markLine(1);
+        } else {
+            this.view.dispatch({ effects: markLine.of(undefined) });
         }
     }
 

--- a/src/editor/DebugExtension.ts
+++ b/src/editor/DebugExtension.ts
@@ -32,8 +32,8 @@ const markedLineGutterHighlighter = gutterLineClass.compute([markedLine], state 
 
 export class DebugExtension {
     private readonly view: EditorView;
-    private readonly gutter: DebugLineGutter;
-    private readonly lineEffect: LineEffectExtension;
+    private gutter: DebugLineGutter;
+    private lineEffect: LineEffectExtension;
 
 
     constructor(view: EditorView) {
@@ -47,15 +47,8 @@ export class DebugExtension {
         });
     }
 
-    public toggle(show: boolean): void {
-        this.gutter.toggle(show);
-        this.lineEffect.clear();
-
-        if (show) {
-            this.markLine(1);
-        } else {
-            this.view.dispatch({ effects: markLine.of(undefined) });
-        }
+    public reset(): void {
+        this.markLine(1);
     }
 
     public markLine(lineNr: number): void {
@@ -68,6 +61,12 @@ export class DebugExtension {
     }
 
     public toExtension(): Extension {
-        return [this.lineEffect.toExtension(), this.gutter.toExtension(), markedLine, markedLineGutterHighlighter];
+        return [
+            this.lineEffect.toExtension(),
+            this.gutter.toExtension(),
+            markedLine,
+            markedLineGutterHighlighter,
+            EditorView.editable.of(false)
+        ];
     }
 }

--- a/src/editor/DebugExtension.ts
+++ b/src/editor/DebugExtension.ts
@@ -1,0 +1,47 @@
+import { Decoration, EditorView } from "@codemirror/view";
+import { LineEffectExtension } from "./LineEffectExtension";
+import { DebugLineGutter } from "./Gutters";
+import { Extension } from "@codemirror/state";
+import { BackendManager } from "../BackendManager";
+import { BackendEventType } from "../BackendEvent";
+
+const activeLineDecoration = Decoration.line({ class: "cm-activeLine" });
+
+export class DebugExtension {
+    private readonly view: EditorView;
+    private readonly gutter: DebugLineGutter;
+    private readonly lineEffect: LineEffectExtension;
+
+
+    constructor(view: EditorView) {
+        this.view = view;
+        this.gutter = new DebugLineGutter();
+        this.lineEffect = new LineEffectExtension(view);
+
+        BackendManager.subscribe(BackendEventType.FrameChange, e => {
+            const line = e.data.line;
+            this.markLine(line);
+        });
+    }
+
+    public toggle(show: boolean): void {
+        this.gutter.toggle(show);
+        this.lineEffect.clear();
+
+        if (show) {
+            this.markLine(1);
+        }
+    }
+
+    public markLine(lineNr: number): void {
+        this.gutter.markLine(this.view, lineNr);
+        this.lineEffect.set([activeLineDecoration.range(this.view.state.doc.line(lineNr).from)]);
+        this.view.dispatch({
+            effects: EditorView.scrollIntoView(this.view.state.doc.line(lineNr).from)
+        });
+    }
+
+    public toExtension(): Extension {
+        return [this.lineEffect.toExtension(), this.gutter.toExtension()];
+    }
+}

--- a/src/editor/Gutters.ts
+++ b/src/editor/Gutters.ts
@@ -236,6 +236,14 @@ export class UsedInputGutters extends Gutters<UsedInputGutterInfo> {
     }
 }
 
+class DebugMarker extends GutterMarker {
+    public override toDOM(): HTMLElement {
+        const icon = document.createElement("i");
+        icon.classList.add("mdi", "mdi-arrow-right-bold", "mdi-18");
+        return icon;
+    }
+}
+
 /**
  * shows the debugged line
  */
@@ -248,9 +256,9 @@ export class DebugLineGutter extends Gutters<GutterInfo> {
             extraExtensions: [
                 EditorView.baseTheme({
                     ".cm-debugline-gutter .cm-gutterElement": {
-                        lineHeight: "12px",
+                        lineHeight: "20px",
                         marginRight: "-5px",
-                        fontSize: "40px"
+                        fontSize: "18px"
                     }
                 })
             ]
@@ -258,7 +266,7 @@ export class DebugLineGutter extends Gutters<GutterInfo> {
     }
 
     protected override marker(): GutterMarker {
-        return new SimpleMarker(() => document.createTextNode("⇨"));
+        return new DebugMarker();
     }
 
     public toggle(show: boolean): void {

--- a/src/editor/Gutters.ts
+++ b/src/editor/Gutters.ts
@@ -276,6 +276,15 @@ export class DebugLineGutter extends Gutters<GutterInfo> {
 
         if (lineNr > 0) {
             this.setMarker(view, { lineNr, on: true });
+            // set the cursor to the line
+            // This marks the line as active and scrolls to it
+            view.dispatch({
+                selection: {
+                    anchor: view.state.doc.line(lineNr).from,
+                    head: view.state.doc.line(lineNr).from
+                },
+                scrollIntoView: true,
+            });
             this.show();
         } else {
             this.hide();

--- a/src/editor/Gutters.ts
+++ b/src/editor/Gutters.ts
@@ -268,15 +268,6 @@ export class DebugLineGutter extends Gutters<GutterInfo> {
     public markLine(view: EditorView, lineNr: number): void {
         this.setMarker(view, { lineNr: this.activeLine, on: false });
         this.setMarker(view, { lineNr, on: true });
-        // set the cursor to the line
-        // This marks the line as active and scrolls to it
-        view.dispatch({
-            selection: {
-                anchor: view.state.doc.line(lineNr).from,
-                head: view.state.doc.line(lineNr).from
-            },
-            scrollIntoView: true,
-        });
         this.activeLine = lineNr;
     }
 }

--- a/src/editor/Gutters.ts
+++ b/src/editor/Gutters.ts
@@ -269,10 +269,6 @@ export class DebugLineGutter extends Gutters<GutterInfo> {
         return new DebugMarker();
     }
 
-    public toggle(show: boolean): void {
-        document.querySelector(".cm-debugline-gutter")?.classList.toggle("show", show);
-    }
-
     public markLine(view: EditorView, lineNr: number): void {
         this.setMarker(view, { lineNr: this.activeLine, on: false });
         this.setMarker(view, { lineNr, on: true });

--- a/src/editor/Gutters.ts
+++ b/src/editor/Gutters.ts
@@ -240,7 +240,7 @@ export class UsedInputGutters extends Gutters<UsedInputGutterInfo> {
  * shows the debugged line
  */
 export class DebugLineGutter extends Gutters<GutterInfo> {
-    private activeLine: number = 0;
+    private activeLine: number = 1;
 
     constructor() {
         super({
@@ -261,34 +261,22 @@ export class DebugLineGutter extends Gutters<GutterInfo> {
         return new SimpleMarker(() => document.createTextNode("⇨"));
     }
 
-    private hide(): void {
-        document.querySelector(".cm-debugline-gutter")?.classList.remove("show");
-    }
-
-    private show(): void {
-        document.querySelector(".cm-debugline-gutter")?.classList.add("show");
+    public toggle(show: boolean): void {
+        document.querySelector(".cm-debugline-gutter")?.classList.toggle("show", show);
     }
 
     public markLine(view: EditorView, lineNr: number): void {
-        if (this.activeLine > 0) {
-            this.setMarker(view, { lineNr: this.activeLine, on: false });
-        }
-
-        if (lineNr > 0) {
-            this.setMarker(view, { lineNr, on: true });
-            // set the cursor to the line
-            // This marks the line as active and scrolls to it
-            view.dispatch({
-                selection: {
-                    anchor: view.state.doc.line(lineNr).from,
-                    head: view.state.doc.line(lineNr).from
-                },
-                scrollIntoView: true,
-            });
-            this.show();
-        } else {
-            this.hide();
-        }
+        this.setMarker(view, { lineNr: this.activeLine, on: false });
+        this.setMarker(view, { lineNr, on: true });
+        // set the cursor to the line
+        // This marks the line as active and scrolls to it
+        view.dispatch({
+            selection: {
+                anchor: view.state.doc.line(lineNr).from,
+                head: view.state.doc.line(lineNr).from
+            },
+            scrollIntoView: true,
+        });
         this.activeLine = lineNr;
     }
 }

--- a/src/editor/LineEffectExtension.ts
+++ b/src/editor/LineEffectExtension.ts
@@ -1,5 +1,5 @@
-import {Extension, Range, StateEffect, StateField} from "@codemirror/state";
-import {Decoration, EditorView} from "@codemirror/view";
+import { Extension, Range, StateEffect, StateField } from "@codemirror/state";
+import { Decoration, EditorView } from "@codemirror/view";
 
 
 export class LineEffectExtension {

--- a/src/editor/LineEffectExtension.ts
+++ b/src/editor/LineEffectExtension.ts
@@ -1,0 +1,57 @@
+import {Extension, Range, StateEffect, StateField} from "@codemirror/state";
+import {Decoration, EditorView} from "@codemirror/view";
+
+
+export class LineEffectExtension {
+    private readonly addEffect = StateEffect.define<Range<Decoration>[]>();
+    private readonly clearEffect = StateEffect.define();
+    private readonly setEffect = StateEffect.define<Range<Decoration>[]>();
+    private editorView: EditorView;
+
+    constructor(view: EditorView) {
+        this.editorView = view;
+    }
+
+    public add(range: Range<Decoration>[]): void {
+        this.editorView.dispatch({
+            effects: this.addEffect.of(range)
+        });
+    }
+
+    public clear(): void {
+        this.editorView.dispatch({
+            effects: this.clearEffect.of(null)
+        });
+    }
+
+    public set(range: Range<Decoration>[]): void {
+        this.editorView.dispatch({
+            effects: this.setEffect.of(range)
+        });
+    }
+
+    public toExtension(): Extension {
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        const self = this;
+        return StateField.define({
+            create() {
+                return Decoration.none;
+            },
+            update(value, transaction) {
+                let v = value.map(transaction.changes);
+
+                for (const effect of transaction.effects) {
+                    if (effect.is(self.clearEffect) || effect.is(self.setEffect)) {
+                        v = Decoration.none;
+                    }
+                    if (effect.is(self.addEffect) || effect.is(self.setEffect)) {
+                        v = v.update({ add: effect.value });
+                    }
+                }
+
+                return v;
+            },
+            provide: f => EditorView.decorations.from(f)
+        });
+    }
+}

--- a/src/input/BatchInputHandler.ts
+++ b/src/input/BatchInputHandler.ts
@@ -121,12 +121,17 @@ export class BatchInputHandler extends UserInputHandler {
         return nextLine;
     }
 
-    public override onRunStart(): void {
-        this.running = true;
+    public reset(): void {
+        super.reset();
         this.lineNr = 0;
         this.debugLine = 0;
         this.prompts = [];
-        this.highlight(true);
+        this.highlight(this.running);
+    }
+
+    public override onRunStart(): void {
+        this.running = true;
+        this.reset();
     }
 
     public override onRunEnd(): void {

--- a/src/input/BatchInputHandler.ts
+++ b/src/input/BatchInputHandler.ts
@@ -27,6 +27,8 @@ export class BatchInputHandler extends UserInputHandler {
      * Is restored upon switching back to InputMode.Batch
      */
     private previousInput: string;
+    public debugMode: boolean = false;
+    private debugLine: number = 0;
 
     /**
      * Construct a new BatchInputHandler
@@ -44,8 +46,8 @@ export class BatchInputHandler extends UserInputHandler {
             delay: 0
         });
         BackendManager.subscribe(BackendEventType.FrameChange, e => {
-            const inputsToHighlight = e.data.inputs;
-            this.highlight(this.running, (i: number) => i < inputsToHighlight);
+            this.debugLine = e.data.inputs;
+            this.highlight(this.running);
         });
     }
 
@@ -90,7 +92,13 @@ export class BatchInputHandler extends UserInputHandler {
         return this.lineNr < this.lines.length;
     }
 
-    private highlight(running: boolean, whichLines = (i: number) => i < this.lineNr): void {
+    private highlight(running: boolean): void {
+        const whichLines = (index: number): boolean => {
+            if (this.debugMode) {
+                return index < this.debugLine;
+            }
+            return index < this.lineNr;
+        };
         this.batchEditor.highlight({
             running,
             getInfo: (lineNr: number) => {
@@ -116,8 +124,9 @@ export class BatchInputHandler extends UserInputHandler {
     public override onRunStart(): void {
         this.running = true;
         this.lineNr = 0;
+        this.debugLine = 0;
         this.prompts = [];
-        this.highlight(true, () => false);
+        this.highlight(true);
     }
 
     public override onRunEnd(): void {

--- a/src/input/InteractiveInputHandler.ts
+++ b/src/input/InteractiveInputHandler.ts
@@ -97,7 +97,7 @@ export class InteractiveInputHandler extends UserInputHandler {
         });
     }
 
-    protected reset(): void {
+    public reset(): void {
         super.reset();
         this.inputArea.value = "";
     }

--- a/src/input/UserInputHandler.ts
+++ b/src/input/UserInputHandler.ts
@@ -89,7 +89,7 @@ export abstract class UserInputHandler extends Renderable<InputManagerRenderOpti
     /**
      * Helper method to reset internal state
      */
-    protected reset(): void {
+    public reset(): void {
         this.waiting = false;
     }
 }

--- a/src/util/Rendering.ts
+++ b/src/util/Rendering.ts
@@ -181,7 +181,7 @@ export function renderSelect<T extends string>(selectId: string,
  * Helper superclass to handle storing options used during rendering
  * to allow re-rendering without needing to explicitly store used options each time
  */
-export abstract class Renderable<Options = RenderOptions> {
+export abstract class Renderable<Options = RenderOptions> extends EventTarget {
     /**
      * The options to render with
      */


### PR DESCRIPTION
This pr improves the debug state of the editor.

When a debug run is started, the editor becomes readonly.
All visualization of generated output, input used and active line is now based on the shown frame instead of the current phase of execution.
While the debug mode is active, the buttons to start a new execution are replaced by an end debug mode button.
![Peek 2024-02-16 10-30](https://github.com/dodona-edu/papyros/assets/21177904/6dcf196d-6069-4d72-956c-eb290a2af51d)

closes #628 #623 #611 