### PR TITLE
Add a manual pre-release publish workflow

### DIFF
--- a/.github/workflows/publish-prerelease.yaml
+++ b/.github/workflows/publish-prerelease.yaml
@@ -1,0 +1,54 @@
+name: Publish pre-release on NPM
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Pre-release version to publish (e.g. 4.8.0-rc.1)'
+        required: true
+        type: string
+      dist_tag:
+        description: 'npm dist-tag to publish under'
+        required: true
+        default: 'next'
+        type: string
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yaml
+    secrets: inherit
+  build-and-publish:
+    needs: [test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      VERSION: ${{ inputs.version }}
+      DIST_TAG: ${{ inputs.dist_tag }}
+    steps:
+      - name: Verify inputs
+        run: |
+          if ! [[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-[0-9A-Za-z.-]+$ ]]; then
+            echo "::error::$VERSION is not a pre-release version (x.y.z-suffix); releases go through the tag-driven publish workflow"
+            exit 1
+          fi
+          if [ "$DIST_TAG" = "latest" ]; then
+            echo "::error::Refusing to publish a pre-release to the latest dist-tag"
+            exit 1
+          fi
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: yarn
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install and Build
+        run: |
+          yarn install --frozen-lockfile
+          npm version "$VERSION" --no-git-tag-version
+          yarn build:lib
+      - name: Publish @dodona/papyros pre-release to NPM
+        run: npm publish --provenance --access public --tag "$DIST_TAG"


### PR DESCRIPTION
This pull request allows us to push a pre-release version to NPM to make it easier to test production builds on staging. It uses manual input version that's forces a `-` to be part of the version string, and publishes to npm with the `next` tag (overwritable), and unsures that `latest` can't be used as tag.

<details>
Adds a `workflow_dispatch`-only workflow to publish pre-release versions to npm under a non-`latest` dist-tag, so a branch (e.g. #1058) can ship a `4.8.0-rc.1` for consumers to pin without touching the release path.

Design notes:

- The existing tag-driven `publish.yaml` is untouched: releases keep working exactly as today, and no pre-release detection logic enters the path that publishes `latest`.
- Dispatch takes a `version` input and bumps `package.json` in CI (`npm version --no-git-tag-version`), so the branch needs no bump commit and no tag. Tags on branches we rebase would end up pointing at orphaned commits, so avoiding them entirely felt safer; cutting an `rc.2` is just another dispatch.
- The version guard refuses anything that isn't semver-pre-release-shaped, and the `dist_tag` input refuses `latest`. Both guards can only fail closed (worst case: you re-dispatch). The version check can't be dropped entirely: dist-tags don't affect range resolution, so a plain `x.y.z` published from here would still reach every `^`-range consumer.
- Reuses the test workflow as a gate, same as `publish.yaml`; no GitHub release object is created for pre-releases.

Two operational notes:

- GitHub only dispatches workflows whose file exists on the default branch, so this needs to land on main before it can be run against a feature branch. That's also why it's a separate small PR rather than part of #1058.
- Publishing authenticates via npm trusted publishing (OIDC, like `publish.yaml`), and npm scopes trusted-publisher entries to a workflow filename — so `publish-prerelease.yaml` needs its own entry added under the package's Trusted Publishers on npmjs.com before the first dispatch, or the publish step will fail auth.

</details>

**Manual testing instructions**
- After merge: Actions → "Publish pre-release on NPM" → run on `enhancement/worker-factory-hook` with version `4.8.0-rc.1` → verify `npm view @dodona/papyros dist-tags` shows it under `next` and `latest` still points at 4.7.0.
- Guard check: dispatch with version `4.8.0` and confirm the run fails at the verify step without publishing.

**Checklist**
- Tests: n/a (workflow only; guards exercised via the manual dispatch above)
- Docs: n/a
- AI: drafted with Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
