### PR TITLE
Add Turtle support

### DIFF
--- a/src/backend/workers/python/build_package.py
+++ b/src/backend/workers/python/build_package.py
@@ -4,6 +4,7 @@ import shutil
 import os
 import subprocess
 import sys
+import sysconfig
 
 def tarfile_filter(tar_info):
     name = tar_info.name
@@ -27,9 +28,10 @@ def create_package(package_name, dependencies, extra_deps):
     except Exception as e:
         # Always seems to result in a harmless permission denied error
         pass
-    # Bundle CPython's turtle.py (removed from Pyodide's stdlib, required by svg-turtle)
-    import turtle as turtle_mod
-    shutil.copy(turtle_mod.__file__, os.path.join(package_name, "turtle.py"))
+    # Bundle CPython's turtle.py (removed from Pyodide's stdlib, required by svg-turtle).
+    # Locate via sysconfig rather than `import turtle`, which would pull in tkinter.
+    turtle_src = os.path.join(sysconfig.get_path("stdlib"), "turtle.py")
+    shutil.copy(turtle_src, os.path.join(package_name, "turtle.py"))
     tar_name = f"{package_name}.tar.gz.load_by_url"
     if os.path.exists(tar_name):
         os.remove(tar_name)

--- a/src/backend/workers/python/build_package.py
+++ b/src/backend/workers/python/build_package.py
@@ -27,6 +27,9 @@ def create_package(package_name, dependencies, extra_deps):
     except Exception as e:
         # Always seems to result in a harmless permission denied error
         pass
+    # Bundle CPython's turtle.py (removed from Pyodide's stdlib, required by svg-turtle)
+    import turtle as turtle_mod
+    shutil.copy(turtle_mod.__file__, os.path.join(package_name, "turtle.py"))
     tar_name = f"{package_name}.tar.gz.load_by_url"
     if os.path.exists(tar_name):
         os.remove(tar_name)
@@ -45,4 +48,4 @@ def check_tar(tarname, out_dir="."):
 
 
 if __name__ == "__main__":
-    create_package("python_package", "python-runner friendly_traceback pylint>=4,<5 tomli typing-extensions json-tracer>=0.7.0", extra_deps="papyros")
+    create_package("python_package", "python-runner friendly_traceback pylint>=4,<5 tomli typing-extensions json-tracer>=0.7.0 svg-turtle", extra_deps="papyros")

--- a/src/backend/workers/python/papyros/linting.py
+++ b/src/backend/workers/python/papyros/linting.py
@@ -9,7 +9,7 @@ from pylint.reporters.text import TextReporter
 
 
 PYLINT_RC_FILE = os.path.abspath("/tmp/papyros/pylint_config.rc")
-PYLINT_PLUGINS = "pylint_ast_checker"
+PYLINT_PLUGINS = "pylint_ast_checker,pylint_turtle_brain"
 
 def lint(code):
     # Use temporary file to prevent Astroid cache from running into issues

--- a/src/backend/workers/python/papyros/papyros.py
+++ b/src/backend/workers/python/papyros/papyros.py
@@ -103,7 +103,7 @@ class Papyros(python_runner.PyodideRunner):
             if svg_string and svg_string != self._last_emitted_turtle_svg:
                 self._last_emitted_turtle_svg = svg_string
                 img = base64.b64encode(svg_string.encode("utf-8")).decode("utf-8")
-                self.output("img", img, contentType="img/svg+xml;base64")
+                self.callback("turtle", data=img, contentType="image/svg+xml;base64")
         except Exception:
             pass
 

--- a/src/backend/workers/python/papyros/papyros.py
+++ b/src/backend/workers/python/papyros/papyros.py
@@ -339,9 +339,22 @@ if __name__ == "{MODULE_NAME}":
                     self.callback("start", data="RunCode", contentType="text/plain")
                     if mode == "debug":
                         from tracer import JSONTracer
+                        _last_turtle_svg = [None]
+
                         def frame_callback(frame):
                             self._flush_open_files()
                             self._emit_created_files()
+                            hook = getattr(self, '_turtle_hook', None)
+                            if hook and hook.render:
+                                try:
+                                    from svg_turtle import SvgTurtle
+                                    svg_string = SvgTurtle._pen.to_svg()
+                                    if svg_string and svg_string != _last_turtle_svg[0]:
+                                        _last_turtle_svg[0] = svg_string
+                                        img = base64.b64encode(svg_string.encode("utf-8")).decode("utf-8")
+                                        self.output("img", img, contentType="img/svg+xml;base64")
+                                except Exception:
+                                    pass
                             self.callback("frame", data=frame, contentType="application/json")
 
                         result = JSONTracer(frame_callback=frame_callback, module_name=MODULE_NAME).runscript(source_code)

--- a/src/backend/workers/python/papyros/papyros.py
+++ b/src/backend/workers/python/papyros/papyros.py
@@ -50,6 +50,7 @@ class Papyros(python_runner.PyodideRunner):
         self._original_open = builtins.open
         self._last_emitted_snapshot = None
         self._last_emitted_turtle_svg = None
+        self._turtle_hook = TurtleImportHook()
         self._install_open_tracking()
         self.limit = limit
         self.override_globals()
@@ -93,34 +94,21 @@ class Papyros(python_runner.PyodideRunner):
         self.override_turtle()
 
     def _emit_turtle_snapshot(self):
-        """Emit the current turtle drawing if it has changed since the last snapshot."""
-        hook = getattr(self, '_turtle_hook', None)
-        if not hook or not hook.render:
+        if not self._turtle_hook.render:
             return
-        try:
-            from svg_turtle import SvgTurtle
-            svg_string = SvgTurtle._pen.to_svg()
-            if svg_string and svg_string != self._last_emitted_turtle_svg:
-                self._last_emitted_turtle_svg = svg_string
-                img = base64.b64encode(svg_string.encode("utf-8")).decode("utf-8")
-                self.callback("turtle", data=img, contentType="image/svg+xml;base64")
-        except Exception:
-            pass
-
-    def _render_turtle(self):
-        self._emit_turtle_snapshot()
+        from svg_turtle import SvgTurtle
+        svg_string = SvgTurtle._pen.to_svg()
+        if svg_string and svg_string != self._last_emitted_turtle_svg:
+            self._last_emitted_turtle_svg = svg_string
+            img = base64.b64encode(svg_string.encode("utf-8")).decode("utf-8")
+            self.callback("turtle", data=img, contentType="image/svg+xml;base64")
 
     def override_turtle(self):
-        if not hasattr(self, '_turtle_hook'):
-            self._turtle_hook = TurtleImportHook()
-
         hook = self._turtle_hook
         hook.papyros = self
         hook.render = None
-
         # Remove turtle from sys.modules so the hook intercepts the next import
         sys.modules.pop('turtle', None)
-
         if hook not in sys.meta_path:
             sys.meta_path.insert(0, hook)
 
@@ -244,7 +232,7 @@ class Papyros(python_runner.PyodideRunner):
                 self.output("traceback", **self.serialize_traceback(e))
                 self._flush_open_files()
                 self._emit_created_files()
-                self._render_turtle()
+                self._emit_turtle_snapshot()
             finally:
                 self._tracking_files = False
         self.post_run()
@@ -282,7 +270,7 @@ if __name__ == "{MODULE_NAME}":
                         result = await result
                     self._flush_open_files()
                     self._emit_created_files()
-                    self._render_turtle()
+                    self._emit_turtle_snapshot()
                     self.callback("end", data="CodeFinished", contentType="text/plain")
                     return result
             except ModuleNotFoundError as mnf:
@@ -299,7 +287,7 @@ if __name__ == "{MODULE_NAME}":
                 # with a js_error containing the reason
                 js_error = str(getattr(e, "js_error", ""))
                 if isinstance(e, KeyboardInterrupt) or "KeyboardInterrupt" in js_error:
-                    self._render_turtle()
+                    self._emit_turtle_snapshot()
                     self.callback("interrupt", data="KeyboardInterrupt", contentType="text/plain")
                 else:
                     raise

--- a/src/backend/workers/python/papyros/papyros.py
+++ b/src/backend/workers/python/papyros/papyros.py
@@ -49,6 +49,7 @@ class Papyros(python_runner.PyodideRunner):
         self._tracking_files = False
         self._original_open = builtins.open
         self._last_emitted_snapshot = None
+        self._last_emitted_turtle_svg = None
         self._install_open_tracking()
         self.limit = limit
         self.override_globals()
@@ -76,6 +77,7 @@ class Papyros(python_runner.PyodideRunner):
             elif event_type == "input":
                 return cb("input", data["prompt"])
             elif event_type == "sleep":
+                self._emit_turtle_snapshot()
                 return cb("sleep", data["seconds"]*1000, contentType="application/number")
             else:
                 return cb(event_type, data.get("data", ""), contentType=data.get("contentType"))
@@ -90,13 +92,23 @@ class Papyros(python_runner.PyodideRunner):
         self.override_matplotlib()
         self.override_turtle()
 
-    def _render_turtle(self):
+    def _emit_turtle_snapshot(self):
+        """Emit the current turtle drawing if it has changed since the last snapshot."""
         hook = getattr(self, '_turtle_hook', None)
-        if hook and hook.render:
-            try:
-                hook.render()
-            except Exception:
-                pass
+        if not hook or not hook.render:
+            return
+        try:
+            from svg_turtle import SvgTurtle
+            svg_string = SvgTurtle._pen.to_svg()
+            if svg_string and svg_string != self._last_emitted_turtle_svg:
+                self._last_emitted_turtle_svg = svg_string
+                img = base64.b64encode(svg_string.encode("utf-8")).decode("utf-8")
+                self.output("img", img, contentType="img/svg+xml;base64")
+        except Exception:
+            pass
+
+    def _render_turtle(self):
+        self._emit_turtle_snapshot()
 
     def override_turtle(self):
         if not hasattr(self, '_turtle_hook'):
@@ -221,6 +233,7 @@ class Papyros(python_runner.PyodideRunner):
         self._tracked_files.clear()
         self._tracking_files = True
         self._last_emitted_snapshot = None
+        self._last_emitted_turtle_svg = None
         with (
             redirect_stdout(python_runner.output.SysStream("output", self.output_buffer)),
             redirect_stderr(python_runner.output.SysStream("error", self.output_buffer)),
@@ -255,24 +268,11 @@ if __name__ == "{MODULE_NAME}":
                     self.callback("start", data="RunCode", contentType="text/plain")
                     if mode == "debug":
                         from tracer import JSONTracer
-                        _last_turtle_svg = [None]
 
                         def frame_callback(frame):
                             self._flush_open_files()
                             self._emit_created_files()
-                            # The hook fires lazily when user code runs `import turtle`, so the
-                            # pen only exists partway through the trace — check per frame.
-                            hook = getattr(self, '_turtle_hook', None)
-                            if hook and hook.render:
-                                try:
-                                    from svg_turtle import SvgTurtle
-                                    svg_string = SvgTurtle._pen.to_svg()
-                                    if svg_string and svg_string != _last_turtle_svg[0]:
-                                        _last_turtle_svg[0] = svg_string
-                                        img = base64.b64encode(svg_string.encode("utf-8")).decode("utf-8")
-                                        self.output("img", img, contentType="img/svg+xml;base64")
-                                except Exception:
-                                    pass
+                            self._emit_turtle_snapshot()
                             self.callback("frame", data=frame, contentType="application/json")
 
                         result = JSONTracer(frame_callback=frame_callback, module_name=MODULE_NAME).runscript(source_code)

--- a/src/backend/workers/python/papyros/papyros.py
+++ b/src/backend/workers/python/papyros/papyros.py
@@ -23,6 +23,92 @@ from types import ModuleType
 SYS_RECURSION_LIMIT = 500
 MODULE_NAME = "sandbox"
 
+
+class _TurtleImportHook:
+    """Import hook that lazily sets up SVG-based turtle graphics.
+
+    Installed in sys.meta_path. When user code does `import turtle`,
+    this hook intercepts it, imports svg-turtle, creates a shared
+    canvas/screen, and patches the turtle module to render SVG.
+
+    If user code never imports turtle, no setup occurs.
+    """
+
+    def __init__(self):
+        self.papyros = None
+        self.render = None
+        self._loading = False
+        self._turtle_module = None
+
+    def find_spec(self, name, path, target=None):
+        if name == 'turtle' and not self._loading:
+            import importlib.util
+            return importlib.util.spec_from_loader(name, self)
+        return None
+
+    def create_module(self, spec):
+        # Return the patched turtle module directly
+        return self._setup_turtle()
+
+    def exec_module(self, module):
+        # Module was already set up in create_module
+        pass
+
+    def _setup_turtle(self):
+        self._loading = True
+        try:
+            from svg_turtle import SvgTurtle
+            from svg_turtle.canvas import Canvas
+
+            if self._turtle_module is None:
+                # First import: svg_turtle stubs tkinter, then imports turtle
+                self._turtle_module = sys.modules.get('turtle')
+                if self._turtle_module is None:
+                    import turtle
+                    self._turtle_module = sys.modules['turtle']
+
+            turtle_mod = self._turtle_module
+            sys.modules['turtle'] = turtle_mod
+
+            # Fresh canvas and screen for this execution
+            canvas = Canvas(400, 400)
+            screen = SvgTurtle._Screen(canvas)
+            screen.cv.config(bg="")
+
+            class PapyrosTurtle(SvgTurtle):
+                def __init__(self):
+                    super().__init__(screen=screen)
+
+            SvgTurtle._screen = screen
+            SvgTurtle._pen = PapyrosTurtle()
+
+            rendered = [False]
+            papyros = self.papyros
+
+            def render():
+                if rendered[0]:
+                    return
+                rendered[0] = True
+                svg_string = SvgTurtle._pen.to_svg()
+                if svg_string:
+                    img = base64.b64encode(svg_string.encode("utf-8")).decode("utf-8")
+                    papyros.output("img", img, contentType="img/svg+xml;base64")
+
+            turtle_mod.Turtle = PapyrosTurtle
+            turtle_mod.done = render
+            turtle_mod.mainloop = render
+            turtle_mod.exitonclick = render
+            turtle_mod.bye = render
+
+            self.render = render
+            return turtle_mod
+        except Exception:
+            self.render = None
+            return None
+        finally:
+            self._loading = False
+
+
 class Papyros(python_runner.PyodideRunner):
     def __init__(
         self,
@@ -86,6 +172,29 @@ class Papyros(python_runner.PyodideRunner):
         # Otherwise `import matplotlib` fails while assuming a browser backend
         os.environ["MPLBACKEND"] = "AGG"
         self.override_matplotlib()
+        self.override_turtle()
+
+    def _render_turtle(self):
+        hook = getattr(self, '_turtle_hook', None)
+        if hook and hook.render:
+            try:
+                hook.render()
+            except Exception:
+                pass
+
+    def override_turtle(self):
+        if not hasattr(self, '_turtle_hook'):
+            self._turtle_hook = _TurtleImportHook()
+
+        hook = self._turtle_hook
+        hook.papyros = self
+        hook.render = None
+
+        # Remove turtle from sys.modules so the hook intercepts the next import
+        sys.modules.pop('turtle', None)
+
+        if hook not in sys.meta_path:
+            sys.meta_path.insert(0, hook)
 
     def override_matplotlib(self):
         try:
@@ -206,6 +315,7 @@ class Papyros(python_runner.PyodideRunner):
                 self.output("traceback", **self.serialize_traceback(e))
                 self._flush_open_files()
                 self._emit_created_files()
+                self._render_turtle()
             finally:
                 self._tracking_files = False
         self.post_run()
@@ -241,6 +351,7 @@ if __name__ == "{MODULE_NAME}":
                         result = await result
                     self._flush_open_files()
                     self._emit_created_files()
+                    self._render_turtle()
                     self.callback("end", data="CodeFinished", contentType="text/plain")
                     return result
             except ModuleNotFoundError as mnf:
@@ -257,6 +368,7 @@ if __name__ == "{MODULE_NAME}":
                 # with a js_error containing the reason
                 js_error = str(getattr(e, "js_error", ""))
                 if isinstance(e, KeyboardInterrupt) or "KeyboardInterrupt" in js_error:
+                    self._render_turtle()
                     self.callback("interrupt", data="KeyboardInterrupt", contentType="text/plain")
                 else:
                     raise

--- a/src/backend/workers/python/papyros/papyros.py
+++ b/src/backend/workers/python/papyros/papyros.py
@@ -17,96 +17,12 @@ from contextlib import contextmanager, redirect_stdout, redirect_stderr
 from pyodide_worker_runner import install_imports
 from pyodide.ffi import JsException, create_proxy
 from .util import to_py
+from .turtle_hook import TurtleImportHook
 from pyodide.http import pyfetch
 from types import ModuleType
 
 SYS_RECURSION_LIMIT = 500
 MODULE_NAME = "sandbox"
-
-
-class _TurtleImportHook:
-    """Import hook that lazily sets up SVG-based turtle graphics.
-
-    Installed in sys.meta_path. When user code does `import turtle`,
-    this hook intercepts it, imports svg-turtle, creates a shared
-    canvas/screen, and patches the turtle module to render SVG.
-
-    If user code never imports turtle, no setup occurs.
-    """
-
-    def __init__(self):
-        self.papyros = None
-        self.render = None
-        self._loading = False
-        self._turtle_module = None
-
-    def find_spec(self, name, path, target=None):
-        if name == 'turtle' and not self._loading:
-            import importlib.util
-            return importlib.util.spec_from_loader(name, self)
-        return None
-
-    def create_module(self, spec):
-        # Return the patched turtle module directly
-        return self._setup_turtle()
-
-    def exec_module(self, module):
-        # Module was already set up in create_module
-        pass
-
-    def _setup_turtle(self):
-        self._loading = True
-        try:
-            from svg_turtle import SvgTurtle
-            from svg_turtle.canvas import Canvas
-
-            if self._turtle_module is None:
-                # First import: svg_turtle stubs tkinter, then imports turtle
-                self._turtle_module = sys.modules.get('turtle')
-                if self._turtle_module is None:
-                    import turtle
-                    self._turtle_module = sys.modules['turtle']
-
-            turtle_mod = self._turtle_module
-            sys.modules['turtle'] = turtle_mod
-
-            # Fresh canvas and screen for this execution
-            canvas = Canvas(400, 400)
-            screen = SvgTurtle._Screen(canvas)
-            screen.cv.config(bg="")
-
-            class PapyrosTurtle(SvgTurtle):
-                def __init__(self):
-                    super().__init__(screen=screen)
-
-            SvgTurtle._screen = screen
-            SvgTurtle._pen = PapyrosTurtle()
-
-            rendered = [False]
-            papyros = self.papyros
-
-            def render():
-                if rendered[0]:
-                    return
-                rendered[0] = True
-                svg_string = SvgTurtle._pen.to_svg()
-                if svg_string:
-                    img = base64.b64encode(svg_string.encode("utf-8")).decode("utf-8")
-                    papyros.output("img", img, contentType="img/svg+xml;base64")
-
-            turtle_mod.Turtle = PapyrosTurtle
-            turtle_mod.done = render
-            turtle_mod.mainloop = render
-            turtle_mod.exitonclick = render
-            turtle_mod.bye = render
-
-            self.render = render
-            return turtle_mod
-        except Exception:
-            self.render = None
-            return None
-        finally:
-            self._loading = False
 
 
 class Papyros(python_runner.PyodideRunner):
@@ -184,7 +100,7 @@ class Papyros(python_runner.PyodideRunner):
 
     def override_turtle(self):
         if not hasattr(self, '_turtle_hook'):
-            self._turtle_hook = _TurtleImportHook()
+            self._turtle_hook = TurtleImportHook()
 
         hook = self._turtle_hook
         hook.papyros = self
@@ -344,6 +260,8 @@ if __name__ == "{MODULE_NAME}":
                         def frame_callback(frame):
                             self._flush_open_files()
                             self._emit_created_files()
+                            # The hook fires lazily when user code runs `import turtle`, so the
+                            # pen only exists partway through the trace — check per frame.
                             hook = getattr(self, '_turtle_hook', None)
                             if hook and hook.render:
                                 try:

--- a/src/backend/workers/python/papyros/papyros.py
+++ b/src/backend/workers/python/papyros/papyros.py
@@ -126,7 +126,7 @@ class Papyros(python_runner.PyodideRunner):
                 # encode to a base64 str
                 img = base64.b64encode(buf.read()).decode("utf-8")
                 matplotlib.pyplot.clf()
-                self.output("img", img, contentType="img/png;base64")
+                self.output("img", img, contentType="image/png;base64")
 
             matplotlib.pyplot.show = show
         except ModuleNotFoundError:

--- a/src/backend/workers/python/papyros/papyros.py
+++ b/src/backend/workers/python/papyros/papyros.py
@@ -76,6 +76,7 @@ class Papyros(python_runner.PyodideRunner):
                     else:
                         cb("output", data, contentType=part.get("contentType"))
             elif event_type == "input":
+                self._emit_turtle_snapshot()
                 return cb("input", data["prompt"])
             elif event_type == "sleep":
                 self._emit_turtle_snapshot()

--- a/src/backend/workers/python/papyros/pylint_turtle_brain.py
+++ b/src/backend/workers/python/papyros/pylint_turtle_brain.py
@@ -1,0 +1,59 @@
+# Astroid brain plugin for Python's turtle module.
+# turtle.py creates module-level functions dynamically via exec() in
+# _make_global_funcs(), so astroid can't see them statically.
+# This plugin injects stubs for those functions so pylint can check
+# valid vs invalid member access (e.g. turtle.forward is OK,
+# turtle.test is not).
+
+import astroid
+from astroid import MANAGER
+
+# These lists mirror CPython 3.13's turtle._tg_turtle_functions and
+# turtle._tg_screen_functions — the functions generated at module level.
+_TG_TURTLE_FUNCTIONS = [
+    'back', 'backward', 'begin_fill', 'begin_poly', 'bk',
+    'circle', 'clear', 'clearstamp', 'clearstamps', 'clone', 'color',
+    'degrees', 'distance', 'dot', 'down', 'end_fill', 'end_poly', 'fd',
+    'fillcolor', 'filling', 'forward', 'get_poly', 'getpen', 'getscreen',
+    'getturtle', 'goto', 'heading', 'hideturtle', 'home', 'ht', 'isdown',
+    'isvisible', 'left', 'lt', 'onclick', 'ondrag', 'onrelease', 'pd',
+    'pen', 'pencolor', 'pendown', 'pensize', 'penup', 'pos', 'position',
+    'pu', 'radians', 'right', 'reset', 'resizemode', 'rt', 'seth',
+    'setheading', 'setpos', 'setposition', 'settiltangle',
+    'setundobuffersize', 'setx', 'sety', 'shape', 'shapesize',
+    'shapetransform', 'shearfactor', 'showturtle', 'speed', 'st', 'stamp',
+    'teleport', 'tilt', 'tiltangle', 'towards', 'turtlesize', 'undo',
+    'undobuffercount', 'up', 'width', 'write', 'xcor', 'ycor',
+]
+
+_TG_SCREEN_FUNCTIONS = [
+    'addshape', 'bgcolor', 'bgpic', 'bye', 'clearscreen', 'colormode',
+    'delay', 'exitonclick', 'getcanvas', 'getshapes', 'listen',
+    'mainloop', 'mode', 'numinput', 'onkey', 'onkeypress', 'onkeyrelease',
+    'onscreenclick', 'ontimer', 'register_shape', 'resetscreen',
+    'screensize', 'setup', 'setworldcoordinates', 'textinput', 'title',
+    'tracer', 'turtles', 'update', 'window_height', 'window_width', 'done',
+]
+
+_ALL_FUNCTIONS = _TG_TURTLE_FUNCTIONS + _TG_SCREEN_FUNCTIONS
+
+
+def _turtle_transform(module):
+    """Add stub definitions for turtle's dynamically generated functions."""
+    code = "\n".join(f"def {name}(*args, **kwargs): ..." for name in _ALL_FUNCTIONS)
+    fake = astroid.parse(code)
+    for node in fake.body:
+        module.body.append(node)
+        module.locals[node.name] = [node]
+
+
+MANAGER.register_transform(
+    astroid.Module,
+    _turtle_transform,
+    lambda node: node.name == 'turtle',
+)
+
+
+def register(linter):
+    """Required by pylint plugin interface (no checkers to register)."""
+    pass

--- a/src/backend/workers/python/papyros/turtle_hook.py
+++ b/src/backend/workers/python/papyros/turtle_hook.py
@@ -1,0 +1,85 @@
+import base64
+import sys
+
+
+class TurtleImportHook:
+    """Import hook that lazily sets up SVG-based turtle graphics.
+
+    Installed in sys.meta_path. When user code does `import turtle`,
+    this hook intercepts it, imports svg-turtle, creates a shared
+    canvas/screen, and patches the turtle module to render SVG.
+
+    If user code never imports turtle, no setup occurs.
+    """
+
+    def __init__(self):
+        self.papyros = None
+        self.render = None
+        self._loading = False
+        self._turtle_module = None
+
+    def find_spec(self, name, path, target=None):
+        if name == 'turtle' and not self._loading:
+            import importlib.util
+            return importlib.util.spec_from_loader(name, self)
+        return None
+
+    def create_module(self, spec):
+        return self._setup_turtle()
+
+    def exec_module(self, module):
+        pass
+
+    def _setup_turtle(self):
+        self._loading = True
+        try:
+            from svg_turtle import SvgTurtle
+            from svg_turtle.canvas import Canvas
+
+            if self._turtle_module is None:
+                # First import: svg_turtle stubs tkinter, then imports turtle
+                self._turtle_module = sys.modules.get('turtle')
+                if self._turtle_module is None:
+                    import turtle
+                    self._turtle_module = sys.modules['turtle']
+
+            turtle_mod = self._turtle_module
+            sys.modules['turtle'] = turtle_mod
+
+            # Fresh canvas and screen for this execution
+            canvas = Canvas(400, 400)
+            screen = SvgTurtle._Screen(canvas)
+            screen.cv.config(bg="")
+
+            class PapyrosTurtle(SvgTurtle):
+                def __init__(self):
+                    super().__init__(screen=screen)
+
+            SvgTurtle._screen = screen
+            SvgTurtle._pen = PapyrosTurtle()
+
+            rendered = [False]
+            papyros = self.papyros
+
+            def render():
+                if rendered[0]:
+                    return
+                rendered[0] = True
+                svg_string = SvgTurtle._pen.to_svg()
+                if svg_string:
+                    img = base64.b64encode(svg_string.encode("utf-8")).decode("utf-8")
+                    papyros.output("img", img, contentType="img/svg+xml;base64")
+
+            turtle_mod.Turtle = PapyrosTurtle
+            turtle_mod.done = render
+            turtle_mod.mainloop = render
+            turtle_mod.exitonclick = render
+            turtle_mod.bye = render
+
+            self.render = render
+            return turtle_mod
+        except Exception:
+            self.render = None
+            return None
+        finally:
+            self._loading = False

--- a/src/backend/workers/python/papyros/turtle_hook.py
+++ b/src/backend/workers/python/papyros/turtle_hook.py
@@ -36,16 +36,13 @@ class TurtleImportHook:
             from svg_turtle.canvas import Canvas
 
             if self._turtle_module is None:
-                # First import: svg_turtle stubs tkinter, then imports turtle
-                self._turtle_module = sys.modules.get('turtle')
-                if self._turtle_module is None:
-                    import turtle
-                    self._turtle_module = sys.modules['turtle']
+                # svg_turtle stubs tkinter as a side effect of import; must precede `import turtle`
+                import turtle
+                self._turtle_module = sys.modules['turtle']
 
             turtle_mod = self._turtle_module
             sys.modules['turtle'] = turtle_mod
 
-            # Fresh canvas and screen for this execution
             canvas = Canvas(400, 400)
             screen = SvgTurtle._Screen(canvas)
             screen.cv.config(bg="")
@@ -57,10 +54,8 @@ class TurtleImportHook:
             SvgTurtle._screen = screen
             SvgTurtle._pen = PapyrosTurtle()
 
-            papyros = self.papyros
-
             def render():
-                papyros._emit_turtle_snapshot()
+                self.papyros._emit_turtle_snapshot()
 
             turtle_mod.Turtle = PapyrosTurtle
             turtle_mod.done = render
@@ -70,7 +65,7 @@ class TurtleImportHook:
 
             self.render = render
             return turtle_mod
-        except Exception:
+        except ImportError:
             self.render = None
             return None
         finally:

--- a/src/backend/workers/python/papyros/turtle_hook.py
+++ b/src/backend/workers/python/papyros/turtle_hook.py
@@ -65,8 +65,5 @@ class TurtleImportHook:
 
             self.render = render
             return turtle_mod
-        except ImportError:
-            self.render = None
-            return None
         finally:
             self._loading = False

--- a/src/backend/workers/python/papyros/turtle_hook.py
+++ b/src/backend/workers/python/papyros/turtle_hook.py
@@ -1,4 +1,3 @@
-import base64
 import sys
 
 
@@ -58,17 +57,10 @@ class TurtleImportHook:
             SvgTurtle._screen = screen
             SvgTurtle._pen = PapyrosTurtle()
 
-            rendered = [False]
             papyros = self.papyros
 
             def render():
-                if rendered[0]:
-                    return
-                rendered[0] = True
-                svg_string = SvgTurtle._pen.to_svg()
-                if svg_string:
-                    img = base64.b64encode(svg_string.encode("utf-8")).decode("utf-8")
-                    papyros.output("img", img, contentType="img/svg+xml;base64")
+                papyros._emit_turtle_snapshot()
 
             turtle_mod.Turtle = PapyrosTurtle
             turtle_mod.done = render

--- a/src/communication/BackendEvent.ts
+++ b/src/communication/BackendEvent.ts
@@ -14,6 +14,7 @@ export enum BackendEventType {
     FrameChange = "frame-change",
     Stop = "stop",
     Files = "files",
+    Turtle = "turtle",
 }
 
 /**

--- a/src/frontend/components/Output.ts
+++ b/src/frontend/components/Output.ts
@@ -137,16 +137,13 @@ export class Output extends PapyrosElement {
 
     get renderedOutputs(): TemplateResult[] {
         let outputsToRender: OutputEntry[];
-        const isTurtle = (o: OutputEntry): boolean => o.type === OutputType.turtle;
         if (this.papyros.io.activeOutputTab === TURTLE_TAB) {
-            // Turtle tab: only the latest snapshot. Intermediate frames from sleep/debug
-            // are kept in the output array (so the debugger slider can step through them) but
-            // only the current one should be visible.
-            const lastIdx = this.outputs.findLastIndex(isTurtle);
+            // Latest snapshot within this.outputs (which is sliced by the debugger's current
+            // step via maxOutputLength) — so stepping the debugger shows the drawing build up.
+            const lastIdx = this.outputs.findLastIndex((o) => o.type === OutputType.turtle);
             outputsToRender = lastIdx >= 0 ? [this.outputs[lastIdx]] : [];
         } else {
-            // Output tab: everything except turtle snapshots.
-            outputsToRender = this.outputs.filter((o) => !isTurtle(o));
+            outputsToRender = this.outputs.filter((o) => o.type !== OutputType.turtle);
         }
         return outputsToRender.map((o) => {
             if (o.type === OutputType.stdout) {

--- a/src/frontend/components/Output.ts
+++ b/src/frontend/components/Output.ts
@@ -1,7 +1,8 @@
 import { customElement } from "lit/decorators.js";
 import { css, CSSResult, html, TemplateResult } from "lit";
-import { FriendlyError, OutputEntry, OutputType } from "../state/InputOutput";
+import { FriendlyError, OutputEntry, OutputType, OUTPUT_TAB, TURTLE_TAB } from "../state/InputOutput";
 import { PapyrosElement } from "./PapyrosElement";
+import { tabButtonStyles } from "./shared-styles";
 import "@material/web/icon/icon";
 
 @customElement("p-output")
@@ -11,8 +12,21 @@ export class Output extends PapyrosElement {
             :host {
                 width: 100%;
                 height: 100%;
+                display: flex;
+                flex-direction: column;
+            }
+
+            .tabs {
+                display: flex;
+                flex-direction: row;
+                gap: 0.25rem;
+                flex-shrink: 0;
+                margin-bottom: 0.75rem;
+            }
+
+            .content {
+                flex: 1;
                 overflow: auto;
-                display: block;
             }
 
             img {
@@ -39,6 +53,8 @@ export class Output extends PapyrosElement {
             md-icon {
                 vertical-align: bottom;
             }
+
+            ${tabButtonStyles}
         `;
     }
 
@@ -65,7 +81,7 @@ export class Output extends PapyrosElement {
     get downloadOverflowUrl(): string {
         const blob = new Blob(
             this.overflow.map((o) => {
-                if (o.type === OutputType.img) {
+                if (o.type === OutputType.img || o.type === OutputType.turtle) {
                     return `[Image output of type ${o.contentType} omitted]\n`;
                 } else if (o.type === OutputType.stdout) {
                     return o.content as string;
@@ -97,22 +113,22 @@ export class Output extends PapyrosElement {
     }
 
     get renderedOutputs(): TemplateResult[] {
-        let outputsToRender = this.outputs;
-        // Only render the latest SVG snapshot — intermediate frames from sleep/debug are kept in
-        // the output array (so the debugger slider can step through them) but only the current
-        // one should be visible at any given time.
-        const lastSvgIdx = outputsToRender.findLastIndex(
-            (o) => o.type === OutputType.img && o.contentType?.includes("svg"),
-        );
-        if (lastSvgIdx >= 0) {
-            outputsToRender = outputsToRender.filter(
-                (o, i) => !(o.type === OutputType.img && o.contentType?.includes("svg")) || i === lastSvgIdx,
-            );
+        let outputsToRender: OutputEntry[];
+        const isTurtle = (o: OutputEntry): boolean => o.type === OutputType.turtle;
+        if (this.papyros.io.activeOutputTab === TURTLE_TAB) {
+            // Turtle tab: only the latest snapshot. Intermediate frames from sleep/debug
+            // are kept in the output array (so the debugger slider can step through them) but
+            // only the current one should be visible.
+            const lastIdx = this.outputs.findLastIndex(isTurtle);
+            outputsToRender = lastIdx >= 0 ? [this.outputs[lastIdx]] : [];
+        } else {
+            // Output tab: everything except turtle snapshots.
+            outputsToRender = this.outputs.filter((o) => !isTurtle(o));
         }
         return outputsToRender.map((o) => {
             if (o.type === OutputType.stdout) {
                 return html`${o.content}`;
-            } else if (o.type === OutputType.img) {
+            } else if (o.type === OutputType.img || o.type === OutputType.turtle) {
                 const mimeType = o.contentType?.replace(/^img\//, "image/") ?? "image/png";
                 return html`<img src="data:${mimeType},${o.content}"></img>`;
             } else if (o.type === OutputType.stderr) {
@@ -143,23 +159,56 @@ export class Output extends PapyrosElement {
         });
     }
 
-    protected override render(): TemplateResult {
-        if (this.outputs.length === 0) {
-            return html`<pre class="place-holder">${this.t("Papyros.output_placeholder")}</pre>`;
-        }
+    private get showTurtleTab(): boolean {
+        return this.papyros.io.hasTurtleOutput || this.papyros.io.activeOutputTab === TURTLE_TAB;
+    }
 
+    private renderTabs(): TemplateResult {
+        const activeTab = this.papyros.io.activeOutputTab;
         return html`
-            <pre>${this.renderedOutputs}</pre>
-            ${this.showOverflowWarning
-                ? html`
-                      <p>
-                          ${this.t("Papyros.output_overflow")}
-                          <a href="${this.downloadOverflowUrl}" download="papyros_output.txt">
-                              ${this.t("Papyros.output_overflow_download")}
-                          </a>
-                      </p>
-                  `
-                : html``}
+            <div class="tabs">
+                <button
+                    class=${activeTab === OUTPUT_TAB ? "active" : ""}
+                    @click=${() => this.papyros.io.selectOutputTab(OUTPUT_TAB)}
+                >
+                    ${this.t("Papyros.output_tab_output")}
+                </button>
+                ${this.showTurtleTab
+                    ? html`
+                          <button
+                              class=${activeTab === TURTLE_TAB ? "active" : ""}
+                              @click=${() => this.papyros.io.selectOutputTab(TURTLE_TAB)}
+                          >
+                              ${this.t("Papyros.output_tab_turtle")}
+                          </button>
+                      `
+                    : html``}
+            </div>
+        `;
+    }
+
+    protected override render(): TemplateResult {
+        const activeTab = this.papyros.io.activeOutputTab;
+        const rendered = this.renderedOutputs;
+        const showPlaceholder = activeTab === OUTPUT_TAB && rendered.length === 0;
+        const showOverflow = activeTab === OUTPUT_TAB && this.showOverflowWarning;
+        return html`
+            ${this.renderTabs()}
+            <div class="content">
+                ${showPlaceholder
+                    ? html`<pre class="place-holder">${this.t("Papyros.output_placeholder")}</pre>`
+                    : html`<pre>${rendered}</pre>`}
+                ${showOverflow
+                    ? html`
+                          <p>
+                              ${this.t("Papyros.output_overflow")}
+                              <a href="${this.downloadOverflowUrl}" download="papyros_output.txt">
+                                  ${this.t("Papyros.output_overflow_download")}
+                              </a>
+                          </p>
+                      `
+                    : html``}
+            </div>
         `;
     }
 }

--- a/src/frontend/components/Output.ts
+++ b/src/frontend/components/Output.ts
@@ -21,13 +21,22 @@ export class Output extends PapyrosElement {
                 flex-direction: row;
                 gap: 0.25rem;
                 flex-shrink: 0;
-                margin-bottom: 0.75rem;
+                position: relative;
+                z-index: 1;
             }
 
             .content {
                 flex: 1;
                 overflow: auto;
                 container-type: size;
+                padding: 0.75rem;
+                background-color: var(--md-sys-color-surface-container-highest);
+            }
+
+            .content.turtle {
+                margin-top: -1px;
+                padding: 0;
+                background-color: transparent;
             }
 
             img {
@@ -44,7 +53,7 @@ export class Output extends PapyrosElement {
                 max-height: 100%;
                 margin: 0;
                 box-sizing: border-box;
-                background-color: var(--md-sys-color-surface-container-lowest);
+                background-color: var(--md-sys-color-surface-container-highest);
                 border: 1px solid var(--md-sys-color-outline-variant);
             }
 
@@ -209,7 +218,7 @@ export class Output extends PapyrosElement {
         const showOverflow = activeTab === OUTPUT_TAB && this.showOverflowWarning;
         return html`
             ${this.renderTabs()}
-            <div class="content">
+            <div class="content ${activeTab === TURTLE_TAB ? "turtle" : ""}">
                 ${showPlaceholder
                     ? html`<pre class="place-holder">${this.t("Papyros.output_placeholder")}</pre>`
                     : html`<pre>${rendered}</pre>`}

--- a/src/frontend/components/Output.ts
+++ b/src/frontend/components/Output.ts
@@ -97,7 +97,21 @@ export class Output extends PapyrosElement {
     }
 
     get renderedOutputs(): TemplateResult[] {
-        return this.outputs.map((o) => {
+        let outputsToRender = this.outputs;
+        if (this.papyros.debugger.active) {
+            // In debug mode, only show the last SVG image for progressive turtle rendering.
+            // Multiple SVG snapshots are emitted during debug (one per turtle state change),
+            // but only the latest one visible at the current frame should be displayed.
+            const lastSvgIdx = outputsToRender.findLastIndex(
+                (o) => o.type === OutputType.img && o.contentType?.includes("svg"),
+            );
+            if (lastSvgIdx >= 0) {
+                outputsToRender = outputsToRender.filter(
+                    (o, i) => !(o.type === OutputType.img && o.contentType?.includes("svg")) || i === lastSvgIdx,
+                );
+            }
+        }
+        return outputsToRender.map((o) => {
             if (o.type === OutputType.stdout) {
                 return html`${o.content}`;
             } else if (o.type === OutputType.img) {

--- a/src/frontend/components/Output.ts
+++ b/src/frontend/components/Output.ts
@@ -101,7 +101,8 @@ export class Output extends PapyrosElement {
             if (o.type === OutputType.stdout) {
                 return html`${o.content}`;
             } else if (o.type === OutputType.img) {
-                return html`<img src="data:${o.contentType}, ${o.content}"></img>`;
+                const mimeType = o.contentType?.replace(/^img\//, "image/") ?? "image/png";
+                return html`<img src="data:${mimeType},${o.content}"></img>`;
             } else if (o.type === OutputType.stderr) {
                 if (typeof o.content === "string") {
                     return html`<span class="error">${o.content}</span>`;

--- a/src/frontend/components/Output.ts
+++ b/src/frontend/components/Output.ts
@@ -98,16 +98,16 @@ export class Output extends PapyrosElement {
 
     get renderedOutputs(): TemplateResult[] {
         let outputsToRender = this.outputs;
-        if (this.papyros.debugger.active) {
-            // Only show the latest SVG snapshot so the debugger slider shows progressive rendering.
-            const lastSvgIdx = outputsToRender.findLastIndex(
-                (o) => o.type === OutputType.img && o.contentType?.includes("svg"),
+        // Only render the latest SVG snapshot — intermediate frames from sleep/debug are kept in
+        // the output array (so the debugger slider can step through them) but only the current
+        // one should be visible at any given time.
+        const lastSvgIdx = outputsToRender.findLastIndex(
+            (o) => o.type === OutputType.img && o.contentType?.includes("svg"),
+        );
+        if (lastSvgIdx >= 0) {
+            outputsToRender = outputsToRender.filter(
+                (o, i) => !(o.type === OutputType.img && o.contentType?.includes("svg")) || i === lastSvgIdx,
             );
-            if (lastSvgIdx >= 0) {
-                outputsToRender = outputsToRender.filter(
-                    (o, i) => !(o.type === OutputType.img && o.contentType?.includes("svg")) || i === lastSvgIdx,
-                );
-            }
         }
         return outputsToRender.map((o) => {
             if (o.type === OutputType.stdout) {

--- a/src/frontend/components/Output.ts
+++ b/src/frontend/components/Output.ts
@@ -99,9 +99,7 @@ export class Output extends PapyrosElement {
     get renderedOutputs(): TemplateResult[] {
         let outputsToRender = this.outputs;
         if (this.papyros.debugger.active) {
-            // In debug mode, only show the last SVG image for progressive turtle rendering.
-            // Multiple SVG snapshots are emitted during debug (one per turtle state change),
-            // but only the latest one visible at the current frame should be displayed.
+            // Only show the latest SVG snapshot so the debugger slider shows progressive rendering.
             const lastSvgIdx = outputsToRender.findLastIndex(
                 (o) => o.type === OutputType.img && o.contentType?.includes("svg"),
             );

--- a/src/frontend/components/Output.ts
+++ b/src/frontend/components/Output.ts
@@ -27,6 +27,7 @@ export class Output extends PapyrosElement {
             .content {
                 flex: 1;
                 overflow: auto;
+                container-type: size;
             }
 
             img {
@@ -34,6 +35,17 @@ export class Output extends PapyrosElement {
                 max-height: 300px;
                 display: block;
                 margin: 0.5rem 0;
+            }
+
+            img.turtle {
+                width: min(100cqw, 100cqh);
+                height: min(100cqw, 100cqh);
+                max-width: 100%;
+                max-height: 100%;
+                margin: 0;
+                box-sizing: border-box;
+                background-color: var(--md-sys-color-surface-container-lowest);
+                border: 1px solid var(--md-sys-color-outline-variant);
             }
 
             pre {
@@ -128,9 +140,12 @@ export class Output extends PapyrosElement {
         return outputsToRender.map((o) => {
             if (o.type === OutputType.stdout) {
                 return html`${o.content}`;
-            } else if (o.type === OutputType.img || o.type === OutputType.turtle) {
+            } else if (o.type === OutputType.img) {
                 const mimeType = o.contentType?.replace(/^img\//, "image/") ?? "image/png";
                 return html`<img src="data:${mimeType},${o.content}"></img>`;
+            } else if (o.type === OutputType.turtle) {
+                const mimeType = o.contentType ?? "image/svg+xml;base64";
+                return html`<img class="turtle" src="data:${mimeType},${o.content}"></img>`;
             } else if (o.type === OutputType.stderr) {
                 if (typeof o.content === "string") {
                     return html`<span class="error">${o.content}</span>`;

--- a/src/frontend/components/Output.ts
+++ b/src/frontend/components/Output.ts
@@ -20,6 +20,7 @@ export class Output extends PapyrosElement {
                 display: flex;
                 flex-direction: row;
                 gap: 0.25rem;
+                padding-top: 0.25rem;
                 flex-shrink: 0;
                 position: relative;
                 z-index: 1;

--- a/src/frontend/components/Output.ts
+++ b/src/frontend/components/Output.ts
@@ -47,7 +47,8 @@ export class Output extends PapyrosElement {
                 margin: 0.5rem 0;
             }
 
-            img.turtle {
+            img.turtle,
+            .turtle-placeholder {
                 width: min(100cqw, 100cqh);
                 height: min(100cqw, 100cqh);
                 max-width: 100%;
@@ -216,13 +217,16 @@ export class Output extends PapyrosElement {
         const activeTab = this.papyros.io.activeOutputTab;
         const rendered = this.renderedOutputs;
         const showPlaceholder = activeTab === OUTPUT_TAB && rendered.length === 0;
+        const showTurtlePlaceholder = activeTab === TURTLE_TAB && rendered.length === 0;
         const showOverflow = activeTab === OUTPUT_TAB && this.showOverflowWarning;
         return html`
             ${this.renderTabs()}
             <div class="content ${activeTab === TURTLE_TAB ? "turtle" : ""}">
                 ${showPlaceholder
                     ? html`<pre class="place-holder">${this.t("Papyros.output_placeholder")}</pre>`
-                    : html`<pre>${rendered}</pre>`}
+                    : showTurtlePlaceholder
+                      ? html`<div class="turtle-placeholder"></div>`
+                      : html`<pre>${rendered}</pre>`}
                 ${showOverflow
                     ? html`
                           <p>

--- a/src/frontend/components/Output.ts
+++ b/src/frontend/components/Output.ts
@@ -149,7 +149,7 @@ export class Output extends PapyrosElement {
             if (o.type === OutputType.stdout) {
                 return html`${o.content}`;
             } else if (o.type === OutputType.img) {
-                const mimeType = o.contentType?.replace(/^img\//, "image/") ?? "image/png";
+                const mimeType = o.contentType ?? "image/png";
                 return html`<img src="data:${mimeType},${o.content}"></img>`;
             } else if (o.type === OutputType.turtle) {
                 const mimeType = o.contentType ?? "image/svg+xml;base64";

--- a/src/frontend/components/app/examples/PythonExamples.ts
+++ b/src/frontend/components/app/examples/PythonExamples.ts
@@ -117,6 +117,14 @@ with open("names.txt", "r") as in_file:
     for line in in_file:
         print(line.rstrip())
 `,
+    Turtle: `import turtle
+
+colors = ['red', 'orange', 'yellow', 'green', 'blue', 'purple']
+for i in range(360):
+    turtle.pencolor(colors[i % 6])
+    turtle.forward(i * 0.5)
+    turtle.left(59)
+`,
     Matplotlib: `import matplotlib.pyplot as plt
 import networkx as nx
 

--- a/src/frontend/state/InputOutput.ts
+++ b/src/frontend/state/InputOutput.ts
@@ -40,6 +40,7 @@ export enum OutputType {
     stdout = "stdout",
     stderr = "stderr",
     img = "img",
+    turtle = "turtle",
 }
 
 export type OutputEntry = {
@@ -61,6 +62,10 @@ export interface FileEntry {
 
 export const CODE_TAB = "code";
 
+export const OUTPUT_TAB = "output";
+export const TURTLE_TAB = "turtle";
+export type OutputTab = typeof OUTPUT_TAB | typeof TURTLE_TAB;
+
 export function parseFileEntries(data: string, contentType?: string): FileEntry[] {
     const parsed = parseData(data, contentType) as Record<string, { content: string; binary: boolean }>;
     return Object.entries(parsed).map(([name, { content, binary }]) => ({ name, content, binary }));
@@ -76,6 +81,10 @@ export class InputOutput extends State {
     files: FileEntry[] = [];
     @stateProperty
     activeEditorTab: string = CODE_TAB;
+    @stateProperty
+    activeOutputTab: OutputTab = OUTPUT_TAB;
+    @stateProperty
+    outputTabManuallySet: boolean = false;
     @stateProperty
     prompt: string = "";
     @stateProperty
@@ -119,6 +128,10 @@ export class InputOutput extends State {
                 this.logOutput(data);
             }
         });
+        BackendManager.subscribe(BackendEventType.Turtle, (e) => {
+            const data = parseData(e.data, e.contentType);
+            this.logTurtle(data, e.contentType);
+        });
         BackendManager.subscribe(BackendEventType.Error, (e) => {
             const data = parseData(e.data, e.contentType);
             this.logError(data);
@@ -134,6 +147,11 @@ export class InputOutput extends State {
         });
         BackendManager.subscribe(BackendEventType.End, () => {
             this.awaitingInput = false;
+            // If the finished run produced no turtle output, drop the (stale) Turtle tab
+            // selection so the tab bar hides. A manual selection is preserved.
+            if (this.activeOutputTab === TURTLE_TAB && !this.hasTurtleOutput && !this.outputTabManuallySet) {
+                this.activeOutputTab = OUTPUT_TAB;
+            }
         });
         BackendManager.subscribe(BackendEventType.Files, (e) => {
             this.files = parseFileEntries(e.data, e.contentType);
@@ -157,6 +175,23 @@ export class InputOutput extends State {
 
     public logImage(imageData: string, contentType: string = "img/png"): void {
         this.output = [...this.output, { type: OutputType.img, content: imageData, contentType }];
+    }
+
+    public logTurtle(imageData: string, contentType: string = "image/svg+xml;base64"): void {
+        const isFirstSnapshot = !this.hasTurtleOutput;
+        this.output = [...this.output, { type: OutputType.turtle, content: imageData, contentType }];
+        if (isFirstSnapshot && this.activeOutputTab === OUTPUT_TAB && !this.outputTabManuallySet) {
+            this.activeOutputTab = TURTLE_TAB;
+        }
+    }
+
+    public selectOutputTab(tab: OutputTab): void {
+        this.activeOutputTab = tab;
+        this.outputTabManuallySet = true;
+    }
+
+    public get hasTurtleOutput(): boolean {
+        return this.output.some((o) => o.type === OutputType.turtle);
     }
 
     public logOutput(output: string): void {
@@ -233,5 +268,8 @@ export class InputOutput extends State {
         this.prompt = "";
         this.awaitingInput = false;
         this.activeEditorTab = CODE_TAB;
+        // activeOutputTab is intentionally preserved across reruns: resetting it would make
+        // the tab bar flicker (Turtle → Output → Turtle) as a turtle rerun progresses. It is
+        // pruned back to OUTPUT_TAB on End when no turtle output was produced.
     }
 }

--- a/src/frontend/state/InputOutput.ts
+++ b/src/frontend/state/InputOutput.ts
@@ -78,6 +78,8 @@ export class InputOutput extends State {
     @stateProperty
     output: OutputEntry[] = [];
     @stateProperty
+    hasTurtleOutput: boolean = false;
+    @stateProperty
     files: FileEntry[] = [];
     @stateProperty
     activeEditorTab: string = CODE_TAB;
@@ -180,6 +182,7 @@ export class InputOutput extends State {
     public logTurtle(imageData: string, contentType: string = "image/svg+xml;base64"): void {
         const isFirstSnapshot = !this.hasTurtleOutput;
         this.output = [...this.output, { type: OutputType.turtle, content: imageData, contentType }];
+        this.hasTurtleOutput = true;
         if (isFirstSnapshot && this.activeOutputTab === OUTPUT_TAB && !this.outputTabManuallySet) {
             this.activeOutputTab = TURTLE_TAB;
         }
@@ -188,10 +191,6 @@ export class InputOutput extends State {
     public selectOutputTab(tab: OutputTab): void {
         this.activeOutputTab = tab;
         this.outputTabManuallySet = true;
-    }
-
-    public get hasTurtleOutput(): boolean {
-        return this.output.some((o) => o.type === OutputType.turtle);
     }
 
     public logOutput(output: string): void {
@@ -265,6 +264,7 @@ export class InputOutput extends State {
     public reset(): void {
         this.inputs = [];
         this.output = [];
+        this.hasTurtleOutput = false;
         this.prompt = "";
         this.awaitingInput = false;
         this.activeEditorTab = CODE_TAB;

--- a/src/frontend/state/InputOutput.ts
+++ b/src/frontend/state/InputOutput.ts
@@ -124,7 +124,7 @@ export class InputOutput extends State {
         BackendManager.subscribe(BackendEventType.Start, () => this.reset());
         BackendManager.subscribe(BackendEventType.Output, (e) => {
             const data = parseData(e.data, e.contentType);
-            if (e.contentType && e.contentType.startsWith("img")) {
+            if (e.contentType && e.contentType.startsWith("image/")) {
                 this.logImage(data, e.contentType);
             } else {
                 this.logOutput(data);
@@ -175,7 +175,7 @@ export class InputOutput extends State {
         this.output = [...this.output, { type: OutputType.stderr, content: error }];
     }
 
-    public logImage(imageData: string, contentType: string = "img/png"): void {
+    public logImage(imageData: string, contentType: string = "image/png"): void {
         this.output = [...this.output, { type: OutputType.img, content: imageData, contentType }];
     }
 

--- a/src/frontend/state/Translations.ts
+++ b/src/frontend/state/Translations.ts
@@ -79,6 +79,8 @@ export const ENGLISH_TRANSLATION = {
         files_download: "Download",
         files_binary: "Binary file",
         files_empty: "Empty file",
+        output_tab_output: "Output",
+        output_tab_turtle: "Turtle",
     },
     CodeMirror: {
         // @codemirror/search
@@ -175,6 +177,8 @@ export const DUTCH_TRANSLATION = {
         files_download: "Downloaden",
         files_binary: "Binair bestand",
         files_empty: "Leeg bestand",
+        output_tab_output: "Uitvoer",
+        output_tab_turtle: "Turtle",
     },
     CodeMirror: {
         // @codemirror/view

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -47,7 +47,8 @@ export function parseData(data: string, contentType?: string): any {
         }
         case "img": {
             switch (specificType) {
-                case "png;base64": {
+                case "png;base64":
+                case "svg+xml;base64": {
                     return data;
                 }
             }

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -45,7 +45,8 @@ export function parseData(data: string, contentType?: string): any {
             }
             break;
         }
-        case "img": {
+        case "img":
+        case "image": {
             switch (specificType) {
                 case "png;base64":
                 case "svg+xml;base64": {

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -17,7 +17,7 @@ export function debounce<T extends (...args: any[]) => void>(fn: T, delay: numbe
 
 /**
  * Parse the data contained within a PapyrosEvent using its contentType
- * Supported content types are: text/plain, text/json, img/png;base64
+ * Supported content types are: text/plain, text/json, image/png;base64
  * @param {string} data The data to parse
  * @param {string} contentType The content type of the data
  * @return {any} The parsed data
@@ -45,7 +45,6 @@ export function parseData(data: string, contentType?: string): any {
             }
             break;
         }
-        case "img":
         case "image": {
             switch (specificType) {
                 case "png;base64":

--- a/test/__tests__/state/Turtle.test.ts
+++ b/test/__tests__/state/Turtle.test.ts
@@ -21,10 +21,10 @@ turtle.done()`;
         await waitForPapyrosReady(papyros);
         await waitForOutput(papyros);
         expect(papyros.runner.state).toBe(RunState.Ready);
-        const imgOutputs = papyros.io.output.filter(o => o.type === OutputType.img);
-        expect(imgOutputs.length).toBeGreaterThan(0);
-        expect(imgOutputs[0].contentType).toBe("img/svg+xml;base64");
-        const decoded = atob(imgOutputs[0].content as string);
+        const turtleOutputs = papyros.io.output.filter(o => o.type === OutputType.turtle);
+        expect(turtleOutputs.length).toBeGreaterThan(0);
+        expect(turtleOutputs[0].contentType).toBe("image/svg+xml;base64");
+        const decoded = atob(turtleOutputs[0].content as string);
         expect(decoded).toContain("<svg");
     });
 
@@ -43,11 +43,11 @@ turtle.done()`;
         await papyros.runner.start();
         await waitForPapyrosReady(papyros);
         await waitForOutput(papyros, 2);
-        const imgOutputs = papyros.io.output.filter(o => o.type === OutputType.img);
-        expect(imgOutputs.length).toBeGreaterThanOrEqual(2);
+        const turtleOutputs = papyros.io.output.filter(o => o.type === OutputType.turtle);
+        expect(turtleOutputs.length).toBeGreaterThanOrEqual(2);
         // Each snapshot should be a valid base64-encoded SVG
-        for (const img of imgOutputs) {
-            expect(img.contentType).toBe("img/svg+xml;base64");
+        for (const img of turtleOutputs) {
+            expect(img.contentType).toBe("image/svg+xml;base64");
             expect(atob(img.content as string)).toContain("<svg");
         }
     });
@@ -63,9 +63,9 @@ turtle.done()`;
         await papyros.runner.start(RunMode.Debug);
         await waitForPapyrosReady(papyros);
         await waitForOutput(papyros);
-        const imgOutputs = papyros.io.output.filter(o => o.type === OutputType.img);
-        expect(imgOutputs.length).toBeGreaterThan(0);
-        expect(imgOutputs[0].contentType).toBe("img/svg+xml;base64");
-        expect(atob(imgOutputs[0].content as string)).toContain("<svg");
+        const turtleOutputs = papyros.io.output.filter(o => o.type === OutputType.turtle);
+        expect(turtleOutputs.length).toBeGreaterThan(0);
+        expect(turtleOutputs[0].contentType).toBe("image/svg+xml;base64");
+        expect(atob(turtleOutputs[0].content as string)).toContain("<svg");
     });
 });

--- a/test/__tests__/state/Turtle.test.ts
+++ b/test/__tests__/state/Turtle.test.ts
@@ -1,0 +1,71 @@
+import {describe, expect, it} from "vitest";
+import {Papyros} from "../../../src/frontend/state/Papyros";
+import {ProgrammingLanguage} from "../../../src/ProgrammingLanguage";
+import {RunState} from "../../../src/frontend/state/Runner";
+import {RunMode} from "../../../src/backend/Backend";
+import {OutputType} from "../../../src/frontend/state/InputOutput";
+import {waitForOutput, waitForPapyrosReady} from "../../helpers";
+
+describe("Turtle", () => {
+    it("can load turtle and generate an SVG image", async () => {
+        const papyros = new Papyros();
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+        papyros.runner.code = `import turtle
+t = turtle.Turtle()
+t.forward(100)
+t.right(90)
+t.forward(100)
+turtle.done()`;
+        await papyros.runner.start();
+        await waitForPapyrosReady(papyros);
+        await waitForOutput(papyros);
+        expect(papyros.runner.state).toBe(RunState.Ready);
+        const imgOutputs = papyros.io.output.filter(o => o.type === OutputType.img);
+        expect(imgOutputs.length).toBeGreaterThan(0);
+        expect(imgOutputs[0].contentType).toBe("img/svg+xml;base64");
+        const decoded = atob(imgOutputs[0].content as string);
+        expect(decoded).toContain("<svg");
+    });
+
+    it("emits incremental snapshots on sleep", async () => {
+        const papyros = new Papyros();
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+        papyros.runner.code = `import turtle
+import time
+t = turtle.Turtle()
+t.forward(50)
+time.sleep(0.1)
+t.right(90)
+t.forward(50)
+turtle.done()`;
+        await papyros.runner.start();
+        await waitForPapyrosReady(papyros);
+        await waitForOutput(papyros, 2);
+        const imgOutputs = papyros.io.output.filter(o => o.type === OutputType.img);
+        expect(imgOutputs.length).toBeGreaterThanOrEqual(2);
+        // Each snapshot should be a valid base64-encoded SVG
+        for (const img of imgOutputs) {
+            expect(img.contentType).toBe("img/svg+xml;base64");
+            expect(atob(img.content as string)).toContain("<svg");
+        }
+    });
+
+    it("emits turtle image in debug mode", async () => {
+        const papyros = new Papyros();
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+        papyros.runner.code = `import turtle
+t = turtle.Turtle()
+t.forward(100)
+turtle.done()`;
+        await papyros.runner.start(RunMode.Debug);
+        await waitForPapyrosReady(papyros);
+        await waitForOutput(papyros);
+        const imgOutputs = papyros.io.output.filter(o => o.type === OutputType.img);
+        expect(imgOutputs.length).toBeGreaterThan(0);
+        expect(imgOutputs[0].contentType).toBe("img/svg+xml;base64");
+        expect(atob(imgOutputs[0].content as string)).toContain("<svg");
+    });
+});


### PR DESCRIPTION
This PR adds Turtle support to Papyros.

The integrations is based on svg-turtle (https://github.com/donkirkby/svg-turtle) which is what's used in the Turtle judge.

It's 100% seamless: `import turtle` is caught in the python module, and emits svg, drawn by the frontend. All Papyros futures are supported: regular running, debugging (including stepping through code), and `input()`.

https://github.com/user-attachments/assets/d8a08ffd-2075-45e6-9d32-ac6ee93a7aa2

When executing Turtle code, a new tab is added to the output pane and is switched to automatically. In case there's stdout, the user can switch back to output. Once a tab pane has been selected, it's persisted if the code is rerun, or when navigating through debugger steps.

To indicate the size of the canvas, a border is added to the Turtle output.

Since the tabs were floating in space, I added a background colour to the stdout output to connect them to the output.