### PR TITLE
Omit extra friendly_traceback info if it doesn't know anything

### DIFF
--- a/src/backend/workers/python/papyros/papyros.py
+++ b/src/backend/workers/python/papyros/papyros.py
@@ -308,6 +308,8 @@ if __name__ == "{MODULE_NAME}":
         tb = fr.info.get("shortened_traceback", "")
         info = fr.info.get("generic", "")
         why = fr.info.get("cause", "")
+        if why.startswith("No information is known about this exception."):
+            why = ""
         what = fr.info.get("message", "")
 
         name = type(exc).__name__


### PR DESCRIPTION
This excludes the message to create an issue on GitHub for unknown errors.

Fixes #1038.