### PR TITLE
Ignore doctest parsing failures

### DIFF
--- a/src/workers/python/papyros/papyros.py
+++ b/src/workers/python/papyros/papyros.py
@@ -229,8 +229,11 @@ if __name__ == "{MODULE_NAME}":
 
     def has_doctests(self, code):
         parser = doctest.DocTestParser()
-        tests = parser.get_examples(code)
-        return bool(tests)
+        try:
+            tests = parser.get_examples(code)
+            return bool(tests)
+        except ValueError:
+            return False
 
     async def provide_files(self, inline_files, href_files):
         inline_files = json.loads(inline_files)


### PR DESCRIPTION
The doctest parsers sometimes fails to parse the file.
Eg if you put `>>>print(repr(boom))` either in the code or in a doctests, this will crash the parser.

I have chosen to simply return `false` on `has_doctests` in this case.

We might want to show a proper error message to the user in the future.

closes [#870](https://github.com/dodona-edu/papyros/issues/870)
