### PR TITLE
Fix enter in batch editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@codemirror/search": "^6.5.4",
     "@codemirror/state": "^6.3.2",
     "@codemirror/theme-one-dark": "^6.1.2",
-    "@codemirror/view": "^6.22.1",
+    "@codemirror/view": "^6.28.0",
     "@dodona/trace-component": "1.1.6",
     "@lezer/common": "^1.1.0",
     "codemirror-readonly-ranges": "^0.1.0-alpha.2",

--- a/src/editor/BatchInputEditor.ts
+++ b/src/editor/BatchInputEditor.ts
@@ -1,7 +1,7 @@
 import { CodeMirrorEditor } from "./CodeMirrorEditor";
 import { UsedInputGutters, UsedInputGutterInfo } from "./Gutters";
-import {keymap, ViewUpdate} from "@codemirror/view";
-import {insertBlankLine, insertNewline} from "@codemirror/commands";
+import { keymap, ViewUpdate } from "@codemirror/view";
+import { insertNewline } from "@codemirror/commands";
 
 /**
  * Arguments used to higlight lines in the Editor

--- a/src/editor/BatchInputEditor.ts
+++ b/src/editor/BatchInputEditor.ts
@@ -1,6 +1,7 @@
 import { CodeMirrorEditor } from "./CodeMirrorEditor";
 import { UsedInputGutters, UsedInputGutterInfo } from "./Gutters";
-import { ViewUpdate } from "@codemirror/view";
+import {keymap, ViewUpdate} from "@codemirror/view";
+import {insertBlankLine, insertNewline} from "@codemirror/commands";
 
 /**
  * Arguments used to higlight lines in the Editor
@@ -37,6 +38,13 @@ export class BatchInputEditor extends CodeMirrorEditor {
         });
         this.usedInputGutters = new UsedInputGutters();
         this.addExtension(this.usedInputGutters.toExtension());
+        this.addExtension([
+            keymap.of([
+                {
+                    key: "Enter", run: insertNewline
+                }
+            ]),
+        ]);
     }
 
     private getLastHighlightArgs(): HighlightArgs {

--- a/yarn.lock
+++ b/yarn.lock
@@ -492,7 +492,7 @@
     "@codemirror/view" "^6.0.0"
     "@lezer/highlight" "^1.0.0"
 
-"@codemirror/view@^6.0.0", "@codemirror/view@^6.17.0", "@codemirror/view@^6.22.1", "@codemirror/view@^6.23.0", "@codemirror/view@^6.27.0":
+"@codemirror/view@^6.0.0", "@codemirror/view@^6.17.0", "@codemirror/view@^6.23.0", "@codemirror/view@^6.27.0", "@codemirror/view@^6.28.0":
   version "6.28.0"
   resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.28.0.tgz#7315e8f122b76319d9b95042cde2c9875e7eeb5e"
   integrity sha512-fo7CelaUDKWIyemw4b+J57cWuRkOu4SWCCPfNDkPvfWkGjM9D5racHQXr4EQeYCD6zEBIBxGCeaKkQo+ysl0gA==
@@ -5113,16 +5113,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5154,14 +5145,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5756,16 +5740,7 @@ worker-loader@^3.0.8:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
When upgrading @codemirror/view to 6.28.0, the default keybinding for 'Enter' seems to have been broken in the most recent chrome versions. (see failing test in https://github.com/dodona-edu/dodona/pull/5604)

This was only a problem in the batch input editor. I would assume that this wasn't a problem in the other editor as one of the many extensions there already overwrites the 'Enter' keybinding.

I fixed this by manually setting the keybinding for 'Enter' to adding a newline.