### PR TITLE
Revert "Use custom module name"

### DIFF
--- a/src/workers/python/build_package.py
+++ b/src/workers/python/build_package.py
@@ -45,4 +45,4 @@ def check_tar(tarname, out_dir="."):
 
 
 if __name__ == "__main__":
-    create_package("python_package", "python-runner friendly_traceback pylint<3.0.0 tomli typing-extensions json-tracer>=0.6.0b1", extra_deps="papyros")
+    create_package("python_package", "python-runner friendly_traceback pylint<3.0.0 tomli typing-extensions json-tracer>=0.5.0", extra_deps="papyros")

--- a/src/workers/python/papyros/papyros.py
+++ b/src/workers/python/papyros/papyros.py
@@ -13,10 +13,8 @@ from pyodide_worker_runner import install_imports
 from pyodide import JsException, create_proxy
 from .util import to_py
 from pyodide.http import pyfetch
-from types import ModuleType
 
 SYS_RECURSION_LIMIT = 500
-MODULE_NAME = "sandbox"
 
 class Papyros(python_runner.PyodideRunner):
     def __init__(
@@ -128,12 +126,18 @@ class Papyros(python_runner.PyodideRunner):
     def pre_run(self, source_code, mode="exec", top_level_await=False):
         self.override_globals()
         if mode == "doctest":
-            source_code += f"""
-if __name__ == "{MODULE_NAME}":
-    import doctest
-    import sys
-    doctest.testmod(m=sys.modules["{MODULE_NAME}"], verbose=True)
-"""
+            # remove if __name__ == "__main__" and replace it
+            lines = source_code.split("\n")
+            main_start = 0
+            while main_start < len(lines) and not re.match("^if(\s)+__name__(\s)*==(\s)*\"__main__\"(\s)*:", lines[main_start]):
+                main_start += 1
+            if main_start < len(lines):
+                # Strip away indented lines making up the main block
+                main_end = main_start + 1
+                while main_end < len(lines) and re.match("^(( |\t)+)", lines[main_end]):
+                    main_end += 1
+                source_code = "\n".join(lines[0:main_start] + lines[main_end:])
+            source_code += "\nif __name__ == \"__main__\":\n    import doctest\n    doctest.testmod(verbose=True)"
         return super().pre_run(source_code, mode=mode, top_level_await=top_level_await)
 
     async def run_async(self, source_code, mode="exec", top_level_await=True):
@@ -147,7 +151,7 @@ if __name__ == "{MODULE_NAME}":
                         def frame_callback(frame):
                             self.callback("frame", data=frame, contentType="application/json")
 
-                        result = JSONTracer(frame_callback=frame_callback, module_name=MODULE_NAME).runscript(source_code)
+                        result = JSONTracer(frame_callback=frame_callback).runscript(source_code)
                     else:
                         result = self.execute(code_obj, mode)
                     while isinstance(result, Awaitable):
@@ -245,16 +249,4 @@ if __name__ == "{MODULE_NAME}":
             with open(f, "wb") as fd:
                 fd.write(await r.bytes())
             self.callback("loading", data=dict(status="loaded", modules=[f]), contentType="application/json")
-
-    def reset(self):
-        """
-        overwritten from PyodideRunner to change the module name
-        Called before running code 'from scratch' (i.e. when `mode` is not 'single' or 'eval')
-        to reset state such as global variables.
-        """
-        mod = ModuleType(MODULE_NAME)
-        mod.__file__ = self.filename
-        sys.modules[MODULE_NAME] = mod
-        self.console.locals = mod.__dict__
-        self.output_buffer.reset()
 


### PR DESCRIPTION
Reverts dodona-edu/papyros#639

broke input

```
{
  "name": "AttributeError",
  "traceback": "Traceback (most recent call last):\n  File \"LOCAL:/python_runner/runner.py\", line 233, in readline\n    return super().readline(*args, **kwargs)\n  File \"LOCAL:/python_runner/runner.py\", line 173, in readline\n    if not self.line and n:\nAttributeError: 'Papyros' object has no attribute 'line'\n\n    During handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"LOCAL:/papyros/papyros.py\", line 123, in _execute_context\n    yield\n       ... More lines not shown. ...\n  File \"LOCAL:/python_runner/runner.py\", line 235, in readline\n    self.pyodide_error(e)\n  File \"LOCAL:/python_runner/runner.py\", line 223, in pyodide_error\n    js_error = e.js_error  # type: ignore\nAttributeError: 'AttributeError' object has no attribute 'js_error'\n",
  "info": "An `AttributeError` occurs when the code contains something like\n    `object.x`\nand `x` is not a method or attribute (variable) belonging to `object`.\n",
  "why": "The object `e` has no attribute named `js_error`.\nThe following are some of its known attributes:\n`args, name, obj, with_traceback`.",
  "where": "",
  "what": "AttributeError: 'AttributeError' object has no attribute 'js_error'\n"
}
```