### PR TITLE
Use custom module name

### DIFF
--- a/scripts/ValidateTranslations.js
+++ b/scripts/ValidateTranslations.js
@@ -8,7 +8,16 @@ const usedKeys = extract.extractFromFiles([
     "src/**/*.ts"
 ], {
     marker: "t", // renamed I18n.t to t for convenience
-    parser: "typescript",
+    babelOptions: {
+        ast: true,
+        parserOpts: {
+            sourceType: 'module',
+            plugins: [
+                'decorators',
+                'typescript'
+            ],
+        }
+    }
 });
 
 const checks = [


### PR DESCRIPTION
This improves handling of `if __name__="__main__"`. which will now be treated the same as in the dodona judge.

It is still posible to get similar behaviour with `if __name__="sandbox"`