### PR TITLE
Bump @dodona/trace-component to 1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@codemirror/state": "^6.3.2",
     "@codemirror/view": "^6.28.0",
     "@dodona/lit-state": "^1.1.1",
-    "@dodona/trace-component": "1.4.1",
+    "@dodona/trace-component": "1.4.2",
     "@material/web": "^2.4.0",
     "codemirror-readonly-ranges": "^0.1.0-alpha.2",
     "comlink": "^4.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,12 +105,12 @@
   dependencies:
     lit "^3.3.1"
 
-"@dodona/trace-component@1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@dodona/trace-component/-/trace-component-1.4.1.tgz#9b7139b587e18de71e2982a5299f3a988f25e1bc"
-  integrity sha512-EyHI8EvynNcxoP6k1qImmrMxy2tLYAJp8pjxZBiTL8dwpm6MLwAXnchTwVMPegAcPbubgFTwubrS7WHqlQlT+A==
+"@dodona/trace-component@1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@dodona/trace-component/-/trace-component-1.4.2.tgz#b5ac12c0e3e9327191ac0ccf4a3fbd178790eadc"
+  integrity sha512-84pGj5ePOPnxzpWjDHLysXzwgVpu7lqPokRatMq//1XlJg5O9OB/oNVlFn1U2OSC8hr7o1Ostj1MDlaSF0EZvw==
   dependencies:
-    lit "^3.3.2"
+    lit "^3.3.3"
 
 "@emnapi/core@1.11.1":
   version "1.11.1"
@@ -1425,7 +1425,7 @@ lit-html@^3.3.0:
   dependencies:
     "@types/trusted-types" "^2.0.2"
 
-"lit@^2.8.0 || ^3.0.0", lit@^3.3.1, lit@^3.3.2:
+"lit@^2.8.0 || ^3.0.0", lit@^3.3.1, lit@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/lit/-/lit-3.3.3.tgz#93579885e51a20a772c68482a34706fe1636e8f0"
   integrity sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==


### PR DESCRIPTION
Bumps `@dodona/trace-component` from 1.4.1 to 1.4.2.

<etails>
The only thing in the release that affects us is [dodona-edu/trace-component#119](https://github.com/dodona-edu/trace-component/pull/119): active references get a more prominent colour. The rest of the release is publish workflow work on the component side, so nothing visible here.

The lit churn in the lockfile is just the widened range (`^3.3.2` to `^3.3.3`); the resolved version stays 3.3.3, so no actual lit upgrade.

Full changelog: https://github.com/dodona-edu/trace-component/compare/v1.4.1...v1.4.2
</details>

## Testing

- Run the debugger on any Python snippet and step through it.
- Click a variable/reference in the trace: the active reference should now stand out a bit more than before.

<details>
<summary>Local verification</summary>

Ran green locally: `yarn typecheck`, `yarn lint`, `yarn build:app`, `yarn build:lib` (after `yarn setup`).

`yarn test` I couldn't get to complete on my machine: the vitest browser run sat there for ~17 minutes and then died with `Browser connection was closed while running tests`, with zero tests actually run. A single test file on its own didn't finish either. CI runs the same suite in 3 minutes and it's green, so that was local, not this bump.

</details>
