### PR TITLE
Give the editor tab bar a specific separate background

### DIFF
--- a/src/frontend/components/AddFileButton.ts
+++ b/src/frontend/components/AddFileButton.ts
@@ -23,14 +23,14 @@ export class AddFileButton extends PapyrosElement {
 
             .add-btn {
                 padding: 0.375rem 0.5rem;
-                border: none;
+                border: 1px solid var(--md-sys-color-outline-variant);
                 border-bottom: 2px solid var(--md-sys-color-outline-variant);
                 border-radius: 0.375rem 0.375rem 0 0;
                 cursor: pointer;
                 font-size: 1rem;
                 line-height: 1;
-                background-color: var(--md-sys-color-surface-variant);
-                color: var(--md-sys-color-on-surface-variant);
+                background-color: var(--md-sys-color-surface);
+                color: var(--md-sys-color-on-surface);
             }
 
             .add-btn:hover {

--- a/src/frontend/components/shared-styles.ts
+++ b/src/frontend/components/shared-styles.ts
@@ -3,13 +3,13 @@ import { css, CSSResult } from "lit";
 export const tabButtonStyles: CSSResult = css`
     button {
         padding: 0.375rem 0.75rem;
-        border: none;
+        border: 1px solid var(--md-sys-color-outline-variant);
         border-bottom: 2px solid var(--md-sys-color-outline-variant);
         border-radius: 0.375rem 0.375rem 0 0;
         cursor: pointer;
         font-size: 0.875rem;
-        background-color: var(--md-sys-color-surface-variant);
-        color: var(--md-sys-color-on-surface-variant);
+        background-color: var(--md-sys-color-surface);
+        color: var(--md-sys-color-on-surface);
         white-space: nowrap;
         display: flex;
         align-items: center;
@@ -17,8 +17,8 @@ export const tabButtonStyles: CSSResult = css`
     }
 
     button.active {
-        background-color: var(--md-sys-color-surface);
-        color: var(--md-sys-color-on-surface);
+        background-color: var(--md-sys-color-surface-variant);
+        color: var(--md-sys-color-on-surface-variant);
         font-weight: 600;
         border-bottom: 2px solid var(--md-sys-color-primary);
     }


### PR DESCRIPTION
What it looks like in papyros:
<img width="353" height="150" alt="image" src="https://github.com/user-attachments/assets/f01434b9-f6c9-4029-b414-69a0b42afa93" />
<img width="345" height="122" alt="image" src="https://github.com/user-attachments/assets/f85c7e48-7d5c-4ec7-b7b5-f6791c79cee0" />




What it looks like in Dodona:
<img width="441" height="167" alt="image" src="https://github.com/user-attachments/assets/1f21ad84-9b7d-4f7a-b695-93e31a401d39" />
<img width="385" height="175" alt="image" src="https://github.com/user-attachments/assets/d2ec1137-b846-4fde-b0c7-4c9fe7906d4c" />


