### PR TITLE
Publish releases and pre-releases from GitHub Releases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,29 +3,58 @@ name: Publish on NPM
 on:
   push:
     tags: ['v*']
-  workflow_dispatch:
+
+concurrency:
+  group: publish
+  cancel-in-progress: false
 
 jobs:
   test:
     uses: ./.github/workflows/test.yaml
     secrets: inherit
-  build-and-publish:
-    needs: [test]
+  verify:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
+    outputs:
+      dist_tag: ${{ steps.check.outputs.dist_tag }}
+      prerelease: ${{ steps.check.outputs.prerelease }}
+    env:
+      TAG_NAME: ${{ github.ref_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Verify tag matches package.json version
+      - name: Verify tag
+        id: check
         run: |
-          TAG="${GITHUB_REF#refs/tags/v}"
-          PKG=$(jq -r .version package.json)
-          if [ "$TAG" != "$PKG" ]; then
-            echo "::error::Tag v$TAG does not match package.json version $PKG"
+          VERSION="${TAG_NAME#v}"
+          if [[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            DIST_TAG=latest
+            PRERELEASE=false
+          elif [[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*$ ]]; then
+            DIST_TAG=next
+            PRERELEASE=true
+          else
+            echo "::error::$VERSION is not a semver version"
             exit 1
           fi
+          PKG=$(jq -r .version package.json)
+          if [ "$VERSION" != "$PKG" ]; then
+            echo "::error::Tag $TAG_NAME does not match package.json version $PKG"
+            exit 1
+          fi
+          echo "dist_tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+  publish:
+    needs: [test, verify]
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      DIST_TAG: ${{ needs.verify.outputs.dist_tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
@@ -37,8 +66,23 @@ jobs:
           yarn install --frozen-lockfile
           yarn build:lib
       - name: Publish @dodona/papyros to NPM
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --tag "$DIST_TAG"
+  release:
+    needs: [verify, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      PRERELEASE: ${{ needs.verify.outputs.prerelease }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${GITHUB_REF#refs/tags/}" --generate-notes --verify-tag
+        run: |
+          if [ "$PRERELEASE" = "true" ]; then
+            gh release create "$GITHUB_REF_NAME" --generate-notes --verify-tag --prerelease
+          else
+            gh release create "$GITHUB_REF_NAME" --generate-notes --verify-tag
+          fi


### PR DESCRIPTION
This PR extends the tag-push publish pipeline to allow us to easily release pre-release versions based on the same workflow (as opposed to #1059 and #1060 using different workflows).

The trigger stays a tag push; the npm dist-tag is derived from the pushed tag's shape: a pre-release version (e.g. `v4.8.0-rc.1`) is published to `next`, a release version to `latest`. Several checks are done in the script to ensure tag validity: the tag must be strict semver and must match the `package.json` version, also for pre-releases, and also checks the format of the tag used. On top of that, the publish job runs in the `npm` environment, so one of the required reviewers has to manually approve every publish after the tests and tag checks have passed. The GitHub release is still created automatically afterwards, marked as a pre-release when the tag is one.

<details>

- Because the tag must match `package.json` for pre-releases too, an rc branch carries a real version bump commit and the published artifact is byte-for-byte the tagged tree; there is no in-CI version bump. The bump commit is dropped or overwritten before the branch merges to main.
- The `npm` environment exists with required reviewers TomNaessens, chvp and bmesuere: any one of them can approve (self-approval allowed, admins can bypass). Rejecting fails the run without publishing; re-runs need a fresh approval. The environment's deployment branch policy is currently unrestricted; it could later be limited to `v*` tags as extra hardening.
- The workflow filename stays `publish.yaml`, so the existing npm trusted-publisher entry keeps working and npmjs.com needs no changes.
- A `concurrency` group serialises publishes, and npm itself refuses re-publishing an existing version.

</details>

**Manual testing instructions**

- The verify script, extracted from this exact file, was executed locally against twelve vectors: three accepts (stable → `latest`, pre-release → `next`, `-0` numeric identifier) and nine refusals (`package.json` mismatch for stable, pre-release, and rc.1-vs-rc.2; missing `v`; non-semver; leading zeros; invalid pre-release identifiers). actionlint is clean.
- First real E2E after merge: on `enhancement/worker-factory-hook`, commit a bump to `4.8.0-rc.1`, tag `v4.8.0-rc.1`, push the tag, approve the environment gate, then verify `npm view @dodona/papyros dist-tags` shows `next: 4.8.0-rc.1` with `latest` still 4.7.0.
- Guard check: push a tag that doesn't match `package.json` and watch the verify job refuse before the approval gate is ever reached.
- The next regular stable release exercises the `latest` path.

**Checklist**
- Tests: n/a (workflow only; guard script exercised locally as above)
- Docs: n/a
- AI: drafted with Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
