### PR TITLE
Add pre-release publishing via a reusable build-and-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -1,0 +1,43 @@
+name: Build and publish on NPM
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version to write to package.json before building; empty publishes the committed version'
+        type: string
+        required: false
+        default: ''
+      dist_tag:
+        description: 'npm dist-tag to publish under'
+        type: string
+        required: false
+        default: 'latest'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      VERSION: ${{ inputs.version }}
+      DIST_TAG: ${{ inputs.dist_tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: yarn
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install and Build
+        run: |
+          yarn install --frozen-lockfile
+          if [ -n "$VERSION" ]; then
+            npm version "$VERSION" --no-git-tag-version
+          fi
+          yarn build:lib
+      - name: Publish @dodona/papyros to NPM
+        run: npm publish --provenance --access public --tag "$DIST_TAG"

--- a/.github/workflows/publish-prerelease.yaml
+++ b/.github/workflows/publish-prerelease.yaml
@@ -1,0 +1,44 @@
+name: Publish pre-release on NPM
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Pre-release version to publish (e.g. 4.8.0-rc.1)'
+        required: true
+        type: string
+      dist_tag:
+        description: 'npm dist-tag to publish under'
+        required: true
+        default: 'next'
+        type: string
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yaml
+    secrets: inherit
+  verify:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ inputs.version }}
+      DIST_TAG: ${{ inputs.dist_tag }}
+    steps:
+      - name: Verify inputs
+        run: |
+          if ! [[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-[0-9A-Za-z.-]+$ ]]; then
+            echo "::error::$VERSION is not a pre-release version (x.y.z-suffix); releases go through the tag-driven publish workflow"
+            exit 1
+          fi
+          if [ "$DIST_TAG" = "latest" ]; then
+            echo "::error::Refusing to publish a pre-release to the latest dist-tag"
+            exit 1
+          fi
+  publish:
+    needs: [test, verify]
+    uses: ./.github/workflows/npm-publish.yaml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      version: ${{ inputs.version }}
+      dist_tag: ${{ inputs.dist_tag }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,12 +9,8 @@ jobs:
   test:
     uses: ./.github/workflows/test.yaml
     secrets: inherit
-  build-and-publish:
-    needs: [test]
+  verify:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -26,18 +22,20 @@ jobs:
             echo "::error::Tag v$TAG does not match package.json version $PKG"
             exit 1
           fi
-      - name: Set up Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
-          cache: yarn
-          registry-url: 'https://registry.npmjs.org'
-      - name: Install and Build
-        run: |
-          yarn install --frozen-lockfile
-          yarn build:lib
-      - name: Publish @dodona/papyros to NPM
-        run: npm publish --provenance --access public
+  publish:
+    needs: [test, verify]
+    uses: ./.github/workflows/npm-publish.yaml
+    permissions:
+      contents: read
+      id-token: write
+  release:
+    needs: [publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
**TODO (author) — drafted by Claude: proofread, verify and remove this line.**

Alternative to #1059: same capability (dispatch-only pre-release publishing to a non-`latest` dist-tag), but the shared build-and-publish steps are extracted into a reusable `workflow_call` workflow instead of being duplicated. Only one of the two PRs should be merged.

Design notes:

- `npm-publish.yaml` is deliberately guard-free: checkout, build, optional in-CI `npm version` bump, publish to a given dist-tag. Callers decide what is legal, so no routing logic exists anywhere.
- `publish.yaml` keeps its trigger and behaviour; its tag-match guard and the GitHub-release step each move to their own job (a job that `uses:` a reusable workflow can't have steps, and the release step is split out so the reusable workflow needs no write permissions). It calls the reusable workflow with defaults: committed version, `latest`.
- `publish-prerelease.yaml` carries the same fail-closed guards as #1059 (semver pre-release shape required, `latest` refused; dist-tags don't affect semver range resolution, so a plain `x.y.z` from here would still reach `^`-range consumers) and passes `version`/`dist_tag` through.
- Compared to #1059 this can't drift between the two publish paths, at the cost of touching `publish.yaml` and one level of indirection.

Operational notes:

- Needs to land on main before the pre-release workflow can be dispatched (GitHub only dispatches workflows that exist on the default branch).
- npm trusted publishing scopes entries to a workflow filename. The OIDC token of a reusable-workflow job carries both the caller (`workflow_ref`) and the reusable file (`job_workflow_ref`); npm is expected to match the caller, meaning `publish.yaml`'s existing entry keeps working and `publish-prerelease.yaml` needs one new entry (same as #1059). This is unverified and fails closed: if the first run fails auth, the trusted-publisher entry may need to reference `npm-publish.yaml` instead.

**Manual testing instructions**
- After merge: Actions → "Publish pre-release on NPM" → run on `enhancement/worker-factory-hook` with version `4.8.0-rc.1` → verify `npm view @dodona/papyros dist-tags` shows it under `next` and `latest` still points at 4.7.0.
- Guard check: dispatch with version `4.8.0` and confirm the run fails at the verify step without publishing.
- Release path: the next regular `v*` tag publish should behave identically to today (publish to `latest` + GitHub release created).

**Checklist**
- Tests: n/a (workflows only; guard regex exercised locally with accept/reject vectors, actionlint clean)
- Docs: n/a
- AI: drafted with Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
