### PR TITLE
Honor turtle.setup() canvas dimensions

### DIFF
--- a/src/backend/workers/python/papyros/turtle_hook.py
+++ b/src/backend/workers/python/papyros/turtle_hook.py
@@ -77,6 +77,7 @@ class TurtleImportHook:
             turtle_mod.exitonclick = render
             turtle_mod.bye = render
             turtle_mod.setup = setup
+            screen.setup = lambda width=400, height=400, startx=None, starty=None: setup(width, height)
 
             self.render = render
             return turtle_mod

--- a/src/backend/workers/python/papyros/turtle_hook.py
+++ b/src/backend/workers/python/papyros/turtle_hook.py
@@ -57,11 +57,26 @@ class TurtleImportHook:
             def render():
                 self.papyros._emit_turtle_snapshot()
 
+            def setup(width=400, height=400, startx=None, starty=None):
+                # Mirror stdlib turtle: floats in (0, 1] are a fraction of the
+                # screen. Papyros has no real screen, so resolve fractions
+                # against a 1000px reference.
+                def resolve(value):
+                    if isinstance(value, float) and 0 < value <= 1:
+                        return int(value * 1000)
+                    v = int(value)
+                    if v <= 0:
+                        raise ValueError(f"turtle.setup() requires positive dimensions, got {value!r}")
+                    return v
+                canvas.options['width'] = resolve(width)
+                canvas.options['height'] = resolve(height)
+
             turtle_mod.Turtle = PapyrosTurtle
             turtle_mod.done = render
             turtle_mod.mainloop = render
             turtle_mod.exitonclick = render
             turtle_mod.bye = render
+            turtle_mod.setup = setup
 
             self.render = render
             return turtle_mod

--- a/src/backend/workers/python/papyros/turtle_hook.py
+++ b/src/backend/workers/python/papyros/turtle_hook.py
@@ -68,8 +68,13 @@ class TurtleImportHook:
                     if v <= 0:
                         raise ValueError(f"turtle.setup() requires positive dimensions, got {value!r}")
                     return v
-                canvas.options['width'] = resolve(width)
-                canvas.options['height'] = resolve(height)
+                w = resolve(width)
+                h = resolve(height)
+                canvas.options['width'] = w
+                canvas.options['height'] = h
+                canvas.options['scrollregion'] = (-w // 2, -h // 2, w // 2, h // 2)
+                screen.canvwidth = w
+                screen.canvheight = h
 
             turtle_mod.Turtle = PapyrosTurtle
             turtle_mod.done = render

--- a/src/frontend/components/Output.ts
+++ b/src/frontend/components/Output.ts
@@ -47,14 +47,21 @@ export class Output extends PapyrosElement {
                 margin: 0.5rem 0;
             }
 
-            img.turtle,
-            .turtle-placeholder {
-                width: min(100cqw, 100cqh);
-                height: min(100cqw, 100cqh);
-                max-width: 100%;
-                max-height: 100%;
+            img.turtle {
+                max-width: 100cqw;
+                max-height: 100cqh;
                 margin: 0;
                 box-sizing: border-box;
+                background-color: var(--md-sys-color-surface-container-highest);
+                border: 1px solid var(--md-sys-color-outline-variant);
+            }
+
+            .turtle-placeholder {
+                width: 400px;
+                height: 400px;
+                max-width: 100cqw;
+                max-height: 100cqh;
+                margin: 0;
                 background-color: var(--md-sys-color-surface-container-highest);
                 border: 1px solid var(--md-sys-color-outline-variant);
             }

--- a/test/__tests__/state/Turtle.test.ts
+++ b/test/__tests__/state/Turtle.test.ts
@@ -52,6 +52,68 @@ turtle.done()`;
         }
     });
 
+    it("honors turtle.setup() canvas dimensions", async () => {
+        const papyros = new Papyros();
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+        papyros.runner.code = `import turtle
+turtle.setup(800, 400)
+turtle.forward(100)
+turtle.done()`;
+        await papyros.runner.start();
+        await waitForPapyrosReady(papyros);
+        await waitForOutput(papyros);
+        const turtleOutputs = papyros.io.output.filter(o => o.type === OutputType.turtle);
+        expect(turtleOutputs.length).toBeGreaterThan(0);
+        const decoded = atob(turtleOutputs[turtleOutputs.length - 1].content as string);
+        expect(decoded).toMatch(/width="800"/);
+        expect(decoded).toMatch(/height="400"/);
+    });
+
+    it("treats fractional setup() values as fractions of a 1000px reference", async () => {
+        const papyros = new Papyros();
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+        // setup(0.5, 0.25) should resolve to 500x250, mirroring stdlib turtle's
+        // "fraction of the screen" semantics rather than collapsing to int(0.x) == 0.
+        papyros.runner.code = `import turtle
+turtle.setup(0.5, 0.25)
+turtle.forward(50)
+turtle.done()`;
+        await papyros.runner.start();
+        await waitForPapyrosReady(papyros);
+        await waitForOutput(papyros);
+        const turtleOutputs = papyros.io.output.filter(o => o.type === OutputType.turtle);
+        expect(turtleOutputs.length).toBeGreaterThan(0);
+        const decoded = atob(turtleOutputs[turtleOutputs.length - 1].content as string);
+        expect(decoded).toMatch(/width="500"/);
+        expect(decoded).toMatch(/height="250"/);
+    });
+
+    it("honors Screen().setup() and recenters the origin", async () => {
+        const papyros = new Papyros();
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+        // Drawing a zero-length stroke at the turtle's home (0, 0) emits a polyline
+        // whose coords reveal the canvas-pixel origin. With setup(1000, 1000) the
+        // origin should sit at the canvas center (500.5, 500.5), not the default 200.5.
+        papyros.runner.code = `import turtle
+window = turtle.Screen()
+window.setup(1000, 1000)
+t = turtle.Turtle()
+t.dot(10, "red")
+turtle.done()`;
+        await papyros.runner.start();
+        await waitForPapyrosReady(papyros);
+        await waitForOutput(papyros);
+        const turtleOutputs = papyros.io.output.filter(o => o.type === OutputType.turtle);
+        expect(turtleOutputs.length).toBeGreaterThan(0);
+        const decoded = atob(turtleOutputs[turtleOutputs.length - 1].content as string);
+        expect(decoded).toMatch(/width="1000"/);
+        expect(decoded).toMatch(/height="1000"/);
+        expect(decoded).toContain("500.5,500.5");
+    });
+
     it("emits turtle image in debug mode", async () => {
         const papyros = new Papyros();
         await papyros.launch();


### PR DESCRIPTION
## Summary
- Override `turtle.setup(width, height)` and `Screen().setup(width, height)` so they actually resize the SVG canvas (previously hardcoded to 400×400 by the import hook). Drawings made before the call are preserved — `setup` mutates `canvas.options` in place rather than recreating the screen.
- Update the Turtle output pane so the rendered canvas reflects the SVG's intrinsic aspect ratio (scaled to fit, anchored top-left under the tabs) instead of forcing a square frame. The empty-state placeholder now matches the 400×400 default so there's no jarring shrink between the empty state and the first frame.

<img width="1505" height="938" alt="image" src="https://github.com/user-attachments/assets/c8962097-7a9b-4219-83ce-da60f5ded979" />

## Test plan
- [ ] `turtle.setup(800, 400)` renders as a 2:1 landscape canvas in the output pane
- [ ] `Screen().setup(1000, 1000)` (the user's original repro) renders at the correct dimensions
- [ ] `turtle.setup(300, 600)` renders as a portrait canvas
- [ ] Default (no setup call) renders as the existing 400×400 square
- [ ] Drawing a square first, then calling `turtle.setup(800, 400)`, preserves the earlier shape in the resized canvas
- [ ] Stepping through with the debugger shows a consistent canvas size from the first frame onward
