### PR TITLE
Wait for activated service worker when configuring input

### DIFF
--- a/src/frontend/state/Papyros.ts
+++ b/src/frontend/state/Papyros.ts
@@ -55,6 +55,7 @@ export class Papyros extends State {
             try {
                 await navigator.serviceWorker.register(this.serviceWorkerName, { scope: "/" });
                 BackendManager.channel = makeChannel({ serviceWorker: { scope: "/" } })!;
+                await this.waitForActiveRegistration();
             } catch(e) {
                 console.error("Error registering service worker:", e);
                 return false;
@@ -63,6 +64,16 @@ export class Papyros extends State {
             BackendManager.channel = makeChannel({ atomics: {  } })!;
         }
         return true;
+    }
+
+    private async waitForActiveRegistration(timeout: number = 5000): Promise<void> {
+        return new Promise<void>((resolve, reject) => {
+            const timeoutHandle = setTimeout(() => reject(new Error("Timed out waiting for activated service worker")), timeout);
+            navigator.serviceWorker.ready.then(() => {
+                clearTimeout(timeoutHandle);
+                resolve();
+            })
+        })
     }
 }
 


### PR DESCRIPTION
Unfortunately there is no good way I could find to just listen to the activation.

**Manual testing instructions**
1. Make sure you can reproduce the issue locally on the `chore/upgrade-to-papyros-4` branch on the Dodona repo.
2. Run `yarn build:lib` in papyros.
3. Run `rm ~/repos/dodona/dodona/node_modules/@dodona/papyros/dist -rf && cp -r dist ~/repos/dodona/dodona/node_modules/@dodona/papyros` (replace `repos/dodona/dodona` with wherever your local checkout of Dodona is located.
4. Re-build your JS in Dodona
5. See that you can't reproduce the error anymore.