### PR TITLE
Vendor the sync-message, comsync and pyodide-worker-runner stack

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 /*
 !/dist
+!/THIRD-PARTY-NOTICES.md

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ yarn add @dodona/papyros
 ### Setup input handling
 
 Running interactive programs in the browser requires special handling of synchronous input.
-Papyros supports two approaches (via [`sync-message`](https://github.com/alexmojaki/sync-message)):
+Papyros supports two approaches:
 
 #### COOP/COEP headers
 Add the following HTTP headers to your server responses:
@@ -126,6 +126,8 @@ The codebase organized into clear layers:
 * `frontend`: all browser-side code
     * `state`: state management (e.g. execution state, debugger, input/output)
     * `components`: visualization of that state, as Lit web components
+* `sync`: synchronous communication between the main thread and the workers, so that Python
+  `input()` and `time.sleep()` can block a worker until the main thread answers
 
 ### Components
 
@@ -184,3 +186,11 @@ yarn build:lib
 # Publish to npm
 yarn publish
 ```
+
+## Third-party code
+
+`src/sync/` and `src/backend/workers/python/pyodide_worker_runner.py` are vendored from
+[sync-message](https://github.com/alexmojaki/sync-message),
+[comsync](https://github.com/alexmojaki/comsync) and
+[pyodide-worker-runner](https://github.com/alexmojaki/pyodide-worker-runner),
+all MIT licensed and copyright (c) 2022 Alex Hall. See [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md).

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,36 @@
+# Third-party notices
+
+Papyros includes source code from the projects listed below. Their license terms are reproduced here as required.
+
+## sync-message, comsync, pyodide-worker-runner
+
+- https://github.com/alexmojaki/sync-message
+- https://github.com/alexmojaki/comsync
+- https://github.com/alexmojaki/pyodide-worker-runner
+
+Vendored into `src/sync/` and `src/backend/workers/python/pyodide_worker_runner.py`. All three are distributed
+under the MIT License with the same copyright holder and identical license text.
+
+```
+MIT License
+
+Copyright (c) 2022 Alex Hall
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/package.json
+++ b/package.json
@@ -18,12 +18,10 @@
     "@material/web": "^2.4.0",
     "codemirror-readonly-ranges": "^0.1.0-alpha.2",
     "comlink": "^4.4.1",
-    "comsync": "^0.0.9",
     "lit": "^3.3.1",
     "node-polyglot": "^2.6.0",
-    "pyodide": "^314.0.0",
-    "pyodide-worker-runner": "1.4.0",
-    "sync-message": "^0.0.12"
+    "p-retry": "^5.1.2",
+    "pyodide": "^314.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/src/backend/Backend.ts
+++ b/src/backend/Backend.ts
@@ -1,5 +1,5 @@
 import { BackendEvent, BackendEventType } from "../communication/BackendEvent";
-import { syncExpose, SyncExtras } from "comsync";
+import { syncExpose, SyncExtras } from "../sync/SyncClient";
 import { BackendEventQueue } from "../communication/BackendEventQueue";
 
 export interface WorkerDiagnostic {

--- a/src/backend/workers/javascript/JavaScriptWorker.ts
+++ b/src/backend/workers/javascript/JavaScriptWorker.ts
@@ -1,7 +1,7 @@
 import { Backend, WorkerDiagnostic } from "../../Backend";
 import { CompletionResult } from "@codemirror/autocomplete";
 import { BackendEventType } from "../../../communication/BackendEvent";
-import { SyncExtras } from "comsync";
+import { SyncExtras } from "../../../sync/SyncClient";
 
 /**
  * Implementation of a JavaScript backend for Papyros

--- a/src/backend/workers/python/PythonWorker.ts
+++ b/src/backend/workers/python/PythonWorker.ts
@@ -2,7 +2,7 @@ import { Backend, RunMode, WorkerDiagnostic } from "../../Backend";
 import { BackendEvent } from "../../../communication/BackendEvent";
 import { loadPyodide, PyodideInterface } from "pyodide";
 import { PyProxy } from "pyodide/ffi";
-import { pyodideExpose, PyodideExtras, loadPyodideAndPackage } from "pyodide-worker-runner";
+import { pyodideExpose, PyodideExtras, loadPyodideAndPackage } from "../../../sync/pyodide";
 
 const pythonPackageUrl = new URL("./python_package.tar.gz.load_by_url", import.meta.url).href;
 

--- a/src/backend/workers/python/build_package.py
+++ b/src/backend/workers/python/build_package.py
@@ -32,6 +32,8 @@ def create_package(package_name, dependencies, extra_deps):
     # Locate via sysconfig rather than `import turtle`, which would pull in tkinter.
     turtle_src = os.path.join(sysconfig.get_path("stdlib"), "turtle.py")
     shutil.copy(turtle_src, os.path.join(package_name, "turtle.py"))
+    # Vendored from pyodide-worker-runner, provides install_imports used by papyros.py
+    shutil.copy("pyodide_worker_runner.py", os.path.join(package_name, "pyodide_worker_runner.py"))
     tar_name = f"{package_name}.tar.gz.load_by_url"
     if os.path.exists(tar_name):
         os.remove(tar_name)

--- a/src/backend/workers/python/pyodide_worker_runner.py
+++ b/src/backend/workers/python/pyodide_worker_runner.py
@@ -1,0 +1,108 @@
+# Vendored from pyodide-worker-runner (https://github.com/alexmojaki/pyodide-worker-runner).
+# Copyright (c) 2022 Alex Hall. MIT licensed, see THIRD-PARTY-NOTICES.md.
+import importlib
+import sys
+from typing import Callable, Literal, Union, TypedDict
+
+try:
+    from pyodide.code import find_imports  # noqa
+except ImportError:
+    from pyodide import find_imports  # noqa
+
+import pyodide_js  # noqa
+
+sys.setrecursionlimit(400)
+
+
+class InstallEntry(TypedDict):
+    module: str
+    package: str
+
+
+def find_imports_to_install(imports: list[str]) -> list[InstallEntry]:
+    """
+    Given a list of module names being imported, return a list of dicts
+    representing the packages that need to be installed to import those modules.
+    The returned list will only contain modules that aren't already installed.
+    Each returned dict has the following keys:
+      - module: the name of the module being imported
+      - package: the name of the package that needs to be installed
+    """
+    try:
+        to_package_name = pyodide_js._module._import_name_to_package_name.to_py()
+    except AttributeError:
+        to_package_name = pyodide_js._api._import_name_to_package_name.to_py()
+
+    to_install: list[InstallEntry] = []
+    for module in imports:
+        try:
+            importlib.import_module(module)
+        except ModuleNotFoundError:
+            to_install.append(
+                dict(
+                    module=module,
+                    package=to_package_name.get(module, module),
+                )
+            )
+    return to_install
+
+
+async def install_imports(
+    source_code_or_imports: Union[str, list[str]],
+    message_callback: Callable[
+        [
+            Literal[
+                "loading_all",
+                "loaded_all",
+                "loading_one",
+                "loaded_one",
+                "loading_micropip",
+                "loaded_micropip",
+            ],
+            Union[InstallEntry, list[InstallEntry]],
+        ],
+        None,
+    ] = lambda event_type, data: None,
+):
+    """
+    Accepts a string of Python source code or a list of module names being imported.
+    Installs any packages that need to be installed to import those modules,
+    using micropip, which may also be installed if needed.
+    If the package is not specially built for Pyodide, it must be available on PyPI
+    as a pure Python wheel file.
+    If the `message_callback` argument is provided, it will be called with an
+    event type and data about the packages being installed.
+    The event types start with `loading_` before installation, and `loaded_` after.
+    The data is either a single dict representing the package being installed,
+    or a list of all the packages being installed.
+    The events are:
+        - loading/loaded_all, with a list of all the packages being installed.
+        - loading/loaded_one, with a dict for a single package.
+        - loading/loaded_micropip, with a dict for the special micropip package.
+    """
+    if isinstance(source_code_or_imports, str):
+        try:
+            imports: list[str] = find_imports(source_code_or_imports)
+        except SyntaxError:
+            return
+    else:
+        imports: list[str] = source_code_or_imports
+
+    to_install = find_imports_to_install(imports)
+    if to_install:
+        message_callback("loading_all", to_install)
+        try:
+            import micropip  # noqa
+        except ModuleNotFoundError:
+            micropip_entry = dict(module="micropip", package="micropip")
+            message_callback("loading_micropip", micropip_entry)
+            await pyodide_js.loadPackage("micropip")
+            import micropip  # noqa
+
+            message_callback("loaded_micropip", micropip_entry)
+
+        for entry in to_install:
+            message_callback("loading_one", entry)
+            await micropip.install(entry["package"])
+            message_callback("loaded_one", entry)
+        message_callback("loaded_all", to_install)

--- a/src/communication/BackendManager.ts
+++ b/src/communication/BackendManager.ts
@@ -2,9 +2,9 @@ import { Backend } from "../backend/Backend";
 import { ProgrammingLanguage } from "../ProgrammingLanguage";
 import { BackendEvent, BackendEventType } from "./BackendEvent";
 import { LogType, papyrosLog } from "../util/Logging";
-import { Channel, makeChannel } from "sync-message";
-import { SyncClient } from "comsync";
-import { PyodideClient } from "pyodide-worker-runner";
+import { Channel } from "../sync/channel";
+import { SyncClient } from "../sync/SyncClient";
+import { PyodideClient } from "../sync/pyodide";
 /**
  * Callback type definition for subscribers
  * @param {BackendEvent} e The published event
@@ -35,8 +35,9 @@ export abstract class BackendManager {
     private static halted: boolean;
     /**
      * The channel used to communicate with the SyncClients
+     * Assigned by Papyros.configureInput before any backend is created
      */
-    public static channel: Channel;
+    public static channel: Channel | null = null;
 
     /**
      * @param {ProgrammingLanguage} language The language to support
@@ -117,7 +118,6 @@ export abstract class BackendManager {
      * Initialise the fields and setup the maps
      */
     static {
-        BackendManager.channel = makeChannel()!;
         BackendManager.createBackendMap = new Map();
         BackendManager.backendMap = new Map();
         BackendManager.subscriberMap = new Map();

--- a/src/communication/InputWorker.ts
+++ b/src/communication/InputWorker.ts
@@ -1,4 +1,4 @@
-import { serviceWorkerFetchListener } from "sync-message";
+import { serviceWorkerFetchListener } from "../sync/channel";
 
 /**
  * Class that is used in a service worker to allow synchronous communication

--- a/src/frontend/state/Papyros.ts
+++ b/src/frontend/state/Papyros.ts
@@ -5,7 +5,7 @@ import { InputOutput } from "./InputOutput";
 import { Constants } from "./Constants";
 import { Examples } from "./Examples";
 import { BackendManager } from "../../communication/BackendManager";
-import { makeChannel } from "sync-message";
+import { makeChannel } from "../../sync/channel";
 import { I18n } from "./I18n";
 import { Test } from "./Test";
 import { PapyrosLaunchError, ServiceWorkerRegistrationError } from "./PapyrosErrors";

--- a/src/frontend/state/Runner.ts
+++ b/src/frontend/state/Runner.ts
@@ -1,5 +1,5 @@
 import { proxy } from "comlink";
-import { SyncClient } from "comsync";
+import { SyncClient } from "../../sync/SyncClient";
 import { Backend, RunMode, WorkerDiagnostic } from "../../backend/Backend";
 import { BackendEvent, BackendEventType } from "../../communication/BackendEvent";
 import { BackendManager } from "../../communication/BackendManager";

--- a/src/sync/SyncClient.ts
+++ b/src/sync/SyncClient.ts
@@ -1,0 +1,219 @@
+/**
+ * Vendored from comsync (https://github.com/alexmojaki/comsync).
+ * Copyright (c) 2022 Alex Hall. MIT licensed, see THIRD-PARTY-NOTICES.md.
+ */
+import { Channel, readMessage, uuidv4, writeMessage } from "./channel";
+import * as Comlink from "comlink";
+
+export class InterruptError extends Error {
+    // To avoid having to use instanceof
+    public readonly type = "InterruptError";
+    public readonly name = this.type;
+}
+
+export class NoChannelError extends Error {
+    // To avoid having to use instanceof
+    public readonly type = "NoChannelError";
+    public readonly name = this.type;
+}
+
+export class SyncClient<T = any> {
+    public interrupter?: () => void;
+    public state: "idle" | "running" | "awaitingMessage" | "sleeping" = "idle";
+    private _worker?: Worker;
+    private _workerProxy?: Comlink.Remote<T>;
+
+    private _interruptRejector?: (reason?: any) => void;
+    private _interruptPromise?: Promise<void>;
+
+    private _messageIdBase?: string;
+    private _messageIdSeq = 0;
+
+    private _awaitingMessageResolve?: () => void;
+
+    public get worker(): Worker {
+        return this._worker!;
+    }
+
+    public get workerProxy(): Comlink.Remote<T> {
+        return this._workerProxy!;
+    }
+
+    public constructor(
+        public workerCreator: () => Worker,
+        public channel?: Channel | null,
+    ) {
+        this._start();
+    }
+
+    public async interrupt(): Promise<void> {
+        if (this.state === "idle") {
+            return;
+        }
+
+        if (this.state === "awaitingMessage" || this.state === "sleeping") {
+            await this._writeMessage({ interrupted: true });
+            return;
+        }
+
+        if (this.interrupter) {
+            await this.interrupter();
+            return;
+        }
+
+        this.terminate();
+        this._start();
+    }
+
+    public async call(proxyMethod: any, ...args: any[]): Promise<any> {
+        if (this.state !== "idle") {
+            throw new Error(`State is ${this.state}, not idle`);
+        }
+
+        let runningThisTask = true;
+        this.state = "running";
+
+        this._messageIdBase = uuidv4();
+        this._messageIdSeq = 0;
+
+        const syncMessageCallback: SyncMessageCallback = (status) => {
+            if (!runningThisTask || status === "init") {
+                return;
+            }
+
+            if (status === "reading") {
+                this.state = "awaitingMessage";
+                this._messageIdSeq++;
+                this._awaitingMessageResolve?.();
+            } else if (status === "sleeping") {
+                this.state = "sleeping";
+                this._messageIdSeq++;
+            } else if (status === "slept") {
+                this.state = "running";
+            }
+        };
+
+        this._interruptPromise = new Promise((resolve, reject) => (this._interruptRejector = reject));
+
+        try {
+            return await Promise.race([
+                proxyMethod(this.channel, Comlink.proxy(syncMessageCallback), this._messageIdBase, ...args),
+                this._interruptPromise,
+            ]);
+        } finally {
+            runningThisTask = false;
+            this._reset();
+        }
+    }
+
+    public async writeMessage(message: any): Promise<void> {
+        if (this.state === "idle" || !this._messageIdBase) {
+            throw new Error("No active call to send a message to.");
+        }
+
+        if (this.state !== "awaitingMessage") {
+            if (this._awaitingMessageResolve) {
+                throw new Error("Not waiting for message, and another write is already queued.");
+            }
+
+            await new Promise<void>((resolve) => {
+                this._awaitingMessageResolve = resolve;
+            });
+            delete this._awaitingMessageResolve;
+        }
+
+        await this._writeMessage({ message });
+    }
+
+    public terminate(): void {
+        this._interruptRejector?.(new InterruptError("Worker terminated"));
+        this._workerProxy![Comlink.releaseProxy]();
+        this._worker!.terminate();
+        delete this._workerProxy;
+        delete this._worker;
+    }
+
+    private async _writeMessage(message: any): Promise<void> {
+        this.state = "running";
+        const messageId = makeMessageId(this._messageIdBase!, this._messageIdSeq);
+        await writeMessage(this.channel!, message, messageId);
+    }
+
+    private _start(): void {
+        this._reset();
+        this._worker = this.workerCreator();
+        this._workerProxy = Comlink.wrap<T>(this._worker);
+    }
+
+    private _reset(): void {
+        this.state = "idle";
+        delete this._interruptPromise;
+        delete this._interruptRejector;
+        delete this._awaitingMessageResolve;
+        delete this._messageIdBase;
+    }
+}
+
+export interface SyncExtras {
+    channel: Channel | null;
+    readMessage: () => any;
+    syncSleep: (ms: number) => void;
+}
+
+type SyncMessageCallbackStatus = "init" | "reading" | "sleeping" | "slept";
+type SyncMessageCallback = (status: SyncMessageCallbackStatus) => void;
+
+export function syncExpose<T extends any[], R>(
+    func: (extras: SyncExtras, ...args: T) => R,
+): (
+    channel: Channel | null,
+    syncMessageCallback: SyncMessageCallback,
+    messageIdBase: string,
+    ...args: T
+) => Promise<R> {
+    return async function (
+        channel: Channel | null,
+        syncMessageCallback: SyncMessageCallback,
+        messageIdBase: string,
+        ...args: T
+    ): Promise<R> {
+        await syncMessageCallback("init");
+        let messageIdSeq = 0;
+
+        function fullSyncMessageCallback(status: "reading" | "sleeping", options?: { timeout: number }): any {
+            if (!channel) {
+                throw new NoChannelError();
+            }
+            syncMessageCallback(status);
+            const messageId = makeMessageId(messageIdBase, ++messageIdSeq);
+            const response = readMessage(channel, messageId, options);
+            if (response) {
+                const { message, interrupted } = response;
+                if (interrupted) {
+                    throw new InterruptError();
+                }
+                return message;
+            } else if (status === "sleeping") {
+                syncMessageCallback("slept");
+            }
+        }
+
+        const extras: SyncExtras = {
+            channel,
+            readMessage(): any {
+                return fullSyncMessageCallback("reading");
+            },
+            syncSleep(ms: number): void {
+                if (!(ms > 0)) {
+                    return;
+                }
+                fullSyncMessageCallback("sleeping", { timeout: ms });
+            },
+        };
+        return func(extras, ...args);
+    };
+}
+
+function makeMessageId(base: string, seq: number): string {
+    return `${base}-${seq}`;
+}

--- a/src/sync/channel.ts
+++ b/src/sync/channel.ts
@@ -1,0 +1,396 @@
+/**
+ * Vendored from sync-message (https://github.com/alexmojaki/sync-message).
+ * Copyright (c) 2022 Alex Hall. MIT licensed, see THIRD-PARTY-NOTICES.md.
+ */
+const BASE_URL_SUFFIX = "__SyncMessageServiceWorkerInput__";
+const VERSION = "__sync-message-v2__";
+
+interface ServiceWorkerReadRequest {
+    messageId: string;
+    timeout: number;
+}
+
+interface ServiceWorkerWriteRequest {
+    messageId: string;
+    message: string;
+}
+
+interface ServiceWorkerResponse {
+    message: any;
+    version: string;
+}
+
+/**
+ * Checks whether the given request is meant to be intercepted by the sync-message serviceWorkerFetchListener.
+ */
+export function isServiceWorkerRequest(request: FetchEvent | string): boolean {
+    const url = typeof request === "string" ? request : request.request.url;
+    return url.includes(BASE_URL_SUFFIX);
+}
+
+/**
+ * Returns a function that can respond to fetch events in a service worker event listener.
+ * The function returns true if the request came from this library and it responded.
+ * Call `serviceWorkerFetchListener` and reuse the returned function as it manages internal state.
+ */
+export function serviceWorkerFetchListener(): (e: FetchEvent) => boolean {
+    const earlyMessages: { [messageId: string]: any } = {};
+    const resolvers: { [messageId: string]: (r: Response) => void } = {};
+
+    return (e: FetchEvent): boolean => {
+        const { url } = e.request;
+        if (!isServiceWorkerRequest(url)) {
+            return false;
+        }
+
+        async function respond(): Promise<Response> {
+            function success(message: any): Response {
+                const response: ServiceWorkerResponse = { message, version: VERSION };
+                return new Response(JSON.stringify(response), { status: 200 });
+            }
+
+            if (url.endsWith("/read")) {
+                const { messageId, timeout }: ServiceWorkerReadRequest = await e.request.json();
+                if (messageId in earlyMessages) {
+                    const message = earlyMessages[messageId];
+                    delete earlyMessages[messageId];
+                    return success(message);
+                } else {
+                    return await new Promise((resolver) => {
+                        resolvers[messageId] = resolver;
+
+                        function callback(): void {
+                            delete resolvers[messageId];
+                            resolver(new Response("", { status: 408 })); // timeout
+                        }
+
+                        setTimeout(callback, timeout);
+                    });
+                }
+            } else if (url.endsWith("/write")) {
+                const { message, messageId }: ServiceWorkerWriteRequest = await e.request.json();
+                const resolver = resolvers[messageId];
+                if (resolver) {
+                    resolver(success(message));
+                    delete resolvers[messageId];
+                } else {
+                    earlyMessages[messageId] = message;
+                }
+                return success({ early: !resolver });
+            } else if (url.endsWith("/version")) {
+                return new Response(VERSION, { status: 200 });
+            }
+            return new Response("", { status: 404 });
+        }
+
+        e.respondWith(respond());
+        return true;
+    };
+}
+
+/**
+ * Convenience function that allows writing `await asyncSleep(1000)`
+ * to wait one second before continuing in an async function.
+ */
+export function asyncSleep(ms: number): Promise<unknown> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Options for making an atomics type channel.
+ */
+export interface AtomicsChannelOptions {
+    // The number of bytes to allocate for the `SharedArrayBuffer`.
+    // Defaults to 128KiB.
+    // `writeMessage` will throw an error if the message is larger than the buffer size.
+    bufferSize?: number;
+}
+
+/**
+ * Options for making a serviceWorker type channel.
+ */
+export interface ServiceWorkerChannelOptions {
+    // a string representing the prefix of a path/URL, defaulting to `"/"`.
+    // Both `readMessage` and `writeMessage` will make requests that start with this value
+    // so make sure that your service worker is controlling the page and can intercept those requests.
+    // The `scope` property of the registration object returned by `navigator.serviceWorker.register` should work.
+    scope?: string;
+
+    // number of milliseconds representing a grace period for the service worker to start up.
+    // If requests made by `readMessage` and `writeMessage` fail,
+    // they will be retried until this timeout is exceeded,
+    // at which point they will throw an error.
+    timeout?: number;
+}
+
+interface AtomicsChannel {
+    type: "atomics";
+    data: Uint8Array;
+    meta: Int32Array;
+}
+
+interface ServiceWorkerChannel {
+    type: "serviceWorker";
+    baseUrl: string;
+    timeout: number;
+}
+
+export class ServiceWorkerError extends Error {
+    // To avoid having to use instanceof
+    public readonly type = "ServiceWorkerError";
+
+    constructor(
+        public url: string,
+        public status: number,
+    ) {
+        super(`Received status ${status} from ${url}. Ensure the service worker is registered and active.`);
+        // See https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work for info about this workaround.
+        Object.setPrototypeOf(this, ServiceWorkerError.prototype);
+    }
+}
+
+export type Channel = AtomicsChannel | ServiceWorkerChannel;
+
+export function writeMessageAtomics(channel: AtomicsChannel, message: any): void {
+    const encoder = new TextEncoder();
+    const bytes = encoder.encode(JSON.stringify(message));
+    const { data, meta } = channel;
+    if (bytes.length > data.length) {
+        throw new Error("Message is too big, increase bufferSize when making channel.");
+    }
+    data.set(bytes, 0);
+    Atomics.store(meta, 0, bytes.length);
+    Atomics.store(meta, 1, 1);
+    Atomics.notify(meta, 1);
+}
+
+export async function writeMessageServiceWorker(
+    channel: ServiceWorkerChannel,
+    message: any,
+    messageId: string,
+): Promise<void> {
+    await navigator.serviceWorker.ready;
+    const url = channel.baseUrl + "/write";
+    const startTime = Date.now();
+    while (true) {
+        const request: ServiceWorkerWriteRequest = { message, messageId };
+        const response = await fetch(url, {
+            method: "POST",
+            body: JSON.stringify(request),
+        });
+        if (response.status === 200 && (await response.json()).version === VERSION) {
+            return;
+        }
+        if (Date.now() - startTime < channel.timeout) {
+            await asyncSleep(100);
+            continue;
+        }
+        throw new ServiceWorkerError(url, response.status);
+    }
+}
+
+/**
+ * Call this in the browser's main UI thread
+ * to send a message to the worker reading from the channel with `readMessage`.
+ *
+ * @param channel a non-null object returned by `makeChannel`, `makeAtomicsChannel`, or `makeServiceWorkerChannel`.
+ * @param message any object that can be safely passed to `JSON.stringify` and then decoded with `JSON.parse`.
+ * @param messageId a unique string identifying the message that the worker is waiting for.
+ *                  Currently only used by service worker channels.
+ */
+export async function writeMessage(channel: Channel, message: any, messageId: string): Promise<void> {
+    if (channel.type === "atomics") {
+        writeMessageAtomics(channel, message);
+    } else {
+        await writeMessageServiceWorker(channel, message, messageId);
+    }
+}
+
+/**
+ * Accepts one optional argument `options` with optional keys for configuring the different types of channel.
+ * See the types `AtomicsChannelOptions` and `ServiceWorkerChannelOptions` for more info.
+ *
+ * If `SharedArrayBuffer` is available, `makeChannel` will use it to create an `atomics` type channel.
+ * Otherwise, if `navigator.serviceWorker` is available, it will create a `serviceWorker` type channel,
+ * but registering the service worker is up to you.
+ * If that's not available either, it'll return `null`.
+ *
+ * Channel objects have a `type` property which is either `"atomics"` or `"serviceWorker"`.
+ * The other properties are for internal use.
+ *
+ * If you want to control the type of channel,
+ * you can call `makeAtomicsChannel` or `makeServiceWorkerChannel` directly.
+ *
+ * A single channel object shouldn't be used by multiple workers simultaneously,
+ * i.e. you should only read/write one message at a time.
+ */
+export function makeChannel(
+    options: {
+        atomics?: AtomicsChannelOptions;
+        serviceWorker?: ServiceWorkerChannelOptions;
+    } = {},
+): Channel | null {
+    if (typeof SharedArrayBuffer !== "undefined") {
+        return makeAtomicsChannel(options.atomics);
+    } else if ("serviceWorker" in navigator) {
+        return makeServiceWorkerChannel(options.serviceWorker);
+    } else {
+        return null;
+    }
+}
+
+export function makeAtomicsChannel({ bufferSize }: AtomicsChannelOptions = {}): AtomicsChannel {
+    const data = new Uint8Array(new SharedArrayBuffer(bufferSize || 128 * 1024));
+    const meta = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2));
+    return { type: "atomics", data, meta };
+}
+
+export function makeServiceWorkerChannel(options: ServiceWorkerChannelOptions = {}): ServiceWorkerChannel {
+    const baseUrl = (options.scope || "/") + BASE_URL_SUFFIX;
+    return { type: "serviceWorker", baseUrl, timeout: options.timeout || 5000 };
+}
+
+function ensurePositiveNumber(n: number | undefined, defaultValue: number): number {
+    if (n === undefined) {
+        return defaultValue;
+    }
+    return n > 0 ? +n : defaultValue;
+}
+
+/**
+ * Call this in a web worker to synchronously receive a message sent by the main thread with `writeMessage`.
+ *
+ * @param channel a non-null object returned by `makeChannel`, `makeAtomicsChannel`, or `makeServiceWorkerChannel`.
+ *                Should be created once in the main thread and then sent to the worker.
+ * @param messageId a unique string identifying the message that the worker is waiting for.
+ *                  Currently only used by service worker channels.
+ *                  Typically created in the worker using the `uuidv4` function and then sent to the main thread
+ *                  *before* calling `readMessage`.
+ * @param checkInterrupt a function which may be called regularly while `readMessage`
+ *                       is checking for messages on the channel.
+ *                       If it returns `true`, then `readMessage` will return `null`.
+ * @param timeout a number of milliseconds.
+ *                If this much time elapses without receiving a message, `readMessage` will return `null`.
+ */
+export function readMessage(
+    channel: Channel,
+    messageId: string,
+    {
+        checkInterrupt,
+        checkTimeout,
+        timeout,
+    }: {
+        checkInterrupt?: () => boolean;
+        checkTimeout?: number;
+        timeout?: number;
+    } = {},
+): any {
+    const startTime = performance.now();
+
+    let interval = ensurePositiveNumber(checkTimeout, checkInterrupt ? 100 : 5000);
+    const totalTimeout = ensurePositiveNumber(timeout, Number.POSITIVE_INFINITY);
+    let check;
+
+    if (channel.type === "atomics") {
+        const { data, meta } = channel;
+
+        check = () => {
+            if (Atomics.wait(meta, 1, 0, interval) === "timed-out") {
+                return null;
+            } else {
+                const size = Atomics.exchange(meta, 0, 0);
+                const bytes = data.slice(0, size);
+                Atomics.store(meta, 1, 0);
+
+                const decoder = new TextDecoder();
+                const text = decoder.decode(bytes);
+                return JSON.parse(text);
+            }
+        };
+    } else {
+        check = () => {
+            const request = new XMLHttpRequest();
+            // `false` makes the request synchronous
+            const url = channel.baseUrl + "/read";
+            request.open("POST", url, false);
+            const requestBody: ServiceWorkerReadRequest = {
+                messageId,
+                timeout: interval,
+            };
+            request.send(JSON.stringify(requestBody));
+            const { status } = request;
+
+            if (status === 408) {
+                return null;
+            } else if (status === 200) {
+                const response = JSON.parse(request.responseText);
+                if (response.version !== VERSION) {
+                    return null;
+                }
+                return response.message;
+            } else if (performance.now() - startTime < channel.timeout) {
+                return null;
+            } else {
+                throw new ServiceWorkerError(url, status);
+            }
+        };
+    }
+
+    while (true) {
+        const elapsed = performance.now() - startTime;
+        const remaining = totalTimeout - elapsed;
+        if (remaining <= 0) {
+            return null;
+        }
+
+        interval = Math.min(interval, remaining);
+        const result = check();
+
+        if (result !== null) {
+            return result;
+        } else if (checkInterrupt?.()) {
+            return null;
+        }
+    }
+}
+
+/**
+ * Synchronously waits until the given time has elapsed without wasting CPU in a busy loop,
+ * but not very accurate.
+ */
+export function syncSleep(ms: number, channel: Channel): void {
+    const duration = ensurePositiveNumber(ms, 0);
+    if (!duration) {
+        return;
+    }
+
+    if (typeof SharedArrayBuffer !== "undefined") {
+        const arr = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+        arr[0] = 0;
+        Atomics.wait(arr, 0, 0, duration);
+    } else {
+        const messageId = `sleep ${duration} ${uuidv4()}`;
+        readMessage(channel, messageId, { timeout: duration });
+    }
+}
+
+/**
+ * Returns a unique random string in UUID v4 format.
+ * Uses `crypto.randomUUID` directly if possible.
+ * Otherwise uses a custom implementation which uses `crypto.getRandomValues`.
+ */
+export let uuidv4: () => string;
+
+if ("randomUUID" in crypto) {
+    uuidv4 = function uuidv4() {
+        return (crypto as any).randomUUID();
+    };
+} else {
+    // https://stackoverflow.com/a/2117523/2482744
+    uuidv4 = function uuidv4() {
+        return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (char) => {
+            const c = Number(char);
+            return (c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))).toString(16);
+        });
+    };
+}

--- a/src/sync/pyodide.ts
+++ b/src/sync/pyodide.ts
@@ -1,0 +1,321 @@
+/**
+ * Vendored from pyodide-worker-runner (https://github.com/alexmojaki/pyodide-worker-runner).
+ * Copyright (c) 2022 Alex Hall. MIT licensed, see THIRD-PARTY-NOTICES.md.
+ */
+import pRetry from "p-retry";
+import { SyncClient, syncExpose, SyncExtras } from "./SyncClient";
+import * as Comlink from "comlink";
+import { loadPyodide, PyodideInterface, version as npmVersion } from "pyodide";
+
+export type PyodideLoader = () => Promise<PyodideInterface>;
+export interface PackageOptions {
+    url: string; // URL to fetch the package from
+
+    // These arguments are passed to `pyodide.unpackArchive`
+    // (https://pyodide.org/en/stable/usage/api/js-api.html#pyodide.unpackArchive)
+    format: string; // By default the options are 'bztar', 'gztar', 'tar', 'zip', and 'wheel'
+    extractDir?: string; // Defaults to /tmp/
+}
+
+/**
+ * Loads the Pyodide module from the official CDN as suggested in
+ * https://pyodide.org/en/stable/usage/quickstart.html#setup.
+ * To load a specific version, pass a string such as "1.2.3" as the argument.
+ * By default, uses `pyodide.version`, i.e. the version you have installed from npm
+ * as a peer dependency.
+ */
+export async function defaultPyodideLoader(version: string = npmVersion): Promise<PyodideInterface> {
+    const indexURL = `https://cdn.jsdelivr.net/pyodide/v${version}/full/`;
+    const result = await loadPyodide({ indexURL });
+    if (result.version !== version) {
+        throw new Error(`loadPyodide loaded version ${result.version} instead of ${version}`);
+    }
+    return result;
+}
+
+/**
+ * Converts a version string to an array of numbers,
+ * e.g. "1.2.3" -> [1, 2, 3]
+ */
+export function versionInfo(version: string): number[] {
+    return version.split(".").map(Number);
+}
+
+/**
+ * Loads Pyodide in parallel to downloading an archive with your own code and dependencies,
+ * which it then unpacks into the virtual filesystem ready for you to import.
+ *
+ * This helps you to work with Python code normally with several `.py` files
+ * instead of a giant string passed to Pyodide's `runPython`.
+ * It also lets you start up more quickly instead of waiting for Pyodide to load
+ * before calling `loadPackage` or `micropip.install`.
+ *
+ * The archive should contain your own Python files and any Python dependencies.
+ * A simple way to gather Python dependencies into a folder is with `pip install -t <folder>`.
+ * The location where the archive is extracted will be added to `sys.path` so it can be imported immediately,
+ * e.g. with [`pyodide.pyimport`](https://pyodide.org/en/stable/usage/api/js-api.html#pyodide.pyimport).
+ * There should be no top-level folder in the archive containing everything else,
+ * or that's what you'll have to import.
+ *
+ * If you don't use `loadPyodideAndPackage` and just load Pyodide yourself,
+ * then we recommend passing the resulting module object to `initPyodide` for some other housekeeping.
+ *
+ * Loading of both Pyodide and the package is retried up to 3 times in case of network errors.
+ *
+ * The raw contents of the package are cached in memory to avoid re-downloading in case of
+ * a fatal error which requires reloading Pyodide.
+ *
+ * @param packageOptions Object which describes how to load the package file, with the following keys:
+ *    - `url`: URL to fetch the package from.
+ *    - `format`: File format which determines how to extract the archive.
+ *                By default the options are 'bztar', 'gztar', 'tar', 'zip', and 'wheel'.
+ *    - `extractDir`: Directory to extract the archive into. Defaults to /tmp/.
+ * @param pyodideLoader Optional function which takes no arguments and returns the Pyodide module as returned by the
+ *    [`loadPyodide`](https://pyodide.org/en/stable/usage/api/js-api.html#globalThis.loadPyodide) function.
+ *    Defaults to `defaultPyodideLoader`which uses the
+ *    [official CDN](https://pyodide.org/en/stable/usage/quickstart.html#setup).
+ */
+export async function loadPyodideAndPackage(
+    packageOptions: PackageOptions,
+    pyodideLoader: PyodideLoader = defaultPyodideLoader,
+): Promise<PyodideInterface> {
+    const { format, url } = packageOptions;
+    const extractDir = packageOptions.extractDir || "/tmp/";
+
+    const [pyodide, packageBuffer] = await Promise.all([
+        pRetry(() => pyodideLoader(), { retries: 3 }),
+        pRetry(() => getPackageBuffer(url), { retries: 3 }),
+    ]);
+
+    const vInfo = versionInfo(pyodide.version);
+    pyodide.unpackArchive(
+        packageBuffer,
+        format,
+        vInfo[0] === 0 && vInfo[1] <= 19 ? (extractDir as any) : { extractDir },
+    );
+
+    const sys = pyodide.pyimport("sys");
+    sys.path.append(extractDir);
+
+    initPyodide(pyodide);
+
+    return pyodide;
+}
+
+/**
+ * Initializes the given Pyodide module with some extra functionality:
+ *   - `pyodide.registerComlink(Comlink)` makes `Comlink` (and thus `comsync` and the `PyodideClient`) work better.
+ *   - Imports the `pyodide_worker_runner` Python module included with this library, which:
+ *     - Immediately calls `sys.setrecursionlimit` so that deep recursion causes a Python `RecursionError`
+ *       instead of a fatal JS `RangeError: Maximum call stack size exceeded`.
+ *     - Provides the `install_imports` function which allows automatically installing imported modules, similar to
+ *       [`loadPackagesFromImports`](https://pyodide.org/en/stable/usage/api/js-api.html#pyodide.loadPackagesFromImports)
+ *       but also loads packages which are not built into Pyodide but can be installed with `micropip`,
+ *       i.e. pure Python packages with wheels available on PyPI.
+ */
+export function initPyodide(pyodide: PyodideInterface): void {
+    pyodide.registerComlink(Comlink);
+
+    pyodide.pyimport("pyodide_worker_runner");
+}
+
+const packageCache = new Map<string, ArrayBuffer>();
+
+async function getPackageBuffer(url: string): Promise<ArrayBuffer> {
+    if (packageCache.has(url)) {
+        console.log("Loaded package from cache");
+        return packageCache.get(url)!;
+    }
+    console.log("Fetching package from " + url.slice(0, 100) + "...");
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error(`Request for package failed with status ${response.status}: ${response.statusText}`);
+    }
+    const result = await response.arrayBuffer();
+    console.log("Fetched package");
+    packageCache.set(url, result);
+    return result;
+}
+
+/**
+ * See the description of output parts in
+ * https://github.com/alexmojaki/python_runner#callback-events
+ */
+export interface OutputPart {
+    type: string;
+    text: string;
+    [key: string]: unknown;
+}
+
+export interface RunnerCallbacks {
+    input?: (prompt: string) => void;
+    output: (parts: OutputPart[]) => unknown;
+    other?: (type: string, data: unknown) => unknown;
+}
+
+/**
+ * Construct a callback function which can be passed to `python_runner` to handle events.
+ * See https://github.com/alexmojaki/python_runner#callback-events
+ *
+ * @param comsyncExtras
+ *    In a web worker script, you need to pass a function to `pyodideExpose` from this library.
+ *    That function will be passed `extras` as its first argument which can then be used here.
+ *    `extras` is expected to contain a `channel` created by the `makeChannel` function from
+ *    the [`sync-message`](https://github.com/alexmojaki/sync-message) library
+ *    which was then passed to `PyodideClient` in the main thread.
+ *    This enables synchronous communication between the main thread and the worker,
+ *    which is used by the callback to handle `input` and `sleep` events properly.
+ *    See https://github.com/alexmojaki/pyodide-worker-runner#comsync-integration for more info.
+ * @param callbacks
+ *    An object containing callback functions to handle the different event types.
+ *      - `output`: Required. Called with an array of output parts,
+ *         e.g. `[{type: "stdout", text: "Hello world"}]`.
+ *         Use this to tell your UI to display the output.
+ *      - `input`: Optional. Called when the Python code reads from `sys.stdin`, e.g. with `input()`.
+ *         Use this to tell your UI to wait for the user to enter some text.
+ *         The entered text should be passed to `PyodideClient.writeMessage()` in the main thread,
+ *         and will be returned synchronously by this function to the Python code.
+ *         When the Python code calls `input(prompt)`, the string `prompt` is passed to this callback.
+ *         Two types of output part will also be passed to the `output` callback:
+ *             - `input_prompt`: the prompt passed to the `input()` function.
+ *               Using this output part may be a better way to display the prompt in the UI
+ *               than the argument of the `input` callback, but the `input` callback is still needed
+ *               even if it doesn't display the prompt.
+ *              - `input`: the user's input passed to stdin.
+ *                Not actually 'output', but included as an output part
+ *                because it's typically shown in regular Python consoles.
+ *      - `other`: Optional. Called for all other event types
+ *        (except `sleep` which is handled directly by `makeRunnerCallback`).
+ *        The actual event type is passed as the first argument.
+ */
+export function makeRunnerCallback(
+    comsyncExtras: SyncExtras,
+    callbacks: RunnerCallbacks,
+): (type: string, data: any) => any {
+    return function (type: string, rawData: any): any {
+        const data = rawData.toJs ? rawData.toJs({ dict_converter: Object.fromEntries }) : rawData;
+
+        if (type === "input") {
+            callbacks.input?.(data.prompt);
+            return comsyncExtras.readMessage() + "\n";
+        } else if (type === "sleep") {
+            comsyncExtras.syncSleep(data.seconds * 1000);
+        } else if (type === "output") {
+            return callbacks.output(data.parts);
+        } else {
+            return callbacks.other!(type, data);
+        }
+    };
+}
+
+export interface PyodideExtras extends SyncExtras {
+    interruptBuffer: Int32Array | null;
+}
+
+/**
+ * Call this in your web worker code with a function `func`
+ * to allow it to be called from the main thread by `PyodideClient.call`.
+ *
+ * `func` will be called with an object `extras` of type `PyodideExtras` as its first argument.
+ * The other arguments are those passed to `PyodideClient.call`,
+ * and the return value is passed back to the main thread and returned from `PyodideClient.call`.
+ *
+ * `func` will be wrapped into a new function which is returned here.
+ * The returned function should be passed to `Comlink.expose`, possibly as part of a larger object.
+ *
+ * For example, the worker code may look something like this:
+ *
+ *     Comlink.expose({
+ *       myRunCode: pyodideExpose((extras, code) => {
+ *         pyodide.runCode(code);
+ *       }),
+ *     });
+ *
+ * and the main thread code may look something like this:
+ *
+ *    await client.call(client.workerProxy.myRunCode, "print('Hello world')");
+ *
+ * It's recommended to pass `extras` to `makeRunnerCallback` and then pass the resulting callback
+ * to a `python_runner.PyodideRunner` instead of calling `pyodide.runCode` directly.
+ *
+ * If possible, `extras.interruptBuffer` will be a `SharedArrayBuffer` which can be used like this:
+ *
+ *     if (extras.interruptBuffer) {
+ *       pyodide.setInterruptBuffer(extras.interruptBuffer);
+ *     }
+ *
+ * This will allow the main thread to call `PyodideClient.interrupt()`
+ * to raise `KeyboardInterrupt` in Python code running in Pyodide in the worker thread.
+ * `setInterruptBuffer` isn't called automatically so that you can choose the correct place to call it,
+ * after running any Python code that musn't be interrupted.
+ */
+export function pyodideExpose<T extends any[], R>(
+    func: (extras: PyodideExtras, ...args: T) => R,
+): (...args: any[]) => Promise<R> {
+    return syncExpose(function (comsyncExtras: SyncExtras, interruptBuffer: Int32Array | null, ...args: T): R {
+        return func({ ...comsyncExtras, interruptBuffer }, ...args);
+    });
+}
+
+/**
+ * This class should be used in the main browser thread
+ * to call functions exposed with `pyodideExpose` and `Comlink.expose` in a web worker.
+ * See https://github.com/alexmojaki/comsync to learn how to use the base class `SyncClient`.
+ * What this class adds is making it easier to interrupt Python code running in Pyodide in the worker.
+ * Specifically, if `SharedArrayBuffer` is available, then `PyodideClient.call` will pass a buffer
+ * so that the function passed to `pyodideExpose` can call `pyodide.setInterruptBuffer(extras.interruptBuffer)`
+ * to enable interruption. Then `PyodideClient.interrupt()` will use the buffer.
+ * Otherwise, `PyodideClient.interrupt()` will likely restart the web worker entirely, which is more disruptive.
+ */
+export class PyodideClient<T = any> extends SyncClient<T> {
+    async call(proxyMethod: any, ...args: any[]): Promise<any> {
+        let interruptBuffer: Int32Array | null = null;
+        if (typeof SharedArrayBuffer !== "undefined") {
+            const buffer = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 1));
+            interruptBuffer = buffer;
+            this.interrupter = () => {
+                buffer[0] = 2;
+            };
+        }
+
+        return super.call(proxyMethod, interruptBuffer, ...args);
+    }
+}
+
+/**
+ * This class handles automatically reloading Pyodide from scratch when a fatal error occurs.
+ * The constructor accepts a 'loader' function which should return a promise that resolves to a Pyodide module.
+ * We recommend a function which calls `loadPyodideAndPackage`.
+ * The loader function will be called immediately on construction.
+ *
+ * Code that uses the Pyodide module should be wrapped in a `withPyodide` call, e.g:
+ *
+ *    await pyodideFatalErrorReloader.withPyodide(async (pyodide) => {
+ *      pyodide.runCode(...);
+ *    });
+ *
+ * If a fatal error occurs, the loader function will be called again immediately to reload Pyodide in the background,
+ * while the error is rethrown for you to handle.
+ * The next call to `withPyodide` will then be able to use the new Pyodide instance.
+ *
+ * In general, `withPyodide` will wait for the loader function to complete, and will throw any errors it throws.
+ */
+export class PyodideFatalErrorReloader {
+    private pyodidePromise: Promise<PyodideInterface>;
+
+    constructor(private readonly loader: PyodideLoader) {
+        this.pyodidePromise = loader();
+    }
+
+    public async withPyodide<T>(fn: (pyodide: PyodideInterface) => Promise<T>): Promise<T> {
+        const pyodide = await this.pyodidePromise;
+        try {
+            return await fn(pyodide);
+        } catch (e: any) {
+            if (e.pyodide_fatal_error) {
+                this.pyodidePromise = this.loader();
+            }
+            throw e;
+        }
+    }
+}

--- a/test/__mocks__/MockBackend.ts
+++ b/test/__mocks__/MockBackend.ts
@@ -1,4 +1,4 @@
-import { SyncExtras } from "comsync";
+import { SyncExtras } from "../../src/sync/SyncClient";
 import { Backend, WorkerDiagnostic } from "../../src/backend/Backend";
 import { BackendEventType } from "../../src/communication/BackendEvent";
 import { vi } from "vitest";

--- a/test/__tests__/sync/SyncClient.test.ts
+++ b/test/__tests__/sync/SyncClient.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { InterruptError, SyncClient } from "../../../src/sync/SyncClient";
+import { makeServiceWorkerChannel } from "../../../src/sync/channel";
+
+function idleClient(): SyncClient {
+    const url = URL.createObjectURL(new Blob([""], { type: "text/javascript" }));
+    return new SyncClient(() => new Worker(url), makeServiceWorkerChannel());
+}
+
+describe("SyncClient", () => {
+    it("starts idle with a worker", () => {
+        const client = idleClient();
+        expect(client.state).toBe("idle");
+        expect(client.worker).toBeInstanceOf(Worker);
+        client.terminate();
+    });
+
+    it("refuses a second concurrent call", async () => {
+        const client = idleClient();
+        client.state = "running";
+        await expect(client.call(async () => undefined)).rejects.toThrow("State is running, not idle");
+        client.terminate();
+    });
+
+    it("refuses to write a message when no call is active", async () => {
+        const client = idleClient();
+        await expect(client.writeMessage("hello")).rejects.toThrow("No active call to send a message to.");
+        client.terminate();
+    });
+
+    it("ignores an interrupt while idle", async () => {
+        const client = idleClient();
+        const worker = client.worker;
+        await client.interrupt();
+        expect(client.state).toBe("idle");
+        expect(client.worker).toBe(worker);
+        client.terminate();
+    });
+
+    it("replaces the worker when interrupting a run that is not waiting for input", async () => {
+        const client = idleClient();
+        const worker = client.worker;
+        client.state = "running";
+        await client.interrupt();
+        expect(client.state).toBe("idle");
+        expect(client.worker).not.toBe(worker);
+        client.terminate();
+    });
+
+    it("rejects the in-flight call with an InterruptError when terminated", async () => {
+        const client = idleClient();
+        const call = client.call(() => new Promise(() => undefined));
+        await Promise.resolve();
+        client.terminate();
+        await expect(call).rejects.toBeInstanceOf(InterruptError);
+    });
+});

--- a/test/__tests__/sync/channel.test.ts
+++ b/test/__tests__/sync/channel.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+    isServiceWorkerRequest,
+    makeChannel,
+    makeServiceWorkerChannel,
+    readMessage,
+    serviceWorkerFetchListener,
+} from "../../../src/sync/channel";
+
+/**
+ * The wire protocol below is frozen on purpose. A freshly deployed Papyros must keep working
+ * with a service worker that an earlier deploy already registered in the browser, so the URL
+ * suffix and the version string may not change without a migration path.
+ */
+const BASE_URL_SUFFIX = "__SyncMessageServiceWorkerInput__";
+const VERSION = "__sync-message-v2__";
+
+type Responder = (e: any) => boolean;
+
+function fakeEvent(url: string, body: unknown = {}): { event: any; response: Promise<Response> } {
+    let resolveResponse: (r: Response | Promise<Response>) => void;
+    const response = new Promise<Response>((resolve) => {
+        resolveResponse = resolve;
+    });
+    const event = {
+        request: { url, json: async () => body },
+        respondWith: (r: Response | Promise<Response>) => resolveResponse(r),
+    };
+    return { event, response };
+}
+
+function read(listener: Responder, messageId: string, timeout = 50): Promise<Response> {
+    const { event, response } = fakeEvent(`/${BASE_URL_SUFFIX}/read`, { messageId, timeout });
+    listener(event);
+    return response;
+}
+
+function write(listener: Responder, messageId: string, message: unknown): Promise<Response> {
+    const { event, response } = fakeEvent(`/${BASE_URL_SUFFIX}/write`, { messageId, message });
+    listener(event);
+    return response;
+}
+
+describe("isServiceWorkerRequest", () => {
+    it("recognises a sync-message url and ignores others", () => {
+        expect(isServiceWorkerRequest(`/${BASE_URL_SUFFIX}/read`)).toBe(true);
+        expect(isServiceWorkerRequest("/assets/app.js")).toBe(false);
+    });
+
+    it("accepts a fetch event as well as a string", () => {
+        const event = { request: { url: `/${BASE_URL_SUFFIX}/write` } } as any;
+        expect(isServiceWorkerRequest(event)).toBe(true);
+    });
+});
+
+describe("channel construction", () => {
+    it("falls back to a service worker channel when SharedArrayBuffer is unavailable", () => {
+        // The test page is not cross-origin isolated, so this is the path Dodona runs in production
+        expect(typeof SharedArrayBuffer).toBe("undefined");
+        expect(makeChannel()).toMatchObject({ type: "serviceWorker", baseUrl: `/${BASE_URL_SUFFIX}` });
+    });
+
+    it("honours a custom scope and timeout", () => {
+        const channel = makeServiceWorkerChannel({ scope: "/papyros/", timeout: 1234 });
+        expect(channel).toEqual({
+            type: "serviceWorker",
+            baseUrl: `/papyros/${BASE_URL_SUFFIX}`,
+            timeout: 1234,
+        });
+    });
+});
+
+describe("serviceWorkerFetchListener", () => {
+    it("leaves unrelated requests alone", () => {
+        expect(serviceWorkerFetchListener()(fakeEvent("/assets/app.js").event)).toBe(false);
+    });
+
+    it("reports the frozen protocol version", async () => {
+        const { event, response } = fakeEvent(`/${BASE_URL_SUFFIX}/version`);
+        expect(serviceWorkerFetchListener()(event)).toBe(true);
+        expect(await (await response).text()).toBe(VERSION);
+    });
+
+    it("delivers a message written before the read", async () => {
+        const listener = serviceWorkerFetchListener();
+        await write(listener, "id-1", "written first");
+        const body = await (await read(listener, "id-1")).json();
+        expect(body).toEqual({ message: "written first", version: VERSION });
+    });
+
+    it("delivers a message written while the read is pending", async () => {
+        const listener = serviceWorkerFetchListener();
+        const pending = read(listener, "id-2", 5000);
+        await write(listener, "id-2", "written second");
+        const body = await (await pending).json();
+        expect(body).toEqual({ message: "written second", version: VERSION });
+    });
+
+    it("times out a read with status 408", async () => {
+        const listener = serviceWorkerFetchListener();
+        expect((await read(listener, "id-3", 10)).status).toBe(408);
+    });
+});
+
+describe("readMessage", () => {
+    it("gives up and returns null once the total timeout elapses", () => {
+        const channel = makeServiceWorkerChannel();
+        // No service worker is controlling this page, so every check fails and the deadline is hit
+        expect(readMessage(channel, "never-answered", { timeout: 20, checkTimeout: 5 })).toBeNull();
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -840,11 +840,6 @@ comlink@^4.4.1:
   resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.4.2.tgz#cbbcd82742fbebc06489c28a183eedc5c60a2bca"
   integrity sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==
 
-comsync@^0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/comsync/-/comsync-0.0.9.tgz#3fee72ab23da603450350fb505820ea80d88e794"
-  integrity sha512-5xM6K5eiPHtDS9Ehrm6ib3dPQ3p2uQDFzgCgd2dmtCdSOkmj8SnesMtFB/scA/deJNaMFkNucdJ9plpWWdayHw==
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1567,7 +1562,7 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
-p-retry@^5.0.0:
+p-retry@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-5.1.2.tgz#c16eaee4f2016f9161d12da40d3b8b0f2e3c1b76"
   integrity sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==
@@ -1671,13 +1666,6 @@ punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
-
-pyodide-worker-runner@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/pyodide-worker-runner/-/pyodide-worker-runner-1.4.0.tgz#45a3db9ddc682396e90b055770025625411a664d"
-  integrity sha512-t9v49q4sWSlywNMoMPw1Zs9FBpCP70wkHB5zzzmOErIxPS3w3HVxiwSI/ldpT1GH1exLEPGz16YHGVa65XqdHw==
-  dependencies:
-    p-retry "^5.0.0"
 
 pyodide@^314.0.0:
   version "314.0.3"
@@ -1793,11 +1781,6 @@ style-mod@^4.0.0, style-mod@^4.1.0:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.1.3.tgz#6e9012255bb799bdac37e288f7671b5d71bf9f73"
   integrity sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==
-
-sync-message@^0.0.12:
-  version "0.0.12"
-  resolved "https://registry.yarnpkg.com/sync-message/-/sync-message-0.0.12.tgz#5e4fd5c025ba4be7b04d7237662d9948085bf7ce"
-  integrity sha512-ySLe+P2U91a51SbWNUvDvAxCct+EKd5PKq3ptJoCZty7oxrf3+VFXxoskreLqrmN6VFxagqcXloz7fcFS08UFw==
 
 synckit@^0.11.13:
   version "0.11.13"


### PR DESCRIPTION
This pull request vendors `sync-message`, `comsync` and `pyodide-worker-runner` into `src/sync/`, as phase 1 of #1081.

These three packages implement the synchronous channel that lets Python `input()` and `time.sleep()` block a worker until the main thread answers. All three are unmaintained by the same author, and adding a JSPI transport requires changing their internals, so Papyros now owns the code. No behaviour changes, no public API changes: `src/Library.ts` re-exported none of their types.

Two things could not be copied verbatim, because the upstream code was written without TypeScript strict mode and against a webpack `raw-loader` import, neither of which this repo uses:

- `worker` and `workerProxy` became private fields with getters, so `SyncClient` can keep deleting them on `terminate()` without touching the 9 call sites in `Runner.ts`. `readMessage` reassigned its optional `checkTimeout` parameter, now a properly typed local.
- `pyodide_worker_runner.py` now ships inside `python_package.tar.gz` next to `turtle.py`, instead of being written to `/tmp` at runtime. `build_library.sh` compiles with `tsc`, not vite, so a `?raw` import would have leaked into `dist` unresolved and broken bundling for consumers. This was a phase 2 item in #1081, pulled forward out of necessity.

Also folded in the latent bug #1081 flagged: `BackendManager` built a throwaway channel at import time that `Papyros.configureInput` immediately replaced. Not reachable today, since backends are created lazily after `configureInput`, but it meant any backend constructed earlier would have captured the wrong channel.

**Licensing**

All three are MIT and copyright (c) 2022 Alex Hall, with identical license text. The notice is retained per file, in `THIRD-PARTY-NOTICES.md`, and in the README. Note that `.npmignore` was `/*` plus `!/dist`, so a root notices file would not have shipped in the npm tarball even though `dist` contains the compiled vendored code. It now has an explicit exception, verified with `npm pack --dry-run`.

**Manual testing instructions**

No user-visible change is expected. To confirm the service worker path still works end to end:

- `yarn setup && yarn build:sw && yarn start`
- Run `print(input())` in the scratchpad, enter a value, confirm it echoes
- Run `import time; time.sleep(2); print("done")`, confirm the delay
- Press Stop during `input()` and during an infinite loop, confirm both recover

**Verification**

<details>
<summary>Suite, typecheck, lint and library build</summary>

| Check | Before | After |
|---|---|---|
| `yarn vitest --run` | 7 files / 74 tests | 9 files / 90 tests, green |
| `yarn typecheck` | clean | clean |
| `yarn lint` | clean | clean |
| `yarn build:lib` | n/a | succeeds, no dangling references to the removed packages |

16 new tests. `test/__tests__/sync/channel.test.ts` asserts the literal wire strings `__SyncMessageServiceWorkerInput__` and `__sync-message-v2__` rather than the constants, so a rename cannot silently break a browser still running a service worker registered by an earlier deploy. It covers both delivery orders (write before read, write during a pending read), the 408 timeout and the `/version` handshake. `test/__tests__/sync/SyncClient.test.ts` covers the state machine, including that interrupting a run which is not waiting for input replaces the worker.

</details>

**Checklist**
- Tests: 16 new tests covering the service worker wire protocol, channel selection and the `SyncClient` state machine
- Docs: README gains a `sync` entry in the structure list and a third-party section; removed a line that claimed input handling works "via `sync-message`", which is no longer a dependency
- Announcement: n/a
- AI: Claude Code did the vendoring, the strict-mode and lint conformance, and wrote the tests

Part of #1081
