### PR TITLE
Allow dropping URLs on to the editor

### DIFF
--- a/src/frontend/components/CodeRunner.ts
+++ b/src/frontend/components/CodeRunner.ts
@@ -3,6 +3,7 @@ import { PapyrosElement } from "./PapyrosElement";
 import { css, CSSResult, html, TemplateResult } from "lit";
 import { createRef, ref, Ref } from "lit/directives/ref.js";
 import { CODE_TAB } from "../state/InputOutput";
+import { isValidFileName } from "../../util/Util";
 import "./code_runner/Code";
 import "./code_runner/RunState";
 import "./code_runner/ButtonLint";
@@ -11,12 +12,14 @@ import "./FileViewer";
 
 const TEXT_MIME_PATTERNS = ["text/", "application/json", "application/xml", "application/javascript"];
 
-function isTextFile(file: File): boolean {
-    if (!file.type) {
+function isTextMimeType(mime: string | null | undefined): boolean {
+    if (!mime) {
         // No MIME type — assume text
         return true;
     }
-    return TEXT_MIME_PATTERNS.some((prefix) => file.type.startsWith(prefix));
+    // Strip parameters like "; charset=utf-8" before matching
+    const base = mime.split(";")[0].trim().toLowerCase();
+    return TEXT_MIME_PATTERNS.some((prefix) => base.startsWith(prefix));
 }
 
 function arrayBufferToBase64(buffer: ArrayBuffer): string {
@@ -123,10 +126,21 @@ export class CodeRunner extends PapyrosElement {
         e.stopPropagation();
         this.dragOver = false;
 
-        if (this.papyros.debugger.active || !e.dataTransfer?.files.length) return;
+        if (this.papyros.debugger.active || !e.dataTransfer) return;
 
         for (const file of Array.from(e.dataTransfer.files)) {
             this.readAndAddFile(file);
+        }
+
+        if (e.dataTransfer.types.includes("text/uri-list")) {
+            const uriList = e.dataTransfer.getData("text/uri-list");
+            const urls = uriList
+                .split(/\r?\n/)
+                .map((line) => line.trim())
+                .filter((line) => line && !line.startsWith("#"));
+            for (const url of urls) {
+                void this.fetchAndAddUrl(url);
+            }
         }
     };
 
@@ -137,7 +151,7 @@ export class CodeRunner extends PapyrosElement {
 
     private readAndAddFile(file: File): void {
         const reader = new FileReader();
-        if (isTextFile(file)) {
+        if (isTextMimeType(file.type)) {
             reader.onload = (): void => {
                 this.upsertFile(file.name, reader.result as string, false);
             };
@@ -147,6 +161,39 @@ export class CodeRunner extends PapyrosElement {
                 this.upsertFile(file.name, arrayBufferToBase64(reader.result as ArrayBuffer), true);
             };
             reader.readAsArrayBuffer(file);
+        }
+    }
+
+    private filenameFromUrl(url: URL): string {
+        const segments = url.pathname.split("/").filter((s) => s.length > 0);
+        let candidate = segments[segments.length - 1] ?? "";
+        try {
+            candidate = decodeURIComponent(candidate);
+        } catch {
+            // Leave as-is if decoding fails
+        }
+        if (isValidFileName(candidate)) return candidate;
+        if (isValidFileName(url.hostname)) return url.hostname;
+        return "download";
+    }
+
+    private async fetchAndAddUrl(rawUrl: string): Promise<void> {
+        try {
+            const url = new URL(rawUrl);
+            const response = await fetch(url);
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status} ${response.statusText}`);
+            }
+            const name = this.filenameFromUrl(url);
+            const contentType = response.headers.get("Content-Type");
+            if (isTextMimeType(contentType)) {
+                this.upsertFile(name, await response.text(), false);
+            } else {
+                this.upsertFile(name, arrayBufferToBase64(await response.arrayBuffer()), true);
+            }
+        } catch (err) {
+            console.warn("Failed to fetch dropped URL:", rawUrl, err);
+            alert(this.t("Papyros.url_fetch_error", { url: rawUrl }));
         }
     }
 

--- a/src/frontend/state/Translations.ts
+++ b/src/frontend/state/Translations.ts
@@ -47,6 +47,7 @@ export const ENGLISH_TRANSLATION = {
         no_output: "The code did not produce any output.",
         service_worker_error: "The service worker failed to load.",
         launch_error: "Papyros failed to load. Do you want to reload?",
+        url_fetch_error: "Failed to fetch URL: %{url}",
         loading: "Loading %{packages}.",
         run_modes: {
             doctest: "Run doctests",
@@ -145,6 +146,7 @@ export const DUTCH_TRANSLATION = {
         no_output: "De code produceerde geen uitvoer.",
         service_worker_error: "Er liep iets fout bij het laden van de service worker.",
         launch_error: "Er liep iets fout bij het laden van Papyros. Wil je herladen?",
+        url_fetch_error: "Kon URL niet ophalen: %{url}",
         loading: "Bezig met het installeren van %{packages}.",
         run_modes: {
             doctest: "Doctests uitvoeren",


### PR DESCRIPTION
This PR adds the ability to papyros to open dropped URLs as a tab in the editor. In practice, this should allow students to drop a link to a file from an exercise description straight onto the editor to work with it.

The URLs do need a pretty broad CORS allow list to work in papyros. E.g. URLs from dodona won't work in the standalone version. Things that do work in the standalone version are `raw.githubusercontent.com` links, some wikipedia images, ...