### PR TITLE
Stop the linter flagging installed packages as unimportable

### DIFF
--- a/src/backend/workers/python/PythonWorker.ts
+++ b/src/backend/workers/python/PythonWorker.ts
@@ -61,18 +61,25 @@ export class PythonWorker extends Backend<PyodideExtras> {
     }
 
     /**
-     * Helper method to install imports and prevent race conditions with double downloading
+     * Helper method to install imports and prevent race conditions with double downloading.
+     * Installs are serialized (chained) so concurrent calls don't download the same
+     * package twice, but every call still installs the imports for ITS OWN code.
+     * A single shared promise must not be reused across calls: otherwise a call could
+     * ride on an install started for different code (e.g. the editor's empty initial
+     * buffer while it is still linting the real code), leaving its own imports
+     * uninstalled and producing a spurious "unable to import X" lint error.
      * @param {string} code The code containing import statements
      */
     private async installImports(code: string): Promise<void> {
-        if (this.installPromise == null) {
-            this.installPromise = this.papyros?.install_imports.callKwargs({
+        const install = (): Promise<void> | undefined =>
+            this.papyros?.install_imports.callKwargs({
                 source_code: code,
                 ignore_missing: true,
             });
-        }
+        // Chain onto any in-flight install (ignoring its outcome) so this call's
+        // imports are installed after it, without concurrent double-downloads.
+        this.installPromise = (this.installPromise ?? Promise.resolve()).then(install, install);
         await this.installPromise;
-        this.installPromise = null;
     }
 
     public override runModes(code: string): Array<RunMode> {

--- a/src/backend/workers/python/PythonWorker.ts
+++ b/src/backend/workers/python/PythonWorker.ts
@@ -58,18 +58,25 @@ export class PythonWorker extends Backend<PyodideExtras> {
     }
 
     /**
-     * Helper method to install imports and prevent race conditions with double downloading
+     * Helper method to install imports and prevent race conditions with double downloading.
+     * Installs are serialized (chained) so concurrent calls don't download the same
+     * package twice, but every call still installs the imports for ITS OWN code.
+     * A single shared promise must not be reused across calls: otherwise a call could
+     * ride on an install started for different code (e.g. the editor's empty initial
+     * buffer while it is still linting the real code), leaving its own imports
+     * uninstalled and producing a spurious "unable to import X" lint error.
      * @param {string} code The code containing import statements
      */
     private async installImports(code: string): Promise<void> {
-        if (this.installPromise == null) {
-            this.installPromise = this.papyros?.install_imports.callKwargs({
+        const install = (): Promise<void> | undefined =>
+            this.papyros?.install_imports.callKwargs({
                 source_code: code,
                 ignore_missing: true,
             });
-        }
+        // Chain onto any in-flight install (ignoring its outcome) so this call's
+        // imports are installed after it, without concurrent double-downloads.
+        this.installPromise = (this.installPromise ?? Promise.resolve()).then(install, install);
         await this.installPromise;
-        this.installPromise = null;
     }
 
     public override runModes(code: string): Array<RunMode> {

--- a/src/backend/workers/python/papyros/linting.py
+++ b/src/backend/workers/python/papyros/linting.py
@@ -1,17 +1,79 @@
 # Ensure pylint can find the plugin files
 import os
 import sys
+import importlib
+import importlib.util
 from tempfile import NamedTemporaryFile
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 from io import StringIO
 from pylint.lint import Run
 from pylint.reporters.text import TextReporter
+from astroid.manager import AstroidManager as _AstroidManager
+from astroid.builder import AstroidBuilder as _AstroidBuilder
+
+# Pyodide + astroid: astroid resolves most installed packages fine (so E0611 /
+# no-member work), but it can't build a few stdlib modules that are backed by
+# built-ins under Emscripten -- notably `os` (which pulls in `posix`) -- and
+# reports a false "Unable to import 'os'". We let astroid resolve normally and
+# only fall back to a synthetic stub when it fails *and* the module is genuinely
+# importable in this interpreter (Papyros installs the code's imports before
+# linting). A real typo / missing package still raises, so import-error stays
+# accurate. The stub exposes a module-level __getattr__ so `os.getcwd()` style
+# access doesn't trip no-member.
+#
+# We can't know the stubbed module's real names, so `from os import getcwd` would
+# wrongly trip no-name-in-module (E0611, which ignores __getattr__). We record the
+# modules we had to stub and drop E0611 for exactly those in process_pylint_output,
+# leaving E0611 intact for everything astroid could analyse.
+_STUB_SOURCE = "def __getattr__(name): ...\n"
+
+_orig_ast_from_module_name = _AstroidManager.ast_from_module_name
+
+# Modules astroid couldn't build but that are importable. Accumulated across the
+# worker session: astroid caches module builds, so the hook only fires the first
+# time a module is resolved -- clearing this per lint would lose the record on
+# later lints that hit the cache.
+_stubbed_modules: set = set()
+
+
+def _is_importable(modname):
+    try:
+        if importlib.util.find_spec(modname) is not None:
+            return True
+    except Exception:
+        pass
+    # find_spec can return None / raise for some stdlib modules under Emscripten
+    # (e.g. os), so fall back to actually importing it.
+    try:
+        importlib.import_module(modname)
+        return True
+    except Exception:
+        return False
+
+
+def _patched_ast_from_module_name(self, modname, *args, **kwargs):
+    try:
+        return _orig_ast_from_module_name(self, modname, *args, **kwargs)
+    except Exception:
+        # astroid couldn't build it (e.g. os -> posix built-in under Emscripten).
+        # If it's genuinely importable here, hand back a stub so we don't emit a
+        # false import-error. Otherwise it's a real miss, so re-raise.
+        if _is_importable(modname):
+            _stubbed_modules.add(modname)
+            return _AstroidBuilder(self).string_build(_STUB_SOURCE, modname=modname)
+        raise
+
+
+_AstroidManager.ast_from_module_name = _patched_ast_from_module_name
 
 
 PYLINT_RC_FILE = os.path.abspath("/tmp/papyros/pylint_config.rc")
 PYLINT_PLUGINS = "pylint_ast_checker,pylint_turtle_brain"
 
 def lint(code):
+    # Packages were just installed (PythonWorker.lintCode installs imports first);
+    # refresh the finder caches so find_spec() sees them in _is_importable().
+    importlib.invalidate_caches()
     # Use temporary file to prevent Astroid cache from running into issues
     with NamedTemporaryFile() as tmpf:
         tmpf.write(bytes(code, encoding="utf-8"))
@@ -37,6 +99,12 @@ def process_pylint_output(linting_output):
             column_nr = int(column_nr)
             # If Pylint doesn't know the exact cause, just omit it
             message = message.replace("(<unknown>, ", "(")
+            # Drop no-name-in-module for modules we had to stub (astroid couldn't
+            # build them, so we can't verify their names -- see the stub hook above).
+            if message.startswith("No name ") and " in module '" in message:
+                stubbed_module = message.rsplit(" in module '", 1)[1].rstrip("'")
+                if stubbed_module in _stubbed_modules:
+                    continue
             diagnostics.append({
                 "lineNr": line_nr,
                 "columnNr": column_nr,

--- a/src/backend/workers/python/papyros/linting.py
+++ b/src/backend/workers/python/papyros/linting.py
@@ -1,17 +1,62 @@
 # Ensure pylint can find the plugin files
 import os
 import sys
+import keyword
+import importlib
 from tempfile import NamedTemporaryFile
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 from io import StringIO
 from pylint.lint import Run
 from pylint.reporters.text import TextReporter
+from astroid.manager import AstroidManager as _AstroidManager
+from astroid.builder import AstroidBuilder as _AstroidBuilder
+
+# Pyodide + astroid: astroid resolves most installed packages fine on its own (so
+# import-error, no-name-in-module and no-member all work), but it can't build a
+# few stdlib modules that are backed by built-ins under Emscripten -- notably
+# `os` (which pulls in `posix`) -- and reports a false "Unable to import 'os'".
+# We let astroid resolve normally and only fall back to a synthetic stub when it
+# fails *and* the module is genuinely importable in this interpreter (Papyros
+# installs the code's imports before linting). A real typo / missing package
+# still raises, so import-error stays accurate.
+#
+# The stub is built from the live module's real `dir()`, so its names are the
+# real names: `from os import asdfjasdlf` still correctly trips no-name-in-module,
+# while `from os import getcwd` doesn't. Each name is assigned from the undefined
+# `_papyros_any`, so astroid infers it as Uninferable and member access / calls on
+# it don't trip false positives. A module-level __getattr__ is kept too, so
+# dynamic attributes that aren't in dir() still don't trip no-member.
+_orig_ast_from_module_name = _AstroidManager.ast_from_module_name
+
+
+def _patched_ast_from_module_name(self, modname, *args, **kwargs):
+    try:
+        return _orig_ast_from_module_name(self, modname, *args, **kwargs)
+    except Exception as astroid_error:
+        # astroid couldn't build it (e.g. os -> posix built-in under Emscripten).
+        # If it's genuinely importable here, stub it from its real names so we
+        # don't emit a false import-error. Otherwise it's a real miss, so
+        # re-raise the original astroid error.
+        try:
+            module = importlib.import_module(modname)
+        except Exception:
+            raise astroid_error
+        names = [n for n in dir(module) if n.isidentifier() and not keyword.iskeyword(n) and not n.startswith("__")]
+        src = "def __getattr__(name): ...\n" + "".join(f"{n} = _papyros_any\n" for n in names)
+        return _AstroidBuilder(self).string_build(src, modname=modname)
+
+
+_AstroidManager.ast_from_module_name = _patched_ast_from_module_name
 
 
 PYLINT_RC_FILE = os.path.abspath("/tmp/papyros/pylint_config.rc")
 PYLINT_PLUGINS = "pylint_ast_checker,pylint_turtle_brain"
 
 def lint(code):
+    # Packages were just installed (PythonWorker.lintCode installs imports first);
+    # refresh the import caches so importlib.import_module() sees them in the
+    # astroid stub-building hook above.
+    importlib.invalidate_caches()
     # Use temporary file to prevent Astroid cache from running into issues
     with NamedTemporaryFile() as tmpf:
         tmpf.write(bytes(code, encoding="utf-8"))

--- a/src/frontend/components/code_mirror/CodeEditor.ts
+++ b/src/frontend/components/code_mirror/CodeEditor.ts
@@ -21,7 +21,7 @@ import {
     completionKeymap,
 } from "@codemirror/autocomplete";
 import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
-import { linter, lintGutter, lintKeymap } from "@codemirror/lint";
+import { linter, lintGutter, lintKeymap, forceLinting } from "@codemirror/lint";
 import { css, CSSResult } from "lit";
 import { javascript } from "@codemirror/lang-javascript";
 import { python } from "@codemirror/lang-python";
@@ -35,8 +35,13 @@ import {
     testLineExtension,
 } from "./Extensions";
 import readOnlyRangesExtension from "codemirror-readonly-ranges";
+import { BackendManager } from "../../../communication/BackendManager";
+import { BackendEventType } from "../../../communication/BackendEvent";
+import { parseData } from "../../../util/Util";
 
 const tabCompletionKeyMap = [{ key: "Tab", run: acceptCompletion }];
+// Dispatched to ask the linter to re-run without a document change (see needsRefresh).
+const forceLintEffect = StateEffect.define<null>();
 const languageExtensions: Record<ProgrammingLanguage, LanguageSupport> = {
     JavaScript: javascript(),
     Python: python(),
@@ -88,6 +93,25 @@ export class CodeEditor extends CodeMirrorEditor {
             debugging: value ? debugLineExtension : [highlightActiveLineGutter(), lintGutter(), highlightActiveLine()],
         });
         this.readonly = value;
+    }
+
+    private reLintOnLoaded = (e: { data: string; contentType?: string }): void => {
+        // The linter resolves imports against the packages installed in the worker,
+        // so code linted while a package is still downloading is wrongly flagged as
+        // "unable to import X". The editor does not re-lint on its own, so when a
+        // package finishes installing, force a re-lint to clear those stale errors.
+        const loadingData = parseData(e.data, e.contentType);
+        if (loadingData.status === "loaded" && this.view) {
+            // forceLinting only runs an already-scheduled lint, so first dispatch
+            // forceLintEffect to schedule one (via the linter's needsRefresh).
+            this.view.dispatch({ effects: forceLintEffect.of(null) });
+            forceLinting(this.view);
+        }
+    };
+
+    public override connectedCallback(): void {
+        super.connectedCallback();
+        BackendManager.subscribe(BackendEventType.Loading, this.reLintOnLoaded);
     }
 
     set debugLine(value: number | undefined) {
@@ -181,6 +205,12 @@ export class CodeEditor extends CodeMirrorEditor {
                     const to = Math.min(toLine.from + d.endColumnNr, toLine.to);
                     return { ...d, from: from, to: to };
                 });
+            }, {
+                // Re-lint when we dispatch forceLintEffect, even though the document
+                // hasn't changed (e.g. after a package finishes installing).
+                needsRefresh: update => update.transactions.some(
+                    tr => tr.effects.some(e => e.is(forceLintEffect))
+                ),
             }),
         });
     }

--- a/src/frontend/components/code_mirror/CodeEditor.ts
+++ b/src/frontend/components/code_mirror/CodeEditor.ts
@@ -21,7 +21,7 @@ import {
     completionKeymap,
 } from "@codemirror/autocomplete";
 import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
-import { linter, lintGutter, lintKeymap } from "@codemirror/lint";
+import { linter, lintGutter, lintKeymap, forceLinting } from "@codemirror/lint";
 import { css, CSSResult } from "lit";
 import { javascript } from "@codemirror/lang-javascript";
 import { python } from "@codemirror/lang-python";
@@ -35,8 +35,13 @@ import {
     testLineExtension,
 } from "./Extensions";
 import readOnlyRangesExtension from "codemirror-readonly-ranges";
+import { BackendManager } from "../../../communication/BackendManager";
+import { BackendEvent, BackendEventType } from "../../../communication/BackendEvent";
+import { parseData } from "../../../util/Util";
 
 const tabCompletionKeyMap = [{ key: "Tab", run: acceptCompletion }];
+// Dispatched to ask the linter to re-run without a document change (see needsRefresh).
+const forceLintEffect = StateEffect.define<null>();
 const languageExtensions: Record<ProgrammingLanguage, LanguageSupport> = {
     JavaScript: javascript(),
     Python: python(),
@@ -88,6 +93,25 @@ export class CodeEditor extends CodeMirrorEditor {
             debugging: value ? debugLineExtension : [highlightActiveLineGutter(), lintGutter(), highlightActiveLine()],
         });
         this.readonly = value;
+    }
+
+    private reLintOnLoaded = (e: BackendEvent): void => {
+        // The linter resolves imports against the packages installed in the worker,
+        // so code linted while a package is still downloading is wrongly flagged as
+        // "unable to import X". The editor does not re-lint on its own, so when a
+        // package finishes installing, force a re-lint to clear those stale errors.
+        const loadingData = parseData(e.data, e.contentType);
+        if (loadingData.status === "loaded" && this.view) {
+            // forceLinting only runs an already-scheduled lint, so first dispatch
+            // forceLintEffect to schedule one (via the linter's needsRefresh).
+            this.view.dispatch({ effects: forceLintEffect.of(null) });
+            forceLinting(this.view);
+        }
+    };
+
+    public override connectedCallback(): void {
+        super.connectedCallback();
+        BackendManager.subscribe(BackendEventType.Loading, this.reLintOnLoaded);
     }
 
     set debugLine(value: number | undefined) {
@@ -164,24 +188,34 @@ export class CodeEditor extends CodeMirrorEditor {
 
     set lintingSource(lintSource: () => Promise<readonly WorkerDiagnostic[]>) {
         this.configure({
-            linting: linter(async (view) => {
-                const workerDiagnostics = await lintSource();
-                if (
-                    workerDiagnostics.some((d) => d.lineNr > view.state.doc.lines || d.endLineNr > view.state.doc.lines)
-                ) {
-                    // if the diagnostics are out of range, the document has changed since the linting was requested
-                    // these diagnostics are no longer valid
-                    return [];
-                }
+            linting: linter(
+                async (view) => {
+                    const workerDiagnostics = await lintSource();
+                    if (
+                        workerDiagnostics.some(
+                            (d) => d.lineNr > view.state.doc.lines || d.endLineNr > view.state.doc.lines,
+                        )
+                    ) {
+                        // if the diagnostics are out of range, the document has changed since the linting was requested
+                        // these diagnostics are no longer valid
+                        return [];
+                    }
 
-                return workerDiagnostics.map((d) => {
-                    const fromline = view.state.doc.line(d.lineNr);
-                    const toLine = view.state.doc.line(d.endLineNr);
-                    const from = Math.min(fromline.from + d.columnNr, fromline.to);
-                    const to = Math.min(toLine.from + d.endColumnNr, toLine.to);
-                    return { ...d, from: from, to: to };
-                });
-            }),
+                    return workerDiagnostics.map((d) => {
+                        const fromline = view.state.doc.line(d.lineNr);
+                        const toLine = view.state.doc.line(d.endLineNr);
+                        const from = Math.min(fromline.from + d.columnNr, fromline.to);
+                        const to = Math.min(toLine.from + d.endColumnNr, toLine.to);
+                        return { ...d, from: from, to: to };
+                    });
+                },
+                {
+                    // Re-lint when we dispatch forceLintEffect, even though the document
+                    // hasn't changed (e.g. after a package finishes installing).
+                    needsRefresh: (update) =>
+                        update.transactions.some((tr) => tr.effects.some((e) => e.is(forceLintEffect))),
+                },
+            ),
         });
     }
 

--- a/test/__tests__/state/Runner.test.ts
+++ b/test/__tests__/state/Runner.test.ts
@@ -71,13 +71,35 @@ const c = a + b;`;
         expect(Array.isArray(diagnostics)).toBe(true);
     }, 60000);
 
-    it("should lint code that uses pandas without hanging", async () => {
+    it("should lint code that uses pandas without hanging or a false import-error", async () => {
         const papyros = new Papyros();
         await papyros.launch();
         papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
         papyros.runner.code = "import pandas as pd\ndf = pd.DataFrame({'a': [1, 2, 3]})\n";
         const diagnostics = await papyros.runner.lintSource();
         expect(Array.isArray(diagnostics)).toBe(true);
+        // pandas is installed before linting, so it must not be flagged as unimportable
+        expect(diagnostics.some(d => /import-error|Unable to import/.test(d.message))).toBe(false);
+    }, 60000);
+
+    it("should report an import-error for a genuinely missing module", async () => {
+        const papyros = new Papyros();
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+        papyros.runner.code = "import this_module_truly_does_not_exist_xyz\n";
+        const diagnostics = await papyros.runner.lintSource();
+        expect(diagnostics.some(d => /import-error|Unable to import/.test(d.message))).toBe(true);
+    }, 60000);
+
+    it("should not flag stdlib modules astroid cannot build (os) as unimportable", async () => {
+        // astroid can't build `os` under Emscripten (it pulls in the posix built-in),
+        // which used to surface as a false "Unable to import 'os'".
+        const papyros = new Papyros();
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+        papyros.runner.code = "import os\nfrom os import getcwd\nprint(os.getcwd(), getcwd())\n";
+        const diagnostics = await papyros.runner.lintSource();
+        expect(diagnostics.some(d => /import-error|Unable to import|No name '.*' in module 'os'/.test(d.message))).toBe(false);
     }, 60000);
 
     it("should be able to handle sleep", async () => {

--- a/test/__tests__/state/Runner.test.ts
+++ b/test/__tests__/state/Runner.test.ts
@@ -104,13 +104,46 @@ const c = a + b;`;
         expect(Array.isArray(diagnostics)).toBe(true);
     }, 60000);
 
-    it("should lint code that uses pandas without hanging", async () => {
+    it("should lint code that uses pandas without hanging or a false import-error", async () => {
         const papyros = new Papyros();
         await papyros.launch();
         papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
         papyros.runner.code = "import pandas as pd\ndf = pd.DataFrame({'a': [1, 2, 3]})\n";
         const diagnostics = await papyros.runner.lintSource();
         expect(Array.isArray(diagnostics)).toBe(true);
+        // pandas is installed before linting, so it must not be flagged as unimportable
+        expect(diagnostics.some((d) => /import-error|Unable to import/.test(d.message))).toBe(false);
+    }, 60000);
+
+    it("should report an import-error for a genuinely missing module", async () => {
+        const papyros = new Papyros();
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+        papyros.runner.code = "import this_module_truly_does_not_exist_xyz\n";
+        const diagnostics = await papyros.runner.lintSource();
+        expect(diagnostics.some((d) => /import-error|Unable to import/.test(d.message))).toBe(true);
+    }, 60000);
+
+    it("should not flag stdlib modules astroid cannot build (os) as unimportable", async () => {
+        // astroid can't build `os` under Emscripten (it pulls in the posix built-in),
+        // which used to surface as a false "Unable to import 'os'".
+        const papyros = new Papyros();
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+        papyros.runner.code = "import os\nfrom os import getcwd\nprint(os.getcwd(), getcwd())\n";
+        const diagnostics = await papyros.runner.lintSource();
+        expect(
+            diagnostics.some((d) => /import-error|Unable to import|No name '.*' in module 'os'/.test(d.message)),
+        ).toBe(false);
+    }, 60000);
+
+    it("should report a wrong name imported from a stubbed stdlib module (os)", async () => {
+        const papyros = new Papyros();
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+        papyros.runner.code = "from os import asdfjasdlf\n";
+        const diagnostics = await papyros.runner.lintSource();
+        expect(diagnostics.some((d) => /No name 'asdfjasdlf' in module 'os'/.test(d.message))).toBe(true);
     }, 60000);
 
     it("should be able to handle sleep", async () => {


### PR DESCRIPTION
The linter reported false "Unable to import X" errors for packages that Papyros installs and runs fine. It looked pandas-specific, but it's not: stdlib `os` is flagged too (it already is on `main`). Three independent causes, fixed here so any importable module lints cleanly while genuine mistakes are still caught.

The issues we're solving (left: main, right: this branch):

`os` is not imported correctly:

https://github.com/user-attachments/assets/77f1fdaf-1204-41a8-917b-4c609ebe0400

Attribution of import errors:

https://github.com/user-attachments/assets/e279205e-67fa-4f35-a2bc-7486b5336907

The chain of imports overriding one another, causing modules not to get loaded if they are triggered to get loaded when another package is being loaded:

https://github.com/user-attachments/assets/2319edd8-446b-40d7-95de-9dcbadd8a789

### Why it happened
Pylint runs in the Pyodide worker and resolves imports against the packages installed there. Two timing problems meant packages weren't installed when the lint ran, and one resolution problem meant a couple of stdlib modules can't be analysed by astroid at all.

### What changed
**1. Resolution** (`linting.py`)
astroid resolves most installed packages fine (so E0611/no-member work), but can't build a few stdlib modules backed by Emscripten built-ins (notably `os`, via `posix`) and reported a false import-error. We now let astroid resolve normally and only fall back to a synthetic stub when it fails *and* the module is genuinely importable; a real typo/missing package still raises. The stub is generated from the live module's `dir()`, so it carries the module's real names: `from os import getcwd` is clean, `from os import asdfjasdlf` still trips `no-name-in-module`, and member access on stubbed names stays quiet because their values are Uninferable. E0611/no-member stay enabled everywhere.

**2. Install timing** (`PythonWorker.installImports`)
Installs shared a single promise, so a lint could ride on an install started for different code (e.g. the editor's empty initial buffer) and lint the real code with its imports still missing. Installs are now chained so each call installs its own code's imports.

**3. Re-lint on load** (`CodeEditor`)
The editor never re-linted once packages finished downloading, so an import-error shown while a package was still installing stayed until the next edit. It now re-lints when a package finishes loading, via a `forceLintEffect` the linter's `needsRefresh` picks up (plain `forceLinting` no-ops on an unchanged doc).

### Testing
`yarn setup && yarn start`, then in a fresh browser:
- `import pandas as pd` / `pd.DataFrame(...)`, `import os` / `from os import getcwd`, `import matplotlib.pyplot` etc. lint clean.
- `from pandas import Typo`, `from math import sqrtt`, `from os import asdfjasdlf`, `import not_a_real_pkg`, and member mistakes on your own classes are still flagged.
- The last one is the hardest one to verify, what I did:
  - Disable cache, set network to Fast 4G, reload on an empty editor
  - Add `import networkx as nx` and wait until you see the hint "Loading networkx"
  - Then add "import pandas" and wait until the linter runs (takes a while!)
  - On main, pandas should throw an import error, while on the fixed branch, it should just mention unused

`Runner.test.ts` covers: pandas/os lint clean, wrong name from a stubbed module (os) flagged, genuinely missing module still reports import-error.

<details><summary>Note on the resolution trade-off</summary>

For the few modules astroid can't build (os and similar built-in-backed stdlib), the stub knows the module's names but not their types: a wrong top-level name (`from os import <typo>`) is caught, but attribute chains through them (e.g. `os.environ.gett(...)`) aren't checkable. Everything astroid can analyse keeps full checking.
</details>

