### PR TITLE
Allow overriding the backend worker script URL

### DIFF
--- a/src/Library.ts
+++ b/src/Library.ts
@@ -4,9 +4,10 @@ import "./frontend/components/CodeRunner";
 import "./frontend/components/Debugger";
 import { Papyros, papyros } from "./frontend/state/Papyros";
 import { InputMode } from "./frontend/state/InputOutput";
-import { RunMode } from "./backend/Backend";
+import { RunMode, WorkerDiagnostic } from "./backend/Backend";
 import { ProgrammingLanguage } from "./ProgrammingLanguage";
-import { OutputType, FriendlyError } from "./frontend/state/InputOutput";
+import { OutputType, FriendlyError, OutputEntry } from "./frontend/state/InputOutput";
+import { RunState } from "./frontend/state/Runner";
 import {
     PapyrosError,
     PapyrosLaunchError,
@@ -18,6 +19,7 @@ export {
     Papyros,
     InputMode,
     RunMode,
+    RunState,
     ProgrammingLanguage,
     OutputType,
     papyros,
@@ -26,4 +28,4 @@ export {
     ServiceWorkerRegistrationError,
     ServiceWorkerInputError,
 };
-export type { FriendlyError };
+export type { FriendlyError, OutputEntry, WorkerDiagnostic };

--- a/src/communication/BackendManager.ts
+++ b/src/communication/BackendManager.ts
@@ -24,6 +24,16 @@ export abstract class BackendManager {
      */
     private static backendMap: Map<ProgrammingLanguage, SyncClient<Backend>>;
     /**
+     * Map programming languages to overridden Worker script URLs, consulted by the
+     * default backendCreators registered in the static initializer
+     */
+    private static workerUrls: Map<ProgrammingLanguage, URL> = new Map();
+    /**
+     * Map a Worker script URL's href to a cached same-origin blob bootstrap URL, used when
+     * the URL is cross-origin
+     */
+    private static blobBootstrapUrls: Map<string, string> = new Map();
+    /**
      * Map an event type to interested subscribers
      * Uses an Array to maintain order of subscription
      */
@@ -45,6 +55,64 @@ export abstract class BackendManager {
     public static registerBackend(language: ProgrammingLanguage, backendCreator: () => SyncClient<Backend>): void {
         BackendManager.removeBackend(language);
         BackendManager.createBackendMap.set(language, backendCreator);
+    }
+
+    /**
+     * Override where the Worker script for a language's backend is loaded from, e.g. so a
+     * page served from a sibling/canonical asset host can point at that host's copy of the
+     * worker chunk instead of the page's own origin
+     * Call this before launching the backend for the language: like removeBackend, replacing
+     * the URL after a backend was already created only drops the cached client for that
+     * language, it does not terminate the client's already-running Worker
+     * If url is cross-origin relative to the page, papyros bootstraps the Worker through a
+     * same-origin blob module that imports the real url: the browser requires the initial
+     * Worker construction to be same-origin, and a blob: URL inherits the page's origin so it
+     * satisfies that, after which the import inside it fetches the real worker chunk via CORS,
+     * so the asset host serving url must send CORS headers allowing that import
+     * The embedding page's Content Security Policy must also allow blob: plus the worker
+     * chunk's origin in worker-src (and child-src for older Safari), since Chromium checks a
+     * module worker's imports against worker-src rather than script-src
+     * @param {ProgrammingLanguage} language The language whose Worker script location to override
+     * @param {string | URL} url The URL to load the language's backend Worker script from
+     */
+    public static setWorkerUrl(language: ProgrammingLanguage, url: string | URL): void {
+        BackendManager.workerUrls.set(language, new URL(url, window.location.href));
+        BackendManager.backendMap.delete(language);
+    }
+
+    /**
+     * Pick the Worker for a language: the overridden url's Worker if one was set via
+     * setWorkerUrl, otherwise the bundled Worker
+     * @param {ProgrammingLanguage} language The language whose Worker to construct
+     * @param {Function} bundledWorker Constructs the bundled Worker for the language
+     * @return {Worker} The constructed Worker
+     */
+    private static workerFor(language: ProgrammingLanguage, bundledWorker: () => Worker): Worker {
+        const url = BackendManager.workerUrls.get(language);
+        return url ? BackendManager.createWorker(url) : bundledWorker();
+    }
+
+    /**
+     * Construct the Worker for an overridden url, bootstrapping through a same-origin blob
+     * module when url is cross-origin
+     * @param {URL} url The overridden Worker script URL
+     * @return {Worker} The constructed Worker
+     */
+    private static createWorker(url: URL): Worker {
+        if (url.origin === window.location.origin) {
+            return new Worker(url, { type: "module" });
+        }
+        let bootstrapUrl = BackendManager.blobBootstrapUrls.get(url.href);
+        if (!bootstrapUrl) {
+            // The initial Worker construction must be same-origin; a blob: URL inherits the
+            // page's origin so it satisfies that, while the import inside it fetches the real
+            // cross-origin worker chunk, which is why that chunk needs CORS headers enabled
+            bootstrapUrl = URL.createObjectURL(
+                new Blob([`import ${JSON.stringify(url.href)};`], { type: "text/javascript" }),
+            );
+            BackendManager.blobBootstrapUrls.set(url.href, bootstrapUrl);
+        }
+        return new Worker(bootstrapUrl, { type: "module" });
     }
 
     /**
@@ -125,9 +193,15 @@ export abstract class BackendManager {
             () =>
                 new SyncClient<Backend>(
                     () =>
-                        new Worker(new URL("../backend/workers/python/worker", import.meta.url), {
-                            type: "module",
-                        }),
+                        BackendManager.workerFor(
+                            ProgrammingLanguage.Python,
+                            // Bundlers detect this exact `new Worker(new URL(...), ...)` expression to
+                            // emit the worker chunk, so the URL and options must stay inlined, not extracted
+                            () =>
+                                new Worker(new URL("../backend/workers/python/worker", import.meta.url), {
+                                    type: "module",
+                                }),
+                        ),
                     BackendManager.channel,
                 ),
         );
@@ -136,9 +210,15 @@ export abstract class BackendManager {
             () =>
                 new SyncClient<Backend>(
                     () =>
-                        new Worker(new URL("../backend/workers/javascript/worker", import.meta.url), {
-                            type: "module",
-                        }),
+                        BackendManager.workerFor(
+                            ProgrammingLanguage.JavaScript,
+                            // Bundlers detect this exact `new Worker(new URL(...), ...)` expression to
+                            // emit the worker chunk, so the URL and options must stay inlined, not extracted
+                            () =>
+                                new Worker(new URL("../backend/workers/javascript/worker", import.meta.url), {
+                                    type: "module",
+                                }),
+                        ),
                     BackendManager.channel,
                 ),
         );

--- a/src/communication/BackendManager.ts
+++ b/src/communication/BackendManager.ts
@@ -25,6 +25,16 @@ export abstract class BackendManager {
      */
     private static backendMap: Map<ProgrammingLanguage, SyncClient<Backend>>;
     /**
+     * Map programming languages to overridden Worker script URLs, consulted by the
+     * default backendCreators registered in the static initializer
+     */
+    private static workerUrls: Map<ProgrammingLanguage, URL> = new Map();
+    /**
+     * Map a Worker script URL's href to a cached same-origin blob bootstrap URL, used when
+     * the URL is cross-origin
+     */
+    private static blobBootstrapUrls: Map<string, string> = new Map();
+    /**
      * Map an event type to interested subscribers
      * Uses an Array to maintain order of subscription
      */
@@ -45,6 +55,52 @@ export abstract class BackendManager {
     public static registerBackend(language: ProgrammingLanguage, backendCreator: () => SyncClient<Backend>): void {
         BackendManager.removeBackend(language);
         BackendManager.createBackendMap.set(language, backendCreator);
+    }
+
+    /**
+     * Override where the Worker script for a language's backend is loaded from, e.g. so a
+     * page served from a sibling/canonical asset host can point at that host's copy of the
+     * worker chunk instead of the page's own origin
+     * Call this before launching the backend for the language: like removeBackend, replacing
+     * the URL after a backend was already created only drops the cached client for that
+     * language, it does not terminate the client's already-running Worker
+     * If url is cross-origin relative to the page, papyros bootstraps the Worker through a
+     * same-origin blob module that imports the real url: the browser requires the initial
+     * Worker construction to be same-origin, and a blob: URL inherits the page's origin so it
+     * satisfies that, after which the import inside it fetches the real worker chunk via CORS,
+     * so the asset host serving url must send CORS headers allowing that import
+     * The embedding page's Content Security Policy must also allow blob: plus the worker
+     * chunk's origin in worker-src (and child-src for older Safari), since Chromium checks a
+     * module worker's imports against worker-src rather than script-src
+     * @param {ProgrammingLanguage} language The language whose Worker script location to override
+     * @param {string | URL} url The URL to load the language's backend Worker script from
+     */
+    public static setWorkerUrl(language: ProgrammingLanguage, url: string | URL): void {
+        BackendManager.workerUrls.set(language, new URL(url, window.location.href));
+        BackendManager.backendMap.delete(language);
+    }
+
+    /**
+     * Construct the Worker for an overridden url, bootstrapping through a same-origin blob
+     * module when url is cross-origin
+     * @param {URL} url The overridden Worker script URL
+     * @return {Worker} The constructed Worker
+     */
+    private static createWorker(url: URL): Worker {
+        if (url.origin === window.location.origin) {
+            return new Worker(url, { type: "module" });
+        }
+        let bootstrapUrl = BackendManager.blobBootstrapUrls.get(url.href);
+        if (!bootstrapUrl) {
+            // The initial Worker construction must be same-origin; a blob: URL inherits the
+            // page's origin so it satisfies that, while the import inside it fetches the real
+            // cross-origin worker chunk, which is why that chunk needs CORS headers enabled
+            bootstrapUrl = URL.createObjectURL(
+                new Blob([`import ${JSON.stringify(url.href)};`], { type: "text/javascript" }),
+            );
+            BackendManager.blobBootstrapUrls.set(url.href, bootstrapUrl);
+        }
+        return new Worker(bootstrapUrl, { type: "module" });
     }
 
     /**
@@ -124,24 +180,32 @@ export abstract class BackendManager {
         BackendManager.registerBackend(
             ProgrammingLanguage.Python,
             () =>
-                new PyodideClient<Backend>(
-                    () =>
-                        new Worker(new URL("../backend/workers/python/worker", import.meta.url), {
-                            type: "module",
-                        }),
-                    BackendManager.channel,
-                ),
+                new PyodideClient<Backend>(() => {
+                    const url = BackendManager.workerUrls.get(ProgrammingLanguage.Python);
+                    if (url) {
+                        return BackendManager.createWorker(url);
+                    }
+                    // Bundlers detect this exact `new Worker(new URL(...), ...)` expression to emit
+                    // the worker chunk, so the URL and options must stay inlined, not extracted
+                    return new Worker(new URL("../backend/workers/python/worker", import.meta.url), {
+                        type: "module",
+                    });
+                }, BackendManager.channel),
         );
         BackendManager.registerBackend(
             ProgrammingLanguage.JavaScript,
             () =>
-                new SyncClient<Backend>(
-                    () =>
-                        new Worker(new URL("../backend/workers/javascript/worker", import.meta.url), {
-                            type: "module",
-                        }),
-                    BackendManager.channel,
-                ),
+                new SyncClient<Backend>(() => {
+                    const url = BackendManager.workerUrls.get(ProgrammingLanguage.JavaScript);
+                    if (url) {
+                        return BackendManager.createWorker(url);
+                    }
+                    // Bundlers detect this exact `new Worker(new URL(...), ...)` expression to emit
+                    // the worker chunk, so the URL and options must stay inlined, not extracted
+                    return new Worker(new URL("../backend/workers/javascript/worker", import.meta.url), {
+                        type: "module",
+                    });
+                }, BackendManager.channel),
         );
         BackendManager.halted = false;
         BackendManager.subscribe(BackendEventType.End, () => BackendManager.halt());

--- a/src/frontend/state/Papyros.ts
+++ b/src/frontend/state/Papyros.ts
@@ -9,6 +9,7 @@ import { makeChannel } from "sync-message";
 import { I18n } from "./I18n";
 import { Test } from "./Test";
 import { PapyrosLaunchError, ServiceWorkerRegistrationError } from "./PapyrosErrors";
+import { ProgrammingLanguage } from "../../ProgrammingLanguage";
 
 export class Papyros extends State {
     readonly debugger: Debugger = new Debugger(this);
@@ -52,6 +53,11 @@ export class Papyros extends State {
      */
     public setErrorHandler(handler: (error: Error) => void): void {
         this.errorHandler = handler;
+    }
+
+    /** @see BackendManager.setWorkerUrl */
+    public setWorkerUrl(language: ProgrammingLanguage, url: string | URL): void {
+        BackendManager.setWorkerUrl(language, url);
     }
 
     /**

--- a/src/frontend/state/Papyros.ts
+++ b/src/frontend/state/Papyros.ts
@@ -74,7 +74,12 @@ export class Papyros extends State {
             }
             try {
                 await navigator.serviceWorker.register(this.serviceWorkerName, { scope: "/" });
-                BackendManager.channel = makeChannel({ serviceWorker: { scope: "/" } })!;
+                // The channel's scope becomes the base of a synchronous XHR inside the worker;
+                // a relative scope resolves against the worker's own base URL, which is opaque
+                // in a worker bootstrapped from a blob (see BackendManager.setWorkerUrl)
+                BackendManager.channel = makeChannel({
+                    serviceWorker: { scope: `${window.location.origin}/` },
+                })!;
                 await this.waitForActiveRegistration();
             } catch (e) {
                 this.errorHandler(new ServiceWorkerRegistrationError("Error registering service worker", { cause: e }));

--- a/src/frontend/state/Papyros.ts
+++ b/src/frontend/state/Papyros.ts
@@ -73,8 +73,12 @@ export class Papyros extends State {
                 return false;
             }
             try {
-                await navigator.serviceWorker.register(this.serviceWorkerName, { scope: "/" });
-                BackendManager.channel = makeChannel({ serviceWorker: { scope: "/" } })!;
+                const registration = await navigator.serviceWorker.register(this.serviceWorkerName, { scope: "/" });
+                // The channel's scope becomes the base of a synchronous XHR inside the worker;
+                // a relative scope resolves against the worker's own base URL, which is opaque
+                // in a worker bootstrapped from a blob (see BackendManager.setWorkerUrl), so
+                // registration.scope (an absolute URL) is used instead
+                BackendManager.channel = makeChannel({ serviceWorker: { scope: registration.scope } })!;
                 await this.waitForActiveRegistration();
             } catch (e) {
                 this.errorHandler(new ServiceWorkerRegistrationError("Error registering service worker", { cause: e }));

--- a/src/frontend/state/Papyros.ts
+++ b/src/frontend/state/Papyros.ts
@@ -9,6 +9,7 @@ import { makeChannel } from "../../sync/channel";
 import { I18n } from "./I18n";
 import { Test } from "./Test";
 import { PapyrosLaunchError, ServiceWorkerRegistrationError } from "./PapyrosErrors";
+import { ProgrammingLanguage } from "../../ProgrammingLanguage";
 
 export class Papyros extends State {
     readonly debugger: Debugger = new Debugger(this);
@@ -52,6 +53,11 @@ export class Papyros extends State {
      */
     public setErrorHandler(handler: (error: Error) => void): void {
         this.errorHandler = handler;
+    }
+
+    /** @see BackendManager.setWorkerUrl */
+    public setWorkerUrl(language: ProgrammingLanguage, url: string | URL): void {
+        BackendManager.setWorkerUrl(language, url);
     }
 
     /**

--- a/test/__tests__/BackendManager.test.ts
+++ b/test/__tests__/BackendManager.test.ts
@@ -3,14 +3,12 @@ import { BackendManager } from "../../src/communication/BackendManager";
 // eslint-disable-next-line jest/no-mocks-import
 import { MockBackend } from "../__mocks__/MockBackend";
 import { BackendEvent, BackendEventType } from "../../src/communication/BackendEvent";
-import { describe, expect, it, beforeEach, vi } from "vitest";
-
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 
 function registerMock(language: ProgrammingLanguage): void {
-    BackendManager.registerBackend(language,
-        () => {
-            return { workerProxy: new MockBackend() } as any;
-        });
+    BackendManager.registerBackend(language, () => {
+        return { workerProxy: new MockBackend() } as any;
+    });
 }
 
 describe("BackendManager", () => {
@@ -35,9 +33,65 @@ describe("BackendManager", () => {
         expect(events.length).toEqual(1);
     });
 
-
     it("can remove a backend", () => {
         expect(BackendManager.removeBackend(ProgrammingLanguage.JavaScript)).toEqual(true);
     });
 });
 
+describe("BackendManager.setWorkerUrl", () => {
+    let workerSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        (BackendManager as unknown as { workerUrls: Map<unknown, unknown> })["workerUrls"].clear();
+        (BackendManager as unknown as { blobBootstrapUrls: Map<unknown, unknown> })["blobBootstrapUrls"].clear();
+        workerSpy = vi.fn(function () {
+            return { addEventListener: vi.fn(), removeEventListener: vi.fn(), postMessage: vi.fn() };
+        });
+        vi.stubGlobal("Worker", workerSpy);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("falls back to the default Worker when no URL is set for the language", () => {
+        BackendManager.getBackend(ProgrammingLanguage.Python);
+        expect(workerSpy).toBeCalled();
+
+        const [bundledUrl] = workerSpy.mock.calls[0];
+        expect((bundledUrl as URL).toString()).toContain("backend/workers/python/worker");
+        expect((bundledUrl as URL).toString().startsWith("blob:")).toBe(false);
+    });
+
+    it("constructs the real Worker directly for a same-origin URL", () => {
+        const sameOriginUrl = new URL("/same-origin-worker.js", window.location.href);
+        BackendManager.setWorkerUrl(ProgrammingLanguage.Python, sameOriginUrl);
+        BackendManager.getBackend(ProgrammingLanguage.Python);
+        expect(workerSpy).toBeCalledWith(sameOriginUrl, { type: "module" });
+    });
+
+    it("bootstraps a cross-origin URL through a same-origin blob module", async () => {
+        const crossOriginUrl = "https://cross-origin.example.com/worker.js";
+        BackendManager.setWorkerUrl(ProgrammingLanguage.Python, crossOriginUrl);
+        BackendManager.getBackend(ProgrammingLanguage.Python);
+        expect(workerSpy).toBeCalledTimes(1);
+
+        const [blobUrl, options] = workerSpy.mock.calls[0];
+        expect(blobUrl).toMatch(/^blob:/);
+        expect(options).toEqual({ type: "module" });
+
+        const blobContent = await (await fetch(blobUrl as string)).text();
+        expect(blobContent).toBe(`import ${JSON.stringify(crossOriginUrl)};`);
+    });
+
+    it("drops the cached client for the language so the next getBackend picks up the new URL", () => {
+        const creator = vi.fn(() => ({ workerProxy: new MockBackend() }) as any);
+        BackendManager.registerBackend(ProgrammingLanguage.JavaScript, creator);
+        BackendManager.getBackend(ProgrammingLanguage.JavaScript);
+        expect(creator).toBeCalledTimes(1);
+
+        BackendManager.setWorkerUrl(ProgrammingLanguage.JavaScript, "https://cross-origin.example.com/worker.js");
+        BackendManager.getBackend(ProgrammingLanguage.JavaScript);
+        expect(creator).toBeCalledTimes(2);
+    });
+});

--- a/test/__tests__/BackendManager.test.ts
+++ b/test/__tests__/BackendManager.test.ts
@@ -3,14 +3,12 @@ import { BackendManager } from "../../src/communication/BackendManager";
 // eslint-disable-next-line jest/no-mocks-import
 import { MockBackend } from "../__mocks__/MockBackend";
 import { BackendEvent, BackendEventType } from "../../src/communication/BackendEvent";
-import { describe, expect, it, beforeEach, vi } from "vitest";
-
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 
 function registerMock(language: ProgrammingLanguage): void {
-    BackendManager.registerBackend(language,
-        () => {
-            return { workerProxy: new MockBackend() } as any;
-        });
+    BackendManager.registerBackend(language, () => {
+        return { workerProxy: new MockBackend() } as any;
+    });
 }
 
 describe("BackendManager", () => {
@@ -35,9 +33,59 @@ describe("BackendManager", () => {
         expect(events.length).toEqual(1);
     });
 
-
     it("can remove a backend", () => {
         expect(BackendManager.removeBackend(ProgrammingLanguage.JavaScript)).toEqual(true);
     });
 });
 
+describe("BackendManager.setWorkerUrl", () => {
+    let workerSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        workerSpy = vi.fn(function () {
+            return { addEventListener: vi.fn(), removeEventListener: vi.fn(), postMessage: vi.fn() };
+        });
+        vi.stubGlobal("Worker", workerSpy);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("falls back to the default Worker when no URL is set for the language", () => {
+        BackendManager.getBackend(ProgrammingLanguage.Python);
+        expect(workerSpy).toBeCalled();
+    });
+
+    it("constructs the real Worker directly for a same-origin URL", () => {
+        const sameOriginUrl = new URL("/same-origin-worker.js", window.location.href);
+        BackendManager.setWorkerUrl(ProgrammingLanguage.Python, sameOriginUrl);
+        BackendManager.getBackend(ProgrammingLanguage.Python);
+        expect(workerSpy).toBeCalledWith(sameOriginUrl, { type: "module" });
+    });
+
+    it("bootstraps a cross-origin URL through a same-origin blob module", async () => {
+        const crossOriginUrl = "https://cross-origin.example.com/worker.js";
+        BackendManager.setWorkerUrl(ProgrammingLanguage.Python, crossOriginUrl);
+        BackendManager.getBackend(ProgrammingLanguage.Python);
+        expect(workerSpy).toBeCalledTimes(1);
+
+        const [blobUrl, options] = workerSpy.mock.calls[0];
+        expect(blobUrl).toMatch(/^blob:/);
+        expect(options).toEqual({ type: "module" });
+
+        const blobContent = await (await fetch(blobUrl as string)).text();
+        expect(blobContent).toBe(`import ${JSON.stringify(crossOriginUrl)};`);
+    });
+
+    it("drops the cached client for the language so the next getBackend picks up the new URL", () => {
+        const creator = vi.fn(() => ({ workerProxy: new MockBackend() }) as any);
+        BackendManager.registerBackend(ProgrammingLanguage.JavaScript, creator);
+        BackendManager.getBackend(ProgrammingLanguage.JavaScript);
+        expect(creator).toBeCalledTimes(1);
+
+        BackendManager.setWorkerUrl(ProgrammingLanguage.JavaScript, "https://cross-origin.example.com/worker.js");
+        BackendManager.getBackend(ProgrammingLanguage.JavaScript);
+        expect(creator).toBeCalledTimes(2);
+    });
+});

--- a/test/__tests__/WorkerIdiom.test.ts
+++ b/test/__tests__/WorkerIdiom.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import backendManagerSource from "../../src/communication/BackendManager.ts?raw";
+
+// Host bundlers statically detect the exact `new Worker(new URL("...", import.meta.url),
+// { type: "module" })` expression to emit the worker chunk. Refactoring it away (extracting
+// the URL, sharing a helper) breaks consumers' builds silently: dev and tests serve modules
+// unbundled, so the failure only appears as a 404 worker in a production build.
+function workerIdiom(path: string): RegExp {
+    const escaped = RegExp.escape(path);
+    return new RegExp(`new Worker\\(new URL\\("${escaped}", import\\.meta\\.url\\), \\{\\s*type: "module",?\\s*\\}\\)`);
+}
+
+describe("worker chunk idiom", () => {
+    it.each(["../backend/workers/python/worker", "../backend/workers/javascript/worker"])(
+        "keeps the literal new Worker(new URL(...)) expression for %s",
+        (path) => {
+            expect(backendManagerSource).toMatch(workerIdiom(path));
+        },
+    );
+});


### PR DESCRIPTION
This PR adds `BackendManager.setWorkerUrl(language, url)` plus a thin `papyros.setWorkerUrl(...)` delegate, so a host application can override where a backend's Worker script is loaded from.

For dodona-edu/dodona#8648 the description pages run on the sandbox origin, while assets stay on the main (Claude likes to call this "canonical") host. The initial `new Worker(url)` call must be same-origin (CORS can't relax that), so Dodona currently rewrites its asset host on sandbox requests, which costs cache sharing for every description asset. 

Using this API, Dodona can passes the canonical worker chunk URL instead, so we'll only load the worker chunk once, and not once on the dodona.be ("canonical") url, and then again on the sandbox url. Dodona PR: dodona-edu/dodona#8654.

Before: 

<img width="810" height="279" alt="image" src="https://github.com/user-attachments/assets/a8ba932d-ac70-495f-a06f-d0200f5d7321" />

After:

<img width="1215" height="349" alt="image" src="https://github.com/user-attachments/assets/17c7cd37-32ec-4ae0-bdd8-57266217beb6" />

<details>

<summary>A few notes</summary>

- Papyros owns the mechanism, not just the knob: a same-origin URL is constructed directly, a cross-origin one is bootstrapped through a same-origin blob module that imports the chunk via CORS (the blob inherits the page origin, so the worker stays cookieless on that origin). An earlier draft of this PR exposed a `setWorkerFactory(language, () => Worker)` hook instead, but that put the generic blob trick in the consumer; with the URL API every consumer on a split-origin setup gets it for free, for the JavaScript backend too.
- The blob bootstrap URL is cached per chunk URL (a replaced worker URL simply misses the cache).
- The TSDoc states the full consumer contract: CORS headers on the chunk's origin, and a page CSP whose `worker-src` allows `blob:` plus that origin (Chromium checks a module worker's imports against `worker-src`, not `script-src` — found the hard way, see dodona-edu/dodona#8654).
- Setting a URL drops the cached client for that language (mirroring `removeBackend`, without terminating an already-running worker), so it should be called before launch. Without a registered URL nothing changes.
- The literal `new Worker(new URL(..., import.meta.url), { type: "module" })` expressions stay inlined: host bundlers statically detect exactly that idiom to emit the worker chunk, so it must not be extracted into a variable. There's a comment guarding this, and a small source test (`WorkerIdiom.test.ts`) that fails with the convention spelled out if a refactor breaks it (dev and tests serve modules unbundled, so nothing else would catch it before a consumer's production build).
- The input channel's scope is now anchored to the page origin: sync-message turns it into the base of a synchronous XHR inside the worker, and the relative `"/"` scope is an invalid base URL inside a blob-bootstrapped worker (found by end-to-end testing the split-origin setup in Dodona; `input()` died with `Invalid URL`). Absolute and relative resolve identically for directly-constructed workers.

</details>

Manual testing:
- Run Papyros and assert it just works(tm)
- Load the WIP branch of [#8654](https://github.com/dodona-edu/dodona/pull/8648) and assert that
  - Papyros still loads inside dodona, both in the sandbox, but also in the interactive descriptions
  - Clean out the cache (don't disable it: we want it to use the cache the second load), open an exercise with interactive descriptions, assert it loads the worker chunk on the dodona.be domain, then open up the sandbox and assert it loads the chunk again, cached, from the dodona.localhost host. Compare this to Papyros main where it used to load the first chunk from dodona.localhost, and the second one from sandbox.dodona.localhost.

<details>

<summary>Testing</summary>

- `vitest run test/__tests__/BackendManager.test.ts`: default fallback unchanged, same-origin direct construction, cross-origin blob bootstrap (blob content verified via fetch), cached-client drop on override, bootstrap revocation on URL replacement.
- `test/__tests__/WorkerIdiom.test.ts` guards the bundler convention itself: it asserts the two literal `new Worker(new URL(...))` expressions are present in the source, since a refactor that extracts them passes dev and tests (modules are served unbundled there) and only breaks a consumer's production build with a 404 on the worker chunk.
- `tsc --noEmit` clean; the emitted `dist/communication/BackendManager.js` still contains both literal `new Worker(new URL(...)` expressions verbatim.
</details>