### PR TITLE
Merge the vendored sync modules into one coherent layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "comlink": "^4.4.1",
     "lit": "^3.3.1",
     "node-polyglot": "^2.6.0",
-    "p-retry": "^5.1.2",
     "pyodide": "^314.0.0"
   },
   "devDependencies": {

--- a/src/backend/Backend.ts
+++ b/src/backend/Backend.ts
@@ -1,5 +1,5 @@
 import { BackendEvent, BackendEventType } from "../communication/BackendEvent";
-import { syncExpose, SyncExtras } from "../sync/SyncClient";
+import { expose, SyncExtras } from "../sync/expose";
 import { BackendEventQueue } from "../communication/BackendEventQueue";
 
 export interface WorkerDiagnostic {
@@ -36,12 +36,12 @@ export enum RunMode {
     Doctest = "doctest",
 }
 
-export abstract class Backend<Extras extends SyncExtras = SyncExtras> {
+export abstract class Backend {
     /**
      * SyncExtras object that grants access to helpful methods
      * for synchronous operations
      */
-    protected extras: Extras;
+    protected extras: SyncExtras;
     /**
      * Callback to handle events published by this Backend
      */
@@ -56,19 +56,19 @@ export abstract class Backend<Extras extends SyncExtras = SyncExtras> {
      * Synchronously exposing methods should be done here
      */
     constructor() {
-        this.extras = {} as Extras;
+        this.extras = {} as SyncExtras;
         this.onEvent = () => {
             // Empty, initialized in launch
         };
-        this.runCode = this.syncExpose()(this.runCode.bind(this));
+        this.runCode = this.expose()(this.runCode.bind(this));
         this.queue = {} as BackendEventQueue;
     }
 
     /**
-     * @return {any} The function to expose methods for Comsync to allow interrupting
+     * @return {any} The wrapper that lets SyncClient drive exposed methods
      */
-    protected syncExpose(): any {
-        return syncExpose;
+    protected expose(): any {
+        return expose;
     }
 
     /**
@@ -103,12 +103,12 @@ export abstract class Backend<Extras extends SyncExtras = SyncExtras> {
 
     /**
      * Executes the given code
-     * @param {Extras} extras Helper properties to run code
+     * @param {SyncExtras} extras Helper properties to run code
      * @param {string} code The code to run
      * @param {string} mode The mode to run the code in
      * @return {Promise<void>} Promise of execution
      */
-    public abstract runCode(extras: Extras, code: string, mode?: string): Promise<void>;
+    public abstract runCode(extras: SyncExtras, code: string, mode?: string): Promise<void>;
 
     /**
      * Generate linting suggestions for the given code

--- a/src/backend/workers/javascript/JavaScriptWorker.ts
+++ b/src/backend/workers/javascript/JavaScriptWorker.ts
@@ -1,13 +1,13 @@
 import { Backend, WorkerDiagnostic } from "../../Backend";
 import { CompletionResult } from "@codemirror/autocomplete";
 import { BackendEventType } from "../../../communication/BackendEvent";
-import { SyncExtras } from "../../../sync/SyncClient";
+import { SyncExtras } from "../../../sync/expose";
 
 /**
  * Implementation of a JavaScript backend for Papyros
  * by using eval and overriding some builtins
  */
-export class JavaScriptWorker extends Backend<SyncExtras> {
+export class JavaScriptWorker extends Backend {
     /**
      * Convert varargs to a string, similar to how the console does it
      * @param {any[]} args The values to join into a string

--- a/src/backend/workers/python/PythonWorker.ts
+++ b/src/backend/workers/python/PythonWorker.ts
@@ -2,7 +2,8 @@ import { Backend, RunMode, WorkerDiagnostic } from "../../Backend";
 import { BackendEvent } from "../../../communication/BackendEvent";
 import { loadPyodide, PyodideInterface } from "pyodide";
 import { PyProxy } from "pyodide/ffi";
-import { pyodideExpose, PyodideExtras, loadPyodideAndPackage } from "../../../sync/pyodide";
+import { loadPyodideAndPackage } from "../../../sync/pyodide";
+import { SyncExtras } from "../../../sync/expose";
 
 const pythonPackageUrl = new URL("./python_package.tar.gz.load_by_url", import.meta.url).href;
 
@@ -10,7 +11,7 @@ const pythonPackageUrl = new URL("./python_package.tar.gz.load_by_url", import.m
  * Implementation of a Python backend for Papyros
  * Powered by Pyodide (https://pyodide.org/)
  */
-export class PythonWorker extends Backend<PyodideExtras> {
+export class PythonWorker extends Backend {
     private pyodide: PyodideInterface;
     private papyros: PyProxy | undefined;
     /**
@@ -25,13 +26,6 @@ export class PythonWorker extends Backend<PyodideExtras> {
 
     private static convert(data: any): any {
         return data.toJs ? data.toJs({ dict_converter: Object.fromEntries }) : data;
-    }
-
-    /**
-     * @return {any} Function to expose a method with Pyodide support
-     */
-    protected override syncExpose(): any {
-        return pyodideExpose;
     }
 
     private static async getPyodide(indexURL: string | undefined): Promise<PyodideInterface> {
@@ -91,7 +85,7 @@ export class PythonWorker extends Backend<PyodideExtras> {
         return modes;
     }
 
-    public override async runCode(extras: PyodideExtras, code: string, mode = "exec"): Promise<any> {
+    public override async runCode(extras: SyncExtras, code: string, mode = "exec"): Promise<any> {
         this.extras = extras;
         if (extras.interruptBuffer) {
             this.pyodide.setInterruptBuffer(extras.interruptBuffer);

--- a/src/communication/BackendManager.ts
+++ b/src/communication/BackendManager.ts
@@ -4,7 +4,6 @@ import { BackendEvent, BackendEventType } from "./BackendEvent";
 import { LogType, papyrosLog } from "../util/Logging";
 import { Channel } from "../sync/channel";
 import { SyncClient } from "../sync/SyncClient";
-import { PyodideClient } from "../sync/pyodide";
 /**
  * Callback type definition for subscribers
  * @param {BackendEvent} e The published event
@@ -124,7 +123,7 @@ export abstract class BackendManager {
         BackendManager.registerBackend(
             ProgrammingLanguage.Python,
             () =>
-                new PyodideClient<Backend>(
+                new SyncClient<Backend>(
                     () =>
                         new Worker(new URL("../backend/workers/python/worker", import.meta.url), {
                             type: "module",

--- a/src/sync/SyncClient.ts
+++ b/src/sync/SyncClient.ts
@@ -1,22 +1,19 @@
 /**
- * Vendored from comsync (https://github.com/alexmojaki/comsync).
+ * Vendored from comsync (https://github.com/alexmojaki/comsync) and
+ * pyodide-worker-runner (https://github.com/alexmojaki/pyodide-worker-runner).
  * Copyright (c) 2022 Alex Hall. MIT licensed, see THIRD-PARTY-NOTICES.md.
  */
-import { Channel, readMessage, uuidv4, writeMessage } from "./channel";
+import { Channel, uuidv4, writeMessage } from "./channel";
+import { InterruptError } from "./errors";
+import { makeMessageId, SyncMessageCallback } from "./expose";
 import * as Comlink from "comlink";
 
-export class InterruptError extends Error {
-    // To avoid having to use instanceof
-    public readonly type = "InterruptError";
-    public readonly name = this.type;
-}
-
-export class NoChannelError extends Error {
-    // To avoid having to use instanceof
-    public readonly type = "NoChannelError";
-    public readonly name = this.type;
-}
-
+/**
+ * Drives a worker whose methods were wrapped with `expose`, from the main thread.
+ *
+ * A worker blocked on input cannot answer Comlink messages, so every decision here is
+ * made from state tracked on this side. Asking the worker would deadlock whenever it is busy.
+ */
 export class SyncClient<T = any> {
     public interrupter?: () => void;
     public state: "idle" | "running" | "awaitingMessage" | "sleeping" = "idle";
@@ -46,6 +43,10 @@ export class SyncClient<T = any> {
         this._start();
     }
 
+    /**
+     * Stop the running call. A worker blocked on input or sleep is told through the channel,
+     * anything else needs the interrupt buffer, and without one the worker is replaced.
+     */
     public async interrupt(): Promise<void> {
         if (this.state === "idle") {
             return;
@@ -93,11 +94,19 @@ export class SyncClient<T = any> {
             }
         };
 
+        const interruptBuffer = this._makeInterruptBuffer();
+
         this._interruptPromise = new Promise((resolve, reject) => (this._interruptRejector = reject));
 
         try {
             return await Promise.race([
-                proxyMethod(this.channel, Comlink.proxy(syncMessageCallback), this._messageIdBase, ...args),
+                proxyMethod(
+                    this.channel,
+                    Comlink.proxy(syncMessageCallback),
+                    this._messageIdBase,
+                    interruptBuffer,
+                    ...args,
+                ),
                 this._interruptPromise,
             ]);
         } finally {
@@ -133,6 +142,21 @@ export class SyncClient<T = any> {
         delete this._worker;
     }
 
+    /**
+     * Pyodide can only raise KeyboardInterrupt through a shared buffer, which needs COOP/COEP.
+     * Without one, `interrupt` falls back to replacing the worker.
+     */
+    private _makeInterruptBuffer(): Int32Array | null {
+        if (typeof SharedArrayBuffer === "undefined") {
+            return null;
+        }
+        const buffer = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+        this.interrupter = (): void => {
+            buffer[0] = 2;
+        };
+        return buffer;
+    }
+
     private async _writeMessage(message: any): Promise<void> {
         this.state = "running";
         const messageId = makeMessageId(this._messageIdBase!, this._messageIdSeq);
@@ -152,68 +176,4 @@ export class SyncClient<T = any> {
         delete this._awaitingMessageResolve;
         delete this._messageIdBase;
     }
-}
-
-export interface SyncExtras {
-    channel: Channel | null;
-    readMessage: () => any;
-    syncSleep: (ms: number) => void;
-}
-
-type SyncMessageCallbackStatus = "init" | "reading" | "sleeping" | "slept";
-type SyncMessageCallback = (status: SyncMessageCallbackStatus) => void;
-
-export function syncExpose<T extends any[], R>(
-    func: (extras: SyncExtras, ...args: T) => R,
-): (
-    channel: Channel | null,
-    syncMessageCallback: SyncMessageCallback,
-    messageIdBase: string,
-    ...args: T
-) => Promise<R> {
-    return async function (
-        channel: Channel | null,
-        syncMessageCallback: SyncMessageCallback,
-        messageIdBase: string,
-        ...args: T
-    ): Promise<R> {
-        await syncMessageCallback("init");
-        let messageIdSeq = 0;
-
-        function fullSyncMessageCallback(status: "reading" | "sleeping", options?: { timeout: number }): any {
-            if (!channel) {
-                throw new NoChannelError();
-            }
-            syncMessageCallback(status);
-            const messageId = makeMessageId(messageIdBase, ++messageIdSeq);
-            const response = readMessage(channel, messageId, options);
-            if (response) {
-                const { message, interrupted } = response;
-                if (interrupted) {
-                    throw new InterruptError();
-                }
-                return message;
-            } else if (status === "sleeping") {
-                syncMessageCallback("slept");
-            }
-        }
-
-        const extras: SyncExtras = {
-            channel,
-            readMessage(): any {
-                return fullSyncMessageCallback("reading");
-            },
-            syncSleep(ms: number): void {
-                if (!(ms > 0)) {
-                    return;
-                }
-                fullSyncMessageCallback("sleeping", { timeout: ms });
-            },
-        };
-        return func(extras, ...args);
-    };
-}
-
-function makeMessageId(base: string, seq: number): string {
-    return `${base}-${seq}`;
 }

--- a/src/sync/SyncClient.ts
+++ b/src/sync/SyncClient.ts
@@ -129,6 +129,12 @@ export class SyncClient<T = any> {
                 this._awaitingMessageResolve = resolve;
             });
             delete this._awaitingMessageResolve;
+
+            // The call can end while the write is queued, which wakes it without any
+            // reader left to hand the message to
+            if (!this._messageIdBase) {
+                throw new Error("No active call to send a message to.");
+            }
         }
 
         await this._writeMessage({ message });
@@ -173,7 +179,10 @@ export class SyncClient<T = any> {
         this.state = "idle";
         delete this._interruptPromise;
         delete this._interruptRejector;
-        delete this._awaitingMessageResolve;
         delete this._messageIdBase;
+        // Wake a queued writeMessage so it fails fast rather than waiting forever
+        const awaitingMessageResolve = this._awaitingMessageResolve;
+        delete this._awaitingMessageResolve;
+        awaitingMessageResolve?.();
     }
 }

--- a/src/sync/channel.ts
+++ b/src/sync/channel.ts
@@ -246,7 +246,8 @@ export function makeAtomicsChannel({ bufferSize }: AtomicsChannelOptions = {}): 
 }
 
 export function makeServiceWorkerChannel(options: ServiceWorkerChannelOptions = {}): ServiceWorkerChannel {
-    const baseUrl = (options.scope || "/") + BASE_URL_SUFFIX;
+    const scope = options.scope || "/";
+    const baseUrl = (scope.endsWith("/") ? scope : scope + "/") + BASE_URL_SUFFIX;
     return { type: "serviceWorker", baseUrl, timeout: options.timeout || 5000 };
 }
 

--- a/src/sync/errors.ts
+++ b/src/sync/errors.ts
@@ -1,0 +1,22 @@
+/**
+ * Vendored from comsync (https://github.com/alexmojaki/comsync).
+ * Copyright (c) 2022 Alex Hall. MIT licensed, see THIRD-PARTY-NOTICES.md.
+ */
+
+/**
+ * Raised in the worker when the main thread interrupts a running call
+ */
+export class InterruptError extends Error {
+    // To avoid having to use instanceof
+    public readonly type = "InterruptError";
+    public readonly name = this.type;
+}
+
+/**
+ * Raised when a backend needs to block on the main thread but has no channel to do so
+ */
+export class NoChannelError extends Error {
+    // To avoid having to use instanceof
+    public readonly type = "NoChannelError";
+    public readonly name = this.type;
+}

--- a/src/sync/expose.ts
+++ b/src/sync/expose.ts
@@ -1,0 +1,86 @@
+/**
+ * Vendored from comsync (https://github.com/alexmojaki/comsync) and
+ * pyodide-worker-runner (https://github.com/alexmojaki/pyodide-worker-runner).
+ * Copyright (c) 2022 Alex Hall. MIT licensed, see THIRD-PARTY-NOTICES.md.
+ */
+import { Channel, readMessage } from "./channel";
+import { InterruptError, NoChannelError } from "./errors";
+
+/**
+ * Helpers handed to a backend method so it can block until the main thread answers
+ */
+export interface SyncExtras {
+    channel: Channel | null;
+    /**
+     * Buffer that lets the main thread raise KeyboardInterrupt in Pyodide.
+     * Only available when SharedArrayBuffer is, so null without COOP/COEP.
+     */
+    interruptBuffer: Int32Array | null;
+    readMessage: () => any;
+    syncSleep: (ms: number) => void;
+}
+
+export type SyncMessageCallbackStatus = "init" | "reading" | "sleeping" | "slept";
+export type SyncMessageCallback = (status: SyncMessageCallbackStatus) => void;
+
+export function makeMessageId(base: string, seq: number): string {
+    return `${base}-${seq}`;
+}
+
+/**
+ * Wrap a backend method so that SyncClient.call can drive it from the main thread.
+ * The wrapped method receives a SyncExtras as its first argument.
+ */
+export function expose<T extends any[], R>(
+    func: (extras: SyncExtras, ...args: T) => R,
+): (
+    channel: Channel | null,
+    syncMessageCallback: SyncMessageCallback,
+    messageIdBase: string,
+    interruptBuffer: Int32Array | null,
+    ...args: T
+) => Promise<R> {
+    return async function (
+        channel: Channel | null,
+        syncMessageCallback: SyncMessageCallback,
+        messageIdBase: string,
+        interruptBuffer: Int32Array | null,
+        ...args: T
+    ): Promise<R> {
+        await syncMessageCallback("init");
+        let messageIdSeq = 0;
+
+        function block(status: "reading" | "sleeping", options?: { timeout: number }): any {
+            if (!channel) {
+                throw new NoChannelError();
+            }
+            syncMessageCallback(status);
+            const messageId = makeMessageId(messageIdBase, ++messageIdSeq);
+            const response = readMessage(channel, messageId, options);
+            if (response) {
+                const { message, interrupted } = response;
+                if (interrupted) {
+                    throw new InterruptError();
+                }
+                return message;
+            } else if (status === "sleeping") {
+                syncMessageCallback("slept");
+            }
+        }
+
+        const extras: SyncExtras = {
+            channel,
+            interruptBuffer,
+            readMessage(): any {
+                return block("reading");
+            },
+            syncSleep(ms: number): void {
+                if (!(ms > 0)) {
+                    return;
+                }
+                block("sleeping", { timeout: ms });
+            },
+        };
+        return func(extras, ...args);
+    };
+}

--- a/src/sync/pyodide.ts
+++ b/src/sync/pyodide.ts
@@ -17,7 +17,13 @@ export interface PackageOptions {
 }
 
 const RETRIES = 3;
+const RETRY_BASE_DELAY = 1000;
 
+/**
+ * Retry on failure with exponential backoff, matching what p-retry did by default.
+ * The failure this absorbs is a transient network error, so retrying without a delay
+ * would just fail four times against the same blip.
+ */
 async function withRetries<T>(fn: () => Promise<T>): Promise<T> {
     let lastError: unknown;
     for (let attempt = 0; attempt <= RETRIES; attempt++) {
@@ -25,6 +31,9 @@ async function withRetries<T>(fn: () => Promise<T>): Promise<T> {
             return await fn();
         } catch (e) {
             lastError = e;
+            if (attempt < RETRIES) {
+                await new Promise((resolve) => setTimeout(resolve, RETRY_BASE_DELAY * 2 ** attempt));
+            }
         }
     }
     throw lastError;

--- a/src/sync/pyodide.ts
+++ b/src/sync/pyodide.ts
@@ -2,12 +2,11 @@
  * Vendored from pyodide-worker-runner (https://github.com/alexmojaki/pyodide-worker-runner).
  * Copyright (c) 2022 Alex Hall. MIT licensed, see THIRD-PARTY-NOTICES.md.
  */
-import pRetry from "p-retry";
-import { SyncClient, syncExpose, SyncExtras } from "./SyncClient";
 import * as Comlink from "comlink";
 import { loadPyodide, PyodideInterface, version as npmVersion } from "pyodide";
 
 export type PyodideLoader = () => Promise<PyodideInterface>;
+
 export interface PackageOptions {
     url: string; // URL to fetch the package from
 
@@ -17,12 +16,24 @@ export interface PackageOptions {
     extractDir?: string; // Defaults to /tmp/
 }
 
+const RETRIES = 3;
+
+async function withRetries<T>(fn: () => Promise<T>): Promise<T> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= RETRIES; attempt++) {
+        try {
+            return await fn();
+        } catch (e) {
+            lastError = e;
+        }
+    }
+    throw lastError;
+}
+
 /**
  * Loads the Pyodide module from the official CDN as suggested in
  * https://pyodide.org/en/stable/usage/quickstart.html#setup.
- * To load a specific version, pass a string such as "1.2.3" as the argument.
- * By default, uses `pyodide.version`, i.e. the version you have installed from npm
- * as a peer dependency.
+ * By default, uses `pyodide.version`, i.e. the version installed from npm.
  */
 export async function defaultPyodideLoader(version: string = npmVersion): Promise<PyodideInterface> {
     const indexURL = `https://cdn.jsdelivr.net/pyodide/v${version}/full/`;
@@ -34,46 +45,12 @@ export async function defaultPyodideLoader(version: string = npmVersion): Promis
 }
 
 /**
- * Converts a version string to an array of numbers,
- * e.g. "1.2.3" -> [1, 2, 3]
- */
-export function versionInfo(version: string): number[] {
-    return version.split(".").map(Number);
-}
-
-/**
- * Loads Pyodide in parallel to downloading an archive with your own code and dependencies,
- * which it then unpacks into the virtual filesystem ready for you to import.
+ * Loads Pyodide in parallel to downloading an archive with our own code and dependencies,
+ * which it then unpacks into the virtual filesystem ready to be imported.
+ * The extraction directory is added to `sys.path`.
  *
- * This helps you to work with Python code normally with several `.py` files
- * instead of a giant string passed to Pyodide's `runPython`.
- * It also lets you start up more quickly instead of waiting for Pyodide to load
- * before calling `loadPackage` or `micropip.install`.
- *
- * The archive should contain your own Python files and any Python dependencies.
- * A simple way to gather Python dependencies into a folder is with `pip install -t <folder>`.
- * The location where the archive is extracted will be added to `sys.path` so it can be imported immediately,
- * e.g. with [`pyodide.pyimport`](https://pyodide.org/en/stable/usage/api/js-api.html#pyodide.pyimport).
- * There should be no top-level folder in the archive containing everything else,
- * or that's what you'll have to import.
- *
- * If you don't use `loadPyodideAndPackage` and just load Pyodide yourself,
- * then we recommend passing the resulting module object to `initPyodide` for some other housekeeping.
- *
- * Loading of both Pyodide and the package is retried up to 3 times in case of network errors.
- *
- * The raw contents of the package are cached in memory to avoid re-downloading in case of
- * a fatal error which requires reloading Pyodide.
- *
- * @param packageOptions Object which describes how to load the package file, with the following keys:
- *    - `url`: URL to fetch the package from.
- *    - `format`: File format which determines how to extract the archive.
- *                By default the options are 'bztar', 'gztar', 'tar', 'zip', and 'wheel'.
- *    - `extractDir`: Directory to extract the archive into. Defaults to /tmp/.
- * @param pyodideLoader Optional function which takes no arguments and returns the Pyodide module as returned by the
- *    [`loadPyodide`](https://pyodide.org/en/stable/usage/api/js-api.html#globalThis.loadPyodide) function.
- *    Defaults to `defaultPyodideLoader`which uses the
- *    [official CDN](https://pyodide.org/en/stable/usage/quickstart.html#setup).
+ * Both downloads are retried in case of network errors, and the raw contents of the package
+ * are cached in memory to avoid re-downloading when Pyodide has to be reloaded.
  */
 export async function loadPyodideAndPackage(
     packageOptions: PackageOptions,
@@ -83,16 +60,11 @@ export async function loadPyodideAndPackage(
     const extractDir = packageOptions.extractDir || "/tmp/";
 
     const [pyodide, packageBuffer] = await Promise.all([
-        pRetry(() => pyodideLoader(), { retries: 3 }),
-        pRetry(() => getPackageBuffer(url), { retries: 3 }),
+        withRetries(() => pyodideLoader()),
+        withRetries(() => getPackageBuffer(url)),
     ]);
 
-    const vInfo = versionInfo(pyodide.version);
-    pyodide.unpackArchive(
-        packageBuffer,
-        format,
-        vInfo[0] === 0 && vInfo[1] <= 19 ? (extractDir as any) : { extractDir },
-    );
+    pyodide.unpackArchive(packageBuffer, format, { extractDir });
 
     const sys = pyodide.pyimport("sys");
     sys.path.append(extractDir);
@@ -103,19 +75,13 @@ export async function loadPyodideAndPackage(
 }
 
 /**
- * Initializes the given Pyodide module with some extra functionality:
- *   - `pyodide.registerComlink(Comlink)` makes `Comlink` (and thus `comsync` and the `PyodideClient`) work better.
- *   - Imports the `pyodide_worker_runner` Python module included with this library, which:
- *     - Immediately calls `sys.setrecursionlimit` so that deep recursion causes a Python `RecursionError`
- *       instead of a fatal JS `RangeError: Maximum call stack size exceeded`.
- *     - Provides the `install_imports` function which allows automatically installing imported modules, similar to
- *       [`loadPackagesFromImports`](https://pyodide.org/en/stable/usage/api/js-api.html#pyodide.loadPackagesFromImports)
- *       but also loads packages which are not built into Pyodide but can be installed with `micropip`,
- *       i.e. pure Python packages with wheels available on PyPI.
+ * Registers Comlink so proxies survive the worker boundary, and imports the
+ * `pyodide_worker_runner` module shipped in our Python package. Importing it lowers the
+ * recursion limit so deep recursion raises a Python RecursionError instead of a fatal
+ * JS RangeError, and provides `install_imports` used by papyros.py.
  */
 export function initPyodide(pyodide: PyodideInterface): void {
     pyodide.registerComlink(Comlink);
-
     pyodide.pyimport("pyodide_worker_runner");
 }
 
@@ -123,199 +89,13 @@ const packageCache = new Map<string, ArrayBuffer>();
 
 async function getPackageBuffer(url: string): Promise<ArrayBuffer> {
     if (packageCache.has(url)) {
-        console.log("Loaded package from cache");
         return packageCache.get(url)!;
     }
-    console.log("Fetching package from " + url.slice(0, 100) + "...");
     const response = await fetch(url);
     if (!response.ok) {
         throw new Error(`Request for package failed with status ${response.status}: ${response.statusText}`);
     }
     const result = await response.arrayBuffer();
-    console.log("Fetched package");
     packageCache.set(url, result);
     return result;
-}
-
-/**
- * See the description of output parts in
- * https://github.com/alexmojaki/python_runner#callback-events
- */
-export interface OutputPart {
-    type: string;
-    text: string;
-    [key: string]: unknown;
-}
-
-export interface RunnerCallbacks {
-    input?: (prompt: string) => void;
-    output: (parts: OutputPart[]) => unknown;
-    other?: (type: string, data: unknown) => unknown;
-}
-
-/**
- * Construct a callback function which can be passed to `python_runner` to handle events.
- * See https://github.com/alexmojaki/python_runner#callback-events
- *
- * @param comsyncExtras
- *    In a web worker script, you need to pass a function to `pyodideExpose` from this library.
- *    That function will be passed `extras` as its first argument which can then be used here.
- *    `extras` is expected to contain a `channel` created by the `makeChannel` function from
- *    the [`sync-message`](https://github.com/alexmojaki/sync-message) library
- *    which was then passed to `PyodideClient` in the main thread.
- *    This enables synchronous communication between the main thread and the worker,
- *    which is used by the callback to handle `input` and `sleep` events properly.
- *    See https://github.com/alexmojaki/pyodide-worker-runner#comsync-integration for more info.
- * @param callbacks
- *    An object containing callback functions to handle the different event types.
- *      - `output`: Required. Called with an array of output parts,
- *         e.g. `[{type: "stdout", text: "Hello world"}]`.
- *         Use this to tell your UI to display the output.
- *      - `input`: Optional. Called when the Python code reads from `sys.stdin`, e.g. with `input()`.
- *         Use this to tell your UI to wait for the user to enter some text.
- *         The entered text should be passed to `PyodideClient.writeMessage()` in the main thread,
- *         and will be returned synchronously by this function to the Python code.
- *         When the Python code calls `input(prompt)`, the string `prompt` is passed to this callback.
- *         Two types of output part will also be passed to the `output` callback:
- *             - `input_prompt`: the prompt passed to the `input()` function.
- *               Using this output part may be a better way to display the prompt in the UI
- *               than the argument of the `input` callback, but the `input` callback is still needed
- *               even if it doesn't display the prompt.
- *              - `input`: the user's input passed to stdin.
- *                Not actually 'output', but included as an output part
- *                because it's typically shown in regular Python consoles.
- *      - `other`: Optional. Called for all other event types
- *        (except `sleep` which is handled directly by `makeRunnerCallback`).
- *        The actual event type is passed as the first argument.
- */
-export function makeRunnerCallback(
-    comsyncExtras: SyncExtras,
-    callbacks: RunnerCallbacks,
-): (type: string, data: any) => any {
-    return function (type: string, rawData: any): any {
-        const data = rawData.toJs ? rawData.toJs({ dict_converter: Object.fromEntries }) : rawData;
-
-        if (type === "input") {
-            callbacks.input?.(data.prompt);
-            return comsyncExtras.readMessage() + "\n";
-        } else if (type === "sleep") {
-            comsyncExtras.syncSleep(data.seconds * 1000);
-        } else if (type === "output") {
-            return callbacks.output(data.parts);
-        } else {
-            return callbacks.other!(type, data);
-        }
-    };
-}
-
-export interface PyodideExtras extends SyncExtras {
-    interruptBuffer: Int32Array | null;
-}
-
-/**
- * Call this in your web worker code with a function `func`
- * to allow it to be called from the main thread by `PyodideClient.call`.
- *
- * `func` will be called with an object `extras` of type `PyodideExtras` as its first argument.
- * The other arguments are those passed to `PyodideClient.call`,
- * and the return value is passed back to the main thread and returned from `PyodideClient.call`.
- *
- * `func` will be wrapped into a new function which is returned here.
- * The returned function should be passed to `Comlink.expose`, possibly as part of a larger object.
- *
- * For example, the worker code may look something like this:
- *
- *     Comlink.expose({
- *       myRunCode: pyodideExpose((extras, code) => {
- *         pyodide.runCode(code);
- *       }),
- *     });
- *
- * and the main thread code may look something like this:
- *
- *    await client.call(client.workerProxy.myRunCode, "print('Hello world')");
- *
- * It's recommended to pass `extras` to `makeRunnerCallback` and then pass the resulting callback
- * to a `python_runner.PyodideRunner` instead of calling `pyodide.runCode` directly.
- *
- * If possible, `extras.interruptBuffer` will be a `SharedArrayBuffer` which can be used like this:
- *
- *     if (extras.interruptBuffer) {
- *       pyodide.setInterruptBuffer(extras.interruptBuffer);
- *     }
- *
- * This will allow the main thread to call `PyodideClient.interrupt()`
- * to raise `KeyboardInterrupt` in Python code running in Pyodide in the worker thread.
- * `setInterruptBuffer` isn't called automatically so that you can choose the correct place to call it,
- * after running any Python code that musn't be interrupted.
- */
-export function pyodideExpose<T extends any[], R>(
-    func: (extras: PyodideExtras, ...args: T) => R,
-): (...args: any[]) => Promise<R> {
-    return syncExpose(function (comsyncExtras: SyncExtras, interruptBuffer: Int32Array | null, ...args: T): R {
-        return func({ ...comsyncExtras, interruptBuffer }, ...args);
-    });
-}
-
-/**
- * This class should be used in the main browser thread
- * to call functions exposed with `pyodideExpose` and `Comlink.expose` in a web worker.
- * See https://github.com/alexmojaki/comsync to learn how to use the base class `SyncClient`.
- * What this class adds is making it easier to interrupt Python code running in Pyodide in the worker.
- * Specifically, if `SharedArrayBuffer` is available, then `PyodideClient.call` will pass a buffer
- * so that the function passed to `pyodideExpose` can call `pyodide.setInterruptBuffer(extras.interruptBuffer)`
- * to enable interruption. Then `PyodideClient.interrupt()` will use the buffer.
- * Otherwise, `PyodideClient.interrupt()` will likely restart the web worker entirely, which is more disruptive.
- */
-export class PyodideClient<T = any> extends SyncClient<T> {
-    async call(proxyMethod: any, ...args: any[]): Promise<any> {
-        let interruptBuffer: Int32Array | null = null;
-        if (typeof SharedArrayBuffer !== "undefined") {
-            const buffer = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 1));
-            interruptBuffer = buffer;
-            this.interrupter = () => {
-                buffer[0] = 2;
-            };
-        }
-
-        return super.call(proxyMethod, interruptBuffer, ...args);
-    }
-}
-
-/**
- * This class handles automatically reloading Pyodide from scratch when a fatal error occurs.
- * The constructor accepts a 'loader' function which should return a promise that resolves to a Pyodide module.
- * We recommend a function which calls `loadPyodideAndPackage`.
- * The loader function will be called immediately on construction.
- *
- * Code that uses the Pyodide module should be wrapped in a `withPyodide` call, e.g:
- *
- *    await pyodideFatalErrorReloader.withPyodide(async (pyodide) => {
- *      pyodide.runCode(...);
- *    });
- *
- * If a fatal error occurs, the loader function will be called again immediately to reload Pyodide in the background,
- * while the error is rethrown for you to handle.
- * The next call to `withPyodide` will then be able to use the new Pyodide instance.
- *
- * In general, `withPyodide` will wait for the loader function to complete, and will throw any errors it throws.
- */
-export class PyodideFatalErrorReloader {
-    private pyodidePromise: Promise<PyodideInterface>;
-
-    constructor(private readonly loader: PyodideLoader) {
-        this.pyodidePromise = loader();
-    }
-
-    public async withPyodide<T>(fn: (pyodide: PyodideInterface) => Promise<T>): Promise<T> {
-        const pyodide = await this.pyodidePromise;
-        try {
-            return await fn(pyodide);
-        } catch (e: any) {
-            if (e.pyodide_fatal_error) {
-                this.pyodidePromise = this.loader();
-            }
-            throw e;
-        }
-    }
 }

--- a/test/__mocks__/MockBackend.ts
+++ b/test/__mocks__/MockBackend.ts
@@ -1,4 +1,4 @@
-import { SyncExtras } from "../../src/sync/SyncClient";
+import { SyncExtras } from "../../src/sync/expose";
 import { Backend, WorkerDiagnostic } from "../../src/backend/Backend";
 import { BackendEventType } from "../../src/communication/BackendEvent";
 import { vi } from "vitest";
@@ -7,14 +7,14 @@ import { vi } from "vitest";
  * Implementation of a JavaScript backend for Papyros
  * by using eval and overriding some builtins
  */
-export class MockBackend extends Backend<SyncExtras> {
+export class MockBackend extends Backend {
     constructor() {
         super();
         this.runCode = vi.fn(this.runCode);
         this.lintCode = vi.fn(this.lintCode);
     }
 
-    protected syncExpose() {
+    protected expose() {
         return (f: any) => f;
     }
 

--- a/test/__tests__/sync/SyncClient.test.ts
+++ b/test/__tests__/sync/SyncClient.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { InterruptError, SyncClient } from "../../../src/sync/SyncClient";
+import { SyncClient } from "../../../src/sync/SyncClient";
+import { InterruptError } from "../../../src/sync/errors";
 import { makeServiceWorkerChannel } from "../../../src/sync/channel";
 
 function idleClient(): SyncClient {

--- a/test/__tests__/sync/SyncClient.test.ts
+++ b/test/__tests__/sync/SyncClient.test.ts
@@ -48,6 +48,17 @@ describe("SyncClient", () => {
         client.terminate();
     });
 
+    it("fails a queued write instead of hanging when the call ends first", async () => {
+        const client = idleClient();
+        const call = client.call(() => new Promise(() => undefined));
+        await Promise.resolve();
+        // Not waiting for input yet, so the write queues behind the reading status
+        const write = client.writeMessage("typed while still running");
+        client.terminate();
+        await expect(call).rejects.toBeInstanceOf(InterruptError);
+        await expect(write).rejects.toThrow("No active call to send a message to.");
+    });
+
     it("rejects the in-flight call with an InterruptError when terminated", async () => {
         const client = idleClient();
         const call = client.call(() => new Promise(() => undefined));

--- a/test/__tests__/sync/channel.test.ts
+++ b/test/__tests__/sync/channel.test.ts
@@ -60,6 +60,10 @@ describe("channel construction", () => {
         expect(makeChannel()).toMatchObject({ type: "serviceWorker", baseUrl: `/${BASE_URL_SUFFIX}` });
     });
 
+    it("treats a scope without a trailing slash as a directory", () => {
+        expect(makeServiceWorkerChannel({ scope: "/papyros" }).baseUrl).toBe(`/papyros/${BASE_URL_SUFFIX}`);
+    });
+
     it("honours a custom scope and timeout", () => {
         const channel = makeServiceWorkerChannel({ scope: "/papyros/", timeout: 1234 });
         expect(channel).toEqual({

--- a/test/__tests__/sync/expose.test.ts
+++ b/test/__tests__/sync/expose.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { expose, SyncExtras } from "../../../src/sync/expose";
+import { NoChannelError } from "../../../src/sync/errors";
+import { makeServiceWorkerChannel } from "../../../src/sync/channel";
+
+const noop = (): void => undefined;
+
+describe("expose", () => {
+    it("hands the wrapped function a SyncExtras and forwards the remaining arguments", async () => {
+        const seen: SyncExtras[] = [];
+        const wrapped = expose((extras: SyncExtras, a: number, b: number) => {
+            seen.push(extras);
+            return a + b;
+        });
+
+        const channel = makeServiceWorkerChannel();
+        const buffer = new Int32Array(1);
+        expect(await wrapped(channel, noop, "base", buffer, 1, 2)).toBe(3);
+        expect(seen[0].channel).toBe(channel);
+        expect(seen[0].interruptBuffer).toBe(buffer);
+    });
+
+    it("announces itself before running so the client can track state", async () => {
+        const callback = vi.fn();
+        await expose(() => undefined)(null, callback, "base", null);
+        expect(callback).toHaveBeenCalledWith("init");
+    });
+
+    it("reports a missing channel rather than blocking forever", async () => {
+        const wrapped = expose((extras: SyncExtras) => extras.readMessage());
+        await expect(wrapped(null, noop, "base", null)).rejects.toBeInstanceOf(NoChannelError);
+    });
+
+    it("skips a sleep of zero or less without touching the channel", async () => {
+        const callback = vi.fn();
+        await expose((extras: SyncExtras) => extras.syncSleep(0))(null, callback, "base", null);
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledWith("init");
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -471,11 +471,6 @@
   dependencies:
     undici-types "~8.3.0"
 
-"@types/retry@0.12.1":
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.1.tgz#d8f1c0d0dc23afad6dc16a9e993a0865774b4065"
-  integrity sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==
-
 "@types/serviceworker@^0.0.200":
   version "0.0.200"
   resolved "https://registry.yarnpkg.com/@types/serviceworker/-/serviceworker-0.0.200.tgz#aa5a6cfbeff82320dd56cd0ad583b77fbbc4c37e"
@@ -1562,14 +1557,6 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
-p-retry@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-5.1.2.tgz#c16eaee4f2016f9161d12da40d3b8b0f2e3c1b76"
-  integrity sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==
-  dependencies:
-    "@types/retry" "0.12.1"
-    retry "^0.13.1"
-
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -1684,11 +1671,6 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
-
-retry@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
-  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 rolldown@~1.1.5:
   version "1.1.5"


### PR DESCRIPTION
This pull request turns the code vendored in #1082 into one coherent layer, as phase 2 of #1081. No behaviour changes and no public API changes.

The three packages arrived with overlapping responsibilities, which this collapses:

- `syncExpose` and `pyodideExpose` become a single `expose()`. `SyncExtras` now always carries the interrupt buffer, so `Backend` loses its `Extras` type parameter and `PythonWorker` loses its Pyodide specific override.
- `PyodideClient` folds into `SyncClient`, which allocates the interrupt buffer itself. Both languages now use the same client.
- `InterruptError` and `NoChannelError` move to `errors.ts`, the wrapper and its types to `expose.ts`.

`MockBackend` still overrides the expose hook so its methods run unwrapped, so `Backend` keeps that seam rather than calling `expose` directly.

Removed as unreachable from Papyros: `makeRunnerCallback` (papyros.py has its own callback), `PyodideFatalErrorReloader`, the pre 0.19 `unpackArchive` compatibility shim and the `versionInfo` helper that existed only to feed it, and the package loader's console logging. The `p-retry` dependency is replaced by a local loop, which removes the last runtime dependency the vendored code brought with it.

`src/sync/` goes from 936 to 784 lines, and the diff is 237 insertions against 374 deletions.

**Manual testing instructions**

Same as #1082, since neither PR is meant to change behaviour:

- `yarn setup && yarn build:sw && yarn start`
- Run `print(input())` in the scratchpad, enter a value, confirm it echoes
- Run `import time; time.sleep(2); print("done")`, confirm the delay
- Press Stop during `input()` and during an infinite loop, confirm both recover
- Switch to JavaScript and confirm `prompt()` still reads input, since that backend shares the merged `SyncClient` now

**Verification**

<details>
<summary>Suite, typecheck, lint and library build</summary>

| Check | Result |
|---|---|
| `yarn vitest --run` | 10 files / 94 tests, green |
| `yarn typecheck` | clean |
| `yarn lint` | clean |
| `yarn build:lib` | succeeds, no references to the removed symbols in `dist` |

4 new tests in `test/__tests__/sync/expose.test.ts` cover the unified wrapper: that it hands the function a `SyncExtras` carrying the channel and interrupt buffer and forwards the remaining arguments, that it fires the `init` status so the client can track state, that a missing channel raises `NoChannelError` instead of blocking forever, and that a non positive sleep never touches the channel.

</details>

**Checklist**
- Tests: 4 new tests for the unified `expose`, on top of the 16 added in #1082
- Docs: n/a
- Announcement: n/a
- AI: Claude Code did the merge and refactor and wrote the tests

Part of #1081
