### PR TITLE
Expose when the backend is ready to run code

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The codebase organized into clear layers:
 
 A [CodeMirror 6](https://codemirror.net/6/) editor to edit, run, and debug code.
 Additional buttons can be added via the `.buttons` slot.
+Reflects a `backend-ready` attribute once the backend has finished loading, so surrounding pages can style or wait on it.
 
 #### `<p-input>`
 
@@ -156,6 +157,7 @@ A `Papyros` instance contains multiple logical parts:
 * `papyros.i18n`: translations (extend or override as needed).
 * `papyros.io`: input/output handling. Subscribe to `awaitingInput` to supply input when needed.
 * `papyros.runner`: code, execution state, programming language. Run code with `papyros.runner.start()`.
+  Subscribe to `backendReady` to know when the backend has loaded; runs started before that are queued.
 * `papyros.test`: test code (appended to the code document).
 
 ---

--- a/src/frontend/components/CodeRunner.ts
+++ b/src/frontend/components/CodeRunner.ts
@@ -1,6 +1,6 @@
 import { customElement, state } from "lit/decorators.js";
 import { PapyrosElement } from "./PapyrosElement";
-import { css, CSSResult, html, TemplateResult } from "lit";
+import { css, CSSResult, html, PropertyValues, TemplateResult } from "lit";
 import { createRef, ref, Ref } from "lit/directives/ref.js";
 import { CODE_TAB } from "../state/InputOutput";
 import { arrayBufferToBase64, isTextMimeType } from "../../util/Util";
@@ -65,6 +65,16 @@ export class CodeRunner extends PapyrosElement {
                 background-color: var(--md-sys-color-surface-container);
             }
         `;
+    }
+
+    /**
+     * Reflect backend readiness on the host, so surrounding pages can style or
+     * wait on it. Reading the state here keeps it inside the update cycle the
+     * StateController records, so the host re-renders when it flips.
+     */
+    protected override update(changedProperties: PropertyValues): void {
+        this.toggleAttribute("backend-ready", this.papyros.runner.backendReady);
+        super.update(changedProperties);
     }
 
     protected override firstUpdated(): void {

--- a/src/frontend/state/Runner.ts
+++ b/src/frontend/state/Runner.ts
@@ -62,6 +62,13 @@ export class Runner extends State {
     @stateProperty
     public backend: Promise<SyncClient<Backend>>;
     /**
+     * Whether the backend has finished loading and can execute code.
+     * Runs may be started before this is true: they are queued until the
+     * backend is up, so the run state is Ready while it is still loading.
+     */
+    @stateProperty
+    public backendReady: boolean = false;
+    /**
      * Current state of the program
      */
     @stateProperty
@@ -180,6 +187,7 @@ export class Runner extends State {
      */
     public async launch(): Promise<void> {
         this.setState(RunState.Loading);
+        this.backendReady = false;
         const backend = BackendManager.getBackend(this.programmingLanguage);
         // Use a Promise to immediately enable running while downloading
         // eslint-disable-next-line no-async-promise-executor
@@ -191,6 +199,7 @@ export class Runner extends State {
                 this.pyodideAssetURL,
             );
             this.updateRunModes();
+            this.backendReady = true;
             return resolve(backend);
         });
         this.setState(RunState.Ready);

--- a/src/frontend/state/Runner.ts
+++ b/src/frontend/state/Runner.ts
@@ -69,6 +69,10 @@ export class Runner extends State {
     @stateProperty
     public backendReady: boolean = false;
     /**
+     * Identifies the most recent launch, so a superseded one cannot report ready
+     */
+    private launchId: number = 0;
+    /**
      * Current state of the program
      */
     @stateProperty
@@ -188,6 +192,7 @@ export class Runner extends State {
     public async launch(): Promise<void> {
         this.setState(RunState.Loading);
         this.backendReady = false;
+        const launchId = ++this.launchId;
         const backend = BackendManager.getBackend(this.programmingLanguage);
         // Use a Promise to immediately enable running while downloading
         // eslint-disable-next-line no-async-promise-executor
@@ -198,8 +203,10 @@ export class Runner extends State {
                 proxy((e: BackendEvent) => BackendManager.publish(e)),
                 this.pyodideAssetURL,
             );
-            this.updateRunModes();
-            this.backendReady = true;
+            if (launchId === this.launchId) {
+                this.updateRunModes();
+                this.backendReady = true;
+            }
             return resolve(backend);
         });
         this.setState(RunState.Ready);

--- a/test/__tests__/components/CodeRunner.test.ts
+++ b/test/__tests__/components/CodeRunner.test.ts
@@ -1,0 +1,21 @@
+import {describe, expect, it} from "vitest";
+import {Papyros} from "../../../src/frontend/state/Papyros";
+import type {CodeRunner} from "../../../src/frontend/components/CodeRunner";
+import "../../../src/frontend/components/CodeRunner";
+
+describe("CodeRunner", () => {
+    it("reflects backend readiness on the host", async () => {
+        const element = document.createElement("p-code-runner") as CodeRunner;
+        element.papyros = new Papyros();
+        document.body.append(element);
+
+        await element.updateComplete;
+        expect(element.hasAttribute("backend-ready")).toBe(false);
+
+        element.papyros.runner.backendReady = true;
+        await element.updateComplete;
+        expect(element.hasAttribute("backend-ready")).toBe(true);
+
+        element.remove();
+    });
+});

--- a/test/__tests__/state/Runner.test.ts
+++ b/test/__tests__/state/Runner.test.ts
@@ -34,6 +34,26 @@ const c = a + b;`;
         expect(papyros.runner.backendReady).toBe(true);
     });
 
+    it("does not report a superseded launch as ready", async () => {
+        const papyros = new Papyros();
+        await papyros.launch();
+
+        papyros.runner.programmingLanguage = ProgrammingLanguage.JavaScript;
+        const superseded = papyros.runner.backend;
+        papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+        const current = papyros.runner.backend;
+
+        let currentLoaded = false;
+        current.then(() => (currentLoaded = true));
+
+        // Only the current backend may flip the flag, whichever finishes first
+        await superseded;
+        expect(papyros.runner.backendReady).toBe(currentLoaded);
+
+        await current;
+        expect(papyros.runner.backendReady).toBe(true);
+    });
+
     it("should run code that raises an error", async () => {
         const papyros = new Papyros();
         await papyros.launch();

--- a/test/__tests__/state/Runner.test.ts
+++ b/test/__tests__/state/Runner.test.ts
@@ -21,6 +21,19 @@ const c = a + b;`;
         expect(papyros.runner.stateMessage).toMatch(/^Code executed in/);
     });
 
+    it("only reports the backend as ready once it has loaded", async () => {
+        const papyros = new Papyros();
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.JavaScript;
+
+        // Runs are queued while the backend loads, so the run state is Ready first
+        expect(papyros.runner.state).toBe(RunState.Ready);
+        expect(papyros.runner.backendReady).toBe(false);
+
+        await papyros.runner.backend;
+        expect(papyros.runner.backendReady).toBe(true);
+    });
+
     it("should run code that raises an error", async () => {
         const papyros = new Papyros();
         await papyros.launch();


### PR DESCRIPTION
Adds `Runner.backendReady`, so consumers can tell "a run may be queued" apart from "the runtime can execute code". Neither existing signal says the latter: `RunState.Ready` is true from the moment launching starts, and `runner.backend` is a dummy resolved promise until `launch()` swaps it.

It is set false when `launch()` starts and true once the worker is up, and `p-code-runner` reflects it as a `backend-ready` attribute on its host. Queueing a run while the runtime downloads still works exactly as before.

This bit dodona, whose system tests read the Run button as proof the sandbox was usable and flaked when a cold Pyodide download outlasted their wait (dodona-edu/dodona#8679).

**Checklist**
- Tests: the state transition in `Runner.test.ts`, the attribute reflection in a new `components/CodeRunner.test.ts`.
- AI: Claude Code wrote the change and the tests.

Closes #1064
