### PR TITLE
Put webpack options in webpack file instead of inlined in file

### DIFF
--- a/src/workers/python/PythonWorker.ts
+++ b/src/workers/python/PythonWorker.ts
@@ -5,7 +5,7 @@ import { PyProxy } from "pyodide/ffi";
 import { pyodideExpose, PyodideExtras, loadPyodideAndPackage } from "pyodide-worker-runner";
 
 /* eslint-disable-next-line */
-const pythonPackageUrl = require("!!file-loader!./python_package.tar.gz.load_by_url").default;
+const pythonPackageUrl = require("./python_package.tar.gz.load_by_url").default;
 
 /**
  * Implementation of a Python backend for Papyros

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,15 @@ module.exports = function (webpackEnv, argv) {
 						"css-loader",
 						"postcss-loader"
 					],
-				}
+				},
+				{
+					test: /\.tar\.gz\.load_by_url$/,
+					use: [
+						{
+							loader: "file-loader",
+						},
+					],
+				},
 			]
 		},
 		resolve: {


### PR DESCRIPTION
Fix required for https://github.com/dodona-edu/dodona/pull/6097

Leave it to the final processor to decide on how to handle the dynamic import