### PR TITLE
Stop asking for input when user stops program

### DIFF
--- a/src/frontend/state/InputOutput.ts
+++ b/src/frontend/state/InputOutput.ts
@@ -114,6 +114,9 @@ export class InputOutput extends State {
             this.prompt = e.data || "";
             this.awaitingInput = true;
         });
+        BackendManager.subscribe(BackendEventType.End, () => {
+            this.awaitingInput = false;
+        });
     }
 
     public logError(error: FriendlyError | string): void {

--- a/test/__tests__/state/InputOutput.test.ts
+++ b/test/__tests__/state/InputOutput.test.ts
@@ -2,7 +2,7 @@ import {Papyros} from "../../../src/frontend/state/Papyros";
 import {expect, it, describe} from "vitest";
 import {ProgrammingLanguage} from "../../../src/ProgrammingLanguage";
 import {FriendlyError, InputMode, OutputType} from "../../../src/frontend/state/InputOutput";
-import {waitForInputReady, waitForOutput} from "../../helpers";
+import {waitForAwaitingInput, waitForInputReady, waitForOutput} from "../../helpers";
 
 describe.sequential("InputOutput", () => {
     it("can log output", async () => {
@@ -58,6 +58,18 @@ console.log("world!");
         await waitForOutput(papyros);
         expect(papyros.io.output[0].content).toBe("hello foo");
         unsubscribe();
+    });
+
+    it("stops asking for input on stop", async () => {
+        const papyros = new Papyros();
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+        papyros.runner.code = `print("hello " + input())`; // eslint-disable-line quotes
+        await waitForInputReady();
+        papyros.runner.start();
+        await waitForAwaitingInput(papyros);
+        await papyros.runner.stop();
+        expect(papyros.io.awaitingInput).toBe(false);
     });
 
     it("can log friendly errors", async () => {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,5 +1,5 @@
-import {Papyros} from "../src/frontend/state/Papyros";
-import {RunState} from "../src/frontend/state/Runner";
+import { Papyros } from "../src/frontend/state/Papyros";
+import { RunState } from "../src/frontend/state/Runner";
 
 export async function waitForOutput(papyros: Papyros, count: number = 1, timeout = 2000): Promise<void> {
     const start = Date.now();
@@ -29,5 +29,15 @@ export async function waitForInputReady(timeout = 2000): Promise<void> {
             throw new Error("Timeout waiting for service worker to control this page");
         }
         await new Promise(r => setTimeout(r, 20));
+    }
+}
+
+export async function waitForAwaitingInput(papyros: Papyros, timeout: number = 5000): Promise<void> {
+    const start = Date.now();
+    while (!papyros.io.awaitingInput) {
+        if (Date.now() - start > timeout) {
+            throw new Error("Timeout waiting for awaiting input");
+        }
+        await new Promise(r => setTimeout(r, 10));
     }
 }


### PR DESCRIPTION
This fixes at least one type of occurrence of "No active call to send message to".

**Manual testing instructions**
1. On main:
  - Put "input()" as your program.
  - Click run
  - Click stop
  - Enter input
  - See the error in your console
2. See that this is impossible on this branch.