### PR TITLE
Set explicit rootDir in tsconfig to satisfy TypeScript 6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "noEmit": false,
     "isolatedModules": true,
     "sourceMap": true,
+    "rootDir": "./src",
     "outDir": "./dist",
     "declaration": true
   },


### PR DESCRIPTION
TypeScript 6 errors with TS5011 when outDir is set without an explicit rootDir, breaking the publish workflow's build step.