### PR TITLE
Modernize publish workflow with OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,16 +12,21 @@ jobs:
   build-and-publish:
     needs: [test]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Install and Build 🔧
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: yarn
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install and Build
         run: |
-          yarn install
+          yarn install --frozen-lockfile
           yarn build:lib
       - name: Publish @dodona/papyros to NPM
-        uses: JS-DevTools/npm-publish@v4
-        with:
-          token: ${{ secrets.NPM_AUTH_TOKEN }}
-          check-version: true
-          access: public
+        run: npm publish --provenance --access public

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,8 +1,8 @@
 name: Publish on NPM
 
 on:
-  release:
-    types: [created]
+  push:
+    tags: ['v*']
   workflow_dispatch:
 
 jobs:
@@ -13,11 +13,19 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Verify tag matches package.json version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          PKG=$(jq -r .version package.json)
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Tag v$TAG does not match package.json version $PKG"
+            exit 1
+          fi
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
@@ -30,3 +38,7 @@ jobs:
           yarn build:lib
       - name: Publish @dodona/papyros to NPM
         run: npm publish --provenance --access public
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${GITHUB_REF#refs/tags/}" --generate-notes --verify-tag


### PR DESCRIPTION
Pin Node 24.x to match the test workflow, switch from JS-DevTools/npm-publish + NPM_AUTH_TOKEN to direct `npm publish --provenance` via npm trusted publishing, and use a frozen lockfile on install.

Requires a one-time trusted publisher setup on npmjs.com for @dodona/papyros pointing at dodona-edu/papyros + publish.yaml before the next release.

Before the new publish workflow can publish successfully, a maintainer of @dodona/papyros must configure the trusted publisher on npmjs.com:

1. Sign in to npmjs.com as an Owner of the `dodona` npm org
2. Go to https://www.npmjs.com/package/@dodona/papyros/access
3. Scroll down to the "Trusted Publisher" section
4. Under "Select your publisher", click GitHub Actions and fill in:
   - Organization: dodona-edu
   - Repository: papyros
   - Workflow filename: publish.yaml
   - Environment: (leave empty)
5. After the first successful OIDC publish, the legacy NPM_AUTH_TOKEN repo secret can be deleted.

If the trusted publisher is not yet configured at run time, the publish step will fail with an auth error.