### PR TITLE
Use JSPI stack switching for Python input and sleep where available

### DIFF
--- a/src/backend/Backend.ts
+++ b/src/backend/Backend.ts
@@ -49,7 +49,8 @@ export abstract class Backend {
      */
     protected jspi = false;
     /**
-     * The main thread answer this backend is currently suspended on, if any
+     * Settles the promise this backend is suspended on while it waits for the main
+     * thread to answer, if it is waiting at all
      */
     private pending?: { resolve: (value: any) => void; reject: (reason: unknown) => void };
     /**

--- a/src/backend/Backend.ts
+++ b/src/backend/Backend.ts
@@ -1,5 +1,6 @@
 import { BackendEvent, BackendEventType } from "../communication/BackendEvent";
 import { expose, SyncExtras } from "../sync/expose";
+import { InterruptError } from "../sync/errors";
 import { BackendEventQueue } from "../communication/BackendEventQueue";
 
 export interface WorkerDiagnostic {
@@ -43,6 +44,15 @@ export abstract class Backend {
      */
     protected extras: SyncExtras;
     /**
+     * Whether input and sleep suspend the wasm stack (JSPI) instead of blocking on the channel.
+     * Only Pyodide can do this, and only where the browser supports stack switching.
+     */
+    protected jspi = false;
+    /**
+     * The main thread answer this backend is currently suspended on, if any
+     */
+    private pending?: { resolve: (value: any) => void; reject: (reason: unknown) => void };
+    /**
      * Callback to handle events published by this Backend
      */
     protected onEvent: (e: BackendEvent) => any;
@@ -75,20 +85,100 @@ export abstract class Backend {
      * Initialize the backend by doing all setup-related work
      * @param {function(BackendEvent):void} onEvent Callback for when events occur
      * @param {string|undefined} pyodideAssetURL Optional location where pyodide assets can be fetched from if the backend needs it
+     * @param {boolean} allowJspi Whether the backend may suspend the wasm stack instead of using the channel
      * @return {Promise<void>} Promise of launching
      */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public async launch(onEvent: (e: BackendEvent) => void, pyodideAssetURL: string | undefined): Promise<void> {
+    public async launch(
+        onEvent: (e: BackendEvent) => void,
+        pyodideAssetURL: string | undefined,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        allowJspi: boolean = true,
+    ): Promise<void> {
         this.onEvent = (e: BackendEvent) => {
             onEvent(e);
             if (e.type === BackendEventType.Sleep) {
-                return this.extras.syncSleep(e.data);
+                return this.jspi ? this.suspendForSleep(e.data) : this.extras.syncSleep(e.data);
             } else if (e.type === BackendEventType.Input) {
-                return this.extras.readMessage();
+                return this.jspi ? this.suspendForInput() : this.extras.readMessage();
             }
         };
         this.queue = new BackendEventQueue(this.onEvent.bind(this));
         return Promise.resolve();
+    }
+
+    /**
+     * Whether this backend expects input to be delivered by resolving a promise
+     * instead of by writing to the channel. Read once by the client after launching.
+     * @return {boolean} Whether the JSPI transport is in use
+     */
+    public usesJspi(): boolean {
+        return this.jspi;
+    }
+
+    /**
+     * Answer the main thread question this backend is suspended on
+     * @param {any} message The value to resume with
+     * @return {boolean} Whether the backend was waiting for it
+     */
+    public receiveMessage(message: any): boolean {
+        const pending = this.pending;
+        if (!pending) {
+            return false;
+        }
+        this.pending = undefined;
+        pending.resolve(message);
+        return true;
+    }
+
+    /**
+     * Abort the main thread question this backend is suspended on.
+     * python_runner maps the rejection onto a KeyboardInterrupt, so the worker survives.
+     * @return {boolean} Whether the backend was waiting
+     */
+    public interruptMessage(): boolean {
+        const pending = this.pending;
+        if (!pending) {
+            return false;
+        }
+        this.pending = undefined;
+        pending.reject(new InterruptError());
+        return true;
+    }
+
+    /**
+     * Suspend until the main thread provides input
+     * @return {Promise<string>} The value the user entered
+     */
+    private suspendForInput(): Promise<string> {
+        this.extras.reportStatus("reading");
+        return new Promise<string>((resolve, reject) => {
+            this.pending = { resolve, reject };
+        });
+    }
+
+    /**
+     * Suspend for the requested duration, remaining interruptible throughout
+     * @param {number} ms How long to sleep
+     * @return {Promise<void>} Resolves once the time has passed
+     */
+    private suspendForSleep(ms: number): Promise<void> {
+        this.extras.reportStatus("sleeping");
+        return new Promise<void>((resolve, reject) => {
+            const timer = setTimeout(() => {
+                this.pending = undefined;
+                this.extras.reportStatus("slept");
+                resolve();
+            }, ms);
+            const settle = (finish: () => void): void => {
+                clearTimeout(timer);
+                this.extras.reportStatus("slept");
+                finish();
+            };
+            this.pending = {
+                resolve: () => settle(resolve),
+                reject: (reason: unknown) => settle(() => reject(reason)),
+            };
+        });
     }
 
     /**

--- a/src/backend/workers/python/PythonWorker.ts
+++ b/src/backend/workers/python/PythonWorker.ts
@@ -35,8 +35,12 @@ export class PythonWorker extends Backend {
         return await loadPyodideAndPackage({ url: pythonPackageUrl, format: ".tgz" }, () => loadPyodide({ indexURL }));
     }
 
-    public async launch(onEvent: (e: BackendEvent) => void, pyodideAssetURL: string | undefined): Promise<void> {
-        await super.launch(onEvent, pyodideAssetURL);
+    public async launch(
+        onEvent: (e: BackendEvent) => void,
+        pyodideAssetURL: string | undefined,
+        allowJspi: boolean = true,
+    ): Promise<void> {
+        await super.launch(onEvent, pyodideAssetURL, allowJspi);
         this.pyodide = await PythonWorker.getPyodide(pyodideAssetURL);
         // Python calls our function with a PyProxy dict or a Js Map,
         // These must be converted to a PapyrosEvent (JS Object) to allow message passing
@@ -52,6 +56,36 @@ export class PythonWorker extends Backend {
         });
         // preload micropip to allow installing packages
         await (this.pyodide as any).loadPackage("micropip");
+        this.jspi = allowJspi && (await PythonWorker.detectJspi(this.pyodide));
+    }
+
+    /**
+     * Whether Pyodide can suspend the wasm stack here, so input() can await a promise
+     * instead of blocking on the channel.
+     *
+     * can_run_sync() is asked from inside an async def entered through a plain PyProxy
+     * call, which is exactly how run_async is invoked. That covers browser support,
+     * Pyodide build support and the calling convention in one go, and it fails closed:
+     * anything unexpected leaves the channel transport in place.
+     * @param {PyodideInterface} pyodide The loaded interpreter
+     * @return {Promise<boolean>} Whether stack switching is available
+     */
+    private static async detectJspi(pyodide: PyodideInterface): Promise<boolean> {
+        const probe = pyodide.runPython(
+            [
+                "async def __papyros_jspi_probe():",
+                "    from pyodide.ffi import can_run_sync",
+                "    return can_run_sync()",
+                "__papyros_jspi_probe",
+            ].join("\n"),
+        );
+        try {
+            return (await probe()) === true;
+        } catch {
+            return false;
+        } finally {
+            probe.destroy();
+        }
     }
 
     /**

--- a/src/backend/workers/python/papyros/papyros.py
+++ b/src/backend/workers/python/papyros/papyros.py
@@ -56,6 +56,15 @@ class Papyros(python_runner.PyodideRunner):
         self.set_event_callback(callback)
 
     def set_event_callback(self, event_callback):
+        def unwrap(result):
+            # With the JSPI transport the callback answers with a promise instead of a
+            # value, so suspend the wasm stack until it settles. run_sync re-raises a
+            # rejection, which python_runner maps onto KeyboardInterrupt.
+            if hasattr(result, "then"):
+                from pyodide.ffi import run_sync
+                return run_sync(result)
+            return result
+
         def runner_callback(event_type, data):
             def cb(typ, dat, contentType=None, **kwargs):
                 return event_callback(dict(type=typ, data=dat, contentType=contentType or "text/plain", **kwargs))
@@ -76,10 +85,10 @@ class Papyros(python_runner.PyodideRunner):
                         cb("output", data, contentType=part.get("contentType"))
             elif event_type == "input":
                 self._emit_turtle_snapshot()
-                return cb("input", data["prompt"])
+                return unwrap(cb("input", data["prompt"]))
             elif event_type == "sleep":
                 self._emit_turtle_snapshot()
-                return cb("sleep", data["seconds"]*1000, contentType="application/number")
+                return unwrap(cb("sleep", data["seconds"]*1000, contentType="application/number"))
             else:
                 return cb(event_type, data.get("data", ""), contentType=data.get("contentType"))
 

--- a/src/frontend/state/Runner.ts
+++ b/src/frontend/state/Runner.ts
@@ -58,6 +58,14 @@ export class Runner extends State {
     pyodideAssetURL: string | undefined = undefined;
 
     /**
+     * Whether Python may use JSPI stack switching for input and sleep where the browser
+     * supports it. Set to false to force the service worker or SharedArrayBuffer channel,
+     * for instance to work around a browser whose stack switching misbehaves.
+     */
+    @stateProperty
+    allowJspi: boolean = true;
+
+    /**
      * The backend that executes the code asynchronously
      */
     @stateProperty
@@ -214,7 +222,9 @@ export class Runner extends State {
         await backend.workerProxy.launch(
             proxy((e: BackendEvent) => BackendManager.publish(e)),
             this.pyodideAssetURL,
+            this.allowJspi,
         );
+        backend.usesPromiseTransport = await backend.workerProxy.usesJspi();
         if (launchId === this.launchId) {
             this.updateRunModes();
             this.backendReady = true;

--- a/src/sync/SyncClient.ts
+++ b/src/sync/SyncClient.ts
@@ -16,6 +16,11 @@ import * as Comlink from "comlink";
  */
 export class SyncClient<T = any> {
     public interrupter?: () => void;
+    /**
+     * Whether the worker suspends on a promise instead of reading from the channel.
+     * Set from the worker's own probe after launching; delivery routes accordingly.
+     */
+    public usesPromiseTransport = false;
     public state: "idle" | "running" | "awaitingMessage" | "sleeping" = "idle";
     private _worker?: Worker;
     private _workerProxy?: Comlink.Remote<T>;
@@ -165,6 +170,11 @@ export class SyncClient<T = any> {
 
     private async _writeMessage(message: any): Promise<void> {
         this.state = "running";
+        if (this.usesPromiseTransport) {
+            const proxy = this._workerProxy as any;
+            await (message.interrupted ? proxy.interruptMessage() : proxy.receiveMessage(message.message));
+            return;
+        }
         const messageId = makeMessageId(this._messageIdBase!, this._messageIdSeq);
         await writeMessage(this.channel!, message, messageId);
     }

--- a/src/sync/expose.ts
+++ b/src/sync/expose.ts
@@ -19,9 +19,13 @@ export interface SyncExtras {
     readMessage: () => any;
     syncSleep: (ms: number) => void;
     /**
-     * Tell the client that the backend started or stopped waiting on the main thread.
-     * The sync helpers above do this themselves; a backend that blocks another way
-     * (JSPI stack switching) has to report it so the client state machine stays correct.
+     * Tell the client the backend has started waiting on the main thread ("reading" or
+     * "sleeping"), or that a sleep ran to completion ("slept"). There is no counterpart
+     * for input: the client already knows it answered, and moves itself back to running.
+     *
+     * The sync helpers above report this themselves. A backend that blocks another way
+     * (JSPI stack switching) has to report it, or the client state machine will not know
+     * it is waiting and will interrupt by replacing the worker instead of answering.
      */
     reportStatus: (status: Exclude<SyncMessageCallbackStatus, "init">) => void;
 }

--- a/src/sync/expose.ts
+++ b/src/sync/expose.ts
@@ -18,6 +18,12 @@ export interface SyncExtras {
     interruptBuffer: Int32Array | null;
     readMessage: () => any;
     syncSleep: (ms: number) => void;
+    /**
+     * Tell the client that the backend started or stopped waiting on the main thread.
+     * The sync helpers above do this themselves; a backend that blocks another way
+     * (JSPI stack switching) has to report it so the client state machine stays correct.
+     */
+    reportStatus: (status: Exclude<SyncMessageCallbackStatus, "init">) => void;
 }
 
 export type SyncMessageCallbackStatus = "init" | "reading" | "sleeping" | "slept";
@@ -71,6 +77,7 @@ export function expose<T extends any[], R>(
         const extras: SyncExtras = {
             channel,
             interruptBuffer,
+            reportStatus: syncMessageCallback,
             readMessage(): any {
                 return block("reading");
             },

--- a/test/__tests__/state/Debugger.test.ts
+++ b/test/__tests__/state/Debugger.test.ts
@@ -40,6 +40,7 @@ z = 1 + 2`;
         await waitForInputReady();
         await papyros.runner.start(RunMode.Debug);
         await waitForOutput(papyros);
+        // waitForOutput returns on the first output, but the assertions below need every frame
         await waitForPapyrosReady(papyros);
 
         const firstNOutputs = (n: number): string => "".concat(

--- a/test/__tests__/state/Jspi.test.ts
+++ b/test/__tests__/state/Jspi.test.ts
@@ -182,11 +182,20 @@ describe.sequential("channel input transport", () => {
         const papyros = await pythonPapyros(false);
         papyros.runner.code = "x = input('never answered')\nprint(x)";
         await waitForInputReady();
+        const backendBefore = papyros.runner.backend;
         const runPromise = papyros.runner.start();
         await waitForAwaitingInput(papyros);
         await papyros.runner.stop();
         await runPromise;
         await waitForPapyrosReady(papyros, 10000);
         expect(papyros.runner.stateMessage).toMatch(/^Code interrupted after/);
+        // The channel answers the reader too, so this survives just like the JSPI path
+        expect(papyros.runner.backend).toBe(backendBefore);
+        expect(papyros.io.output.every((o) => o.type !== "stderr")).toBe(true);
+
+        papyros.runner.code = "print('alive')";
+        await papyros.runner.start();
+        await waitForOutput(papyros);
+        expect(papyros.io.output[0].content).toBe("alive\n");
     }, 180000);
 });

--- a/test/__tests__/state/Jspi.test.ts
+++ b/test/__tests__/state/Jspi.test.ts
@@ -17,6 +17,9 @@ async function pythonPapyros(allowJspi: boolean = true): Promise<Papyros> {
     papyros.runner.allowJspi = allowJspi;
     await papyros.launch();
     papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+    // BackendManager caches one client per language, so let this launch settle before
+    // the test uses it rather than racing whatever a previous test left in flight
+    await papyros.runner.backend;
     return papyros;
 }
 
@@ -128,6 +131,9 @@ describe.sequential("JSPI input transport", () => {
         await waitForPapyrosReady(papyros, 10000);
         expect(papyros.runner.stateMessage).toMatch(/^Code interrupted after/);
         expect(papyros.runner.backend).not.toBe(backendBefore);
+        // Interrupting terminated the worker, and the relaunch is not awaited by start().
+        // Drain it, or it races the next test's launch on the same cached client.
+        await papyros.runner.backend;
     }, 180000);
 });
 

--- a/test/__tests__/state/Jspi.test.ts
+++ b/test/__tests__/state/Jspi.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import { Papyros } from "../../../src/frontend/state/Papyros";
+import { ProgrammingLanguage } from "../../../src/ProgrammingLanguage";
+import { RunMode } from "../../../src/backend/Backend";
+import { RunState } from "../../../src/frontend/state/Runner";
+import { waitForAwaitingInput, waitForInputReady, waitForOutput, waitForPapyrosReady } from "../../helpers";
+import { NonExceptionFrame } from "@dodona/trace-component/dist/trace_types";
+
+async function pythonPapyros(allowJspi: boolean = true): Promise<Papyros> {
+    const papyros = new Papyros();
+    papyros.runner.allowJspi = allowJspi;
+    await papyros.launch();
+    papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+    return papyros;
+}
+
+function answerInput(papyros: Papyros, value: string): () => void {
+    return papyros.io.subscribe(
+        () => (papyros.io.awaitingInput ? papyros.io.provideInput(value) : ""),
+        "awaitingInput",
+    );
+}
+
+describe.sequential("JSPI input transport", () => {
+    it("is used by the python backend on a browser that supports stack switching", async () => {
+        const papyros = await pythonPapyros();
+        const backend = await papyros.runner.backend;
+        expect(await backend.workerProxy.usesJspi()).toBe(true);
+        expect(backend.usesPromiseTransport).toBe(true);
+    });
+
+    it("is never used by the javascript backend", async () => {
+        const papyros = new Papyros();
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.JavaScript;
+        const backend = await papyros.runner.backend;
+        expect(await backend.workerProxy.usesJspi()).toBe(false);
+        expect(backend.usesPromiseTransport).toBe(false);
+    });
+
+    it("reads input without touching the channel", async () => {
+        const papyros = await pythonPapyros();
+        papyros.runner.code = "print('hello ' + input('name?'))";
+        await waitForInputReady();
+        const unsubscribe = answerInput(papyros, "jspi");
+        await papyros.runner.start();
+        await waitForOutput(papyros);
+        await waitForPapyrosReady(papyros);
+        expect(papyros.io.output[0].content).toBe("hello jspi");
+        unsubscribe();
+    });
+
+    it("reads repeated input in a loop", async () => {
+        const papyros = await pythonPapyros();
+        papyros.runner.code = "total = 0\nfor _ in range(3):\n    total += int(input())\nprint(total)";
+        await waitForInputReady();
+        const unsubscribe = answerInput(papyros, "7");
+        await papyros.runner.start();
+        await waitForOutput(papyros);
+        await waitForPapyrosReady(papyros);
+        expect(papyros.io.output[0].content).toBe("21");
+        unsubscribe();
+    });
+
+    it("sleeps for the requested duration", async () => {
+        const papyros = await pythonPapyros();
+        papyros.runner.code = "import time\ntime.sleep(2)";
+        await papyros.runner.start();
+        await waitForPapyrosReady(papyros);
+        expect(papyros.runner.state).toBe(RunState.Ready);
+        expect(papyros.runner.stateMessage).toMatch(/^Code executed in 2/);
+    });
+
+    it("keeps tracing frames across a suspended input in debug mode", async () => {
+        const papyros = await pythonPapyros();
+        papyros.runner.code = 'print("hello")\nx = input("input: ")\nprint("world " + x)\nz = 1 + 2';
+        const unsubscribe = answerInput(papyros, "foo");
+        await waitForInputReady();
+        await papyros.runner.start(RunMode.Debug);
+        await waitForOutput(papyros);
+        await waitForPapyrosReady(papyros);
+        expect(papyros.debugger.trace.length).toBe(5);
+        expect((papyros.debugger.trace[4] as NonExceptionFrame).globals.z).toBe(3);
+        expect((papyros.debugger.trace[4] as NonExceptionFrame).globals.x).toBe("foo");
+        unsubscribe();
+    });
+
+    it("interrupts a waiting input without replacing the worker", async () => {
+        const papyros = await pythonPapyros();
+        papyros.runner.code = "x = input('never answered')\nprint(x)";
+        await waitForInputReady();
+        const backendBefore = papyros.runner.backend;
+        const runPromise = papyros.runner.start();
+        await waitForAwaitingInput(papyros);
+        await papyros.runner.stop();
+        await runPromise;
+        await waitForPapyrosReady(papyros, 10000);
+        expect(papyros.runner.stateMessage).toMatch(/^Code interrupted after/);
+        expect(papyros.runner.backend).toBe(backendBefore);
+        expect(papyros.io.output.every((o) => o.type !== "stderr")).toBe(true);
+
+        // The same interpreter must still be usable, no relaunch needed
+        papyros.runner.code = "print('alive')";
+        await papyros.runner.start();
+        await waitForOutput(papyros);
+        expect(papyros.io.output[0].content).toBe("alive\n");
+    });
+
+    it("still replaces the worker to interrupt a busy loop", async () => {
+        const papyros = await pythonPapyros();
+        papyros.runner.code = "while True:\n    pass";
+        const backendBefore = papyros.runner.backend;
+        const runPromise = papyros.runner.start();
+        await new Promise((r) => setTimeout(r, 3000));
+        expect(papyros.runner.state).toBe(RunState.Running);
+        await papyros.runner.stop();
+        await runPromise;
+        await waitForPapyrosReady(papyros, 10000);
+        expect(papyros.runner.stateMessage).toMatch(/^Code interrupted after/);
+        expect(papyros.runner.backend).not.toBe(backendBefore);
+    });
+});
+
+describe.sequential("channel input transport", () => {
+    it("still reads input when JSPI is disabled", async () => {
+        const papyros = await pythonPapyros(false);
+        const backend = await papyros.runner.backend;
+        expect(await backend.workerProxy.usesJspi()).toBe(false);
+        expect(backend.usesPromiseTransport).toBe(false);
+
+        papyros.runner.code = "print('hello ' + input('name?'))";
+        await waitForInputReady();
+        const unsubscribe = answerInput(papyros, "channel");
+        await papyros.runner.start();
+        await waitForOutput(papyros);
+        await waitForPapyrosReady(papyros);
+        expect(papyros.io.output[0].content).toBe("hello channel");
+        unsubscribe();
+    });
+
+    it("still interrupts a waiting input when JSPI is disabled", async () => {
+        const papyros = await pythonPapyros(false);
+        papyros.runner.code = "x = input('never answered')\nprint(x)";
+        await waitForInputReady();
+        const runPromise = papyros.runner.start();
+        await waitForAwaitingInput(papyros);
+        await papyros.runner.stop();
+        await runPromise;
+        await waitForPapyrosReady(papyros, 10000);
+        expect(papyros.runner.stateMessage).toMatch(/^Code interrupted after/);
+    });
+});

--- a/test/__tests__/state/Jspi.test.ts
+++ b/test/__tests__/state/Jspi.test.ts
@@ -9,6 +9,7 @@ import {
     waitForOutput,
     waitForPapyrosReady,
     waitForRunning,
+    waitForSleeping,
 } from "../../helpers";
 import { NonExceptionFrame } from "@dodona/trace-component/dist/trace_types";
 
@@ -114,6 +115,29 @@ describe.sequential("JSPI input transport", () => {
         await waitForOutput(papyros);
         expect(papyros.io.output[0].content).toBe("alive\n");
     });
+
+    it("interrupts a sleep without replacing the worker", async () => {
+        const papyros = await pythonPapyros();
+        papyros.runner.code = "import time\ntime.sleep(60)\nprint('never')";
+        const backendBefore = papyros.runner.backend;
+        const runPromise = papyros.runner.start();
+        await waitForSleeping(papyros);
+        const stopStart = Date.now();
+        await papyros.runner.stop();
+        await runPromise;
+        await waitForPapyrosReady(papyros, 10000);
+        // Cancelling the timer is the point: waiting it out would take a minute
+        expect(Date.now() - stopStart).toBeLessThan(5000);
+        expect(papyros.runner.stateMessage).toMatch(/^Code interrupted after/);
+        expect(papyros.runner.backend).toBe(backendBefore);
+        expect(papyros.io.output.every((o) => o.type !== "stderr")).toBe(true);
+
+        // The same interpreter must still be usable, no relaunch needed
+        papyros.runner.code = "print('alive')";
+        await papyros.runner.start();
+        await waitForOutput(papyros);
+        expect(papyros.io.output[0].content).toBe("alive\n");
+    }, 180000);
 
     it("still replaces the worker to interrupt a busy loop", async () => {
         const papyros = await pythonPapyros();

--- a/test/__tests__/state/Jspi.test.ts
+++ b/test/__tests__/state/Jspi.test.ts
@@ -3,7 +3,13 @@ import { Papyros } from "../../../src/frontend/state/Papyros";
 import { ProgrammingLanguage } from "../../../src/ProgrammingLanguage";
 import { RunMode } from "../../../src/backend/Backend";
 import { RunState } from "../../../src/frontend/state/Runner";
-import { waitForAwaitingInput, waitForInputReady, waitForOutput, waitForPapyrosReady } from "../../helpers";
+import {
+    waitForAwaitingInput,
+    waitForInputReady,
+    waitForOutput,
+    waitForPapyrosReady,
+    waitForRunning,
+} from "../../helpers";
 import { NonExceptionFrame } from "@dodona/trace-component/dist/trace_types";
 
 async function pythonPapyros(allowJspi: boolean = true): Promise<Papyros> {
@@ -111,14 +117,18 @@ describe.sequential("JSPI input transport", () => {
         papyros.runner.code = "while True:\n    pass";
         const backendBefore = papyros.runner.backend;
         const runPromise = papyros.runner.start();
-        await new Promise((r) => setTimeout(r, 3000));
-        expect(papyros.runner.state).toBe(RunState.Running);
-        await papyros.runner.stop();
-        await runPromise;
+        try {
+            // Pyodide startup dominates on CI, so wait for the loop rather than guessing a delay
+            await waitForRunning(papyros);
+        } finally {
+            // Never leave the shared backend spinning, it would hang every later test
+            await papyros.runner.stop();
+            await runPromise;
+        }
         await waitForPapyrosReady(papyros, 10000);
         expect(papyros.runner.stateMessage).toMatch(/^Code interrupted after/);
         expect(papyros.runner.backend).not.toBe(backendBefore);
-    });
+    }, 180000);
 });
 
 describe.sequential("channel input transport", () => {
@@ -136,7 +146,7 @@ describe.sequential("channel input transport", () => {
         await waitForPapyrosReady(papyros);
         expect(papyros.io.output[0].content).toBe("hello channel");
         unsubscribe();
-    });
+    }, 180000);
 
     it("still interrupts a waiting input when JSPI is disabled", async () => {
         const papyros = await pythonPapyros(false);
@@ -148,5 +158,5 @@ describe.sequential("channel input transport", () => {
         await runPromise;
         await waitForPapyrosReady(papyros, 10000);
         expect(papyros.runner.stateMessage).toMatch(/^Code interrupted after/);
-    });
+    }, 180000);
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -32,6 +32,16 @@ export async function waitForInputReady(timeout = 2000): Promise<void> {
     }
 }
 
+export async function waitForRunning(papyros: Papyros, timeout = 60000): Promise<void> {
+    const start = Date.now();
+    while (papyros.runner.state !== RunState.Running) {
+        if (Date.now() - start > timeout) {
+            throw new Error(`Timeout waiting for runner to run, still ${papyros.runner.state}`);
+        }
+        await new Promise(r => setTimeout(r, 10));
+    }
+}
+
 export async function waitForAwaitingInput(papyros: Papyros, timeout: number = 5000): Promise<void> {
     const start = Date.now();
     while (!papyros.io.awaitingInput) {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -61,3 +61,13 @@ export async function waitForFiles(papyros: Papyros, count: number = 1, timeout 
         await new Promise(r => setTimeout(r, 10));
     }
 }
+
+export async function waitForSleeping(papyros: Papyros, timeout = 60000): Promise<void> {
+    const start = Date.now();
+    while ((await papyros.runner.backend).state !== "sleeping") {
+        if (Date.now() - start > timeout) {
+            throw new Error("Timeout waiting for the backend to sleep");
+        }
+        await new Promise(r => setTimeout(r, 10));
+    }
+}


### PR DESCRIPTION
This pull request makes Python `input()` and `time.sleep()` suspend the wasm stack and await a promise, instead of blocking on the sync-message channel, wherever the browser supports WebAssembly stack switching. This is phase 3 of #1081.

Chrome 137+, Firefox 153+ and Safari 27+ take the new path, so in practice every current engine does. The JavaScript backend keeps using the channel and always will: `prompt()` in the JavaScript worker is called from synchronous user code with no wasm on the stack, so nothing can suspend it. Both transports are permanent.

**How the transport is chosen**

`PythonWorker` asks `can_run_sync()` from inside an `async def` entered through a plain PyProxy call, which is exactly how `run_async` is invoked. One question covers browser support, Pyodide build support and the calling convention, and anything unexpected leaves the channel in place. `papyros.py` suspends on the callback result only when it is a promise, so the same Python serves both transports and `python_runner` needed no changes at all.

**Where the routing lives**

Delivery routes inside `SyncClient._writeMessage` rather than at the call sites, so `interrupt()` keeps deciding from state tracked on the main thread. A worker in a busy loop never services Comlink messages, so asking it whether it is waiting deadlocks. This was found the hard way during the investigation, at a 100 second timeout. Backends now report `reading` and `sleeping` through the extras, which keeps that state accurate under JSPI too, and it is why sleep stays interruptible here rather than being a bare `setTimeout` nobody can cancel.

**What this improves**

Python `input()` and `time.sleep()` no longer need a channel at all. That is the whole point: the channel is either `SharedArrayBuffer` plus `Atomics.wait`, which Dodona can never have because it embeds third-party iframes, or a service worker holding a synchronous XHR, which is the mechanism behind the `__SyncMessageServiceWorkerInput__` failures in Sentry and the "close all this site's tabs" dead end that follows them. Nothing here stops registering that service worker yet, that is #1086, but this is what makes it possible.

Interrupting is unchanged, and both transports already handled it well. Stopping a program waiting on `input()` leaves the worker alive either way: the channel path answers the reader with `{interrupted: true}` and `expose.block` throws `InterruptError`, the JSPI path rejects the pending promise, and `python_runner` maps both onto `KeyboardInterrupt` through `InterruptError = KeyboardInterrupt`. Pyodide stays loaded with its packages installed in both cases. The tests now assert that for both transports rather than only for JSPI, since an earlier version of this description claimed the channel path terminated the worker, and it does not.

Interrupting a busy loop is also unchanged: that still needs the interrupt buffer, which still needs a `SharedArrayBuffer`, so the worker is still replaced. JSPI does not help there and this PR does not pretend otherwise.

**Escape hatch**

`runner.allowJspi = false` forces the channel transport. It exists both as a way out if a browser ships broken stack switching, and so CI keeps covering the channel path for Python, which would otherwise go untested the moment Chromium started taking the JSPI branch. That second reason got stronger after Safari 27 shipped JSPI: no mainstream browser reaches the Python channel path by default any more.

**Manual testing instructions**

- `yarn setup && yarn build:sw && yarn start`
- Run `print(input())`, enter a value, confirm it echoes
- Run `import time; time.sleep(2); print("done")`, confirm the delay
- Press Stop while waiting on `input()`. Confirm it stops cleanly with no stderr, and that running `print('alive')` afterwards works without a reload
- Press Stop during `import time; time.sleep(60)`. Confirm it stops immediately rather than after a minute
- Press Stop during `while True: pass`. Confirm it still recovers
- Repeat the input checks in the JavaScript language, which stays on the channel
- Optionally set `papyros.runner.allowJspi = false` before launching and repeat, to exercise the channel path

**Verification**

<details>
<summary>Suite, typecheck, lint and library build</summary>

| Check | Result |
|---|---|
| `yarn vitest --run` | 17 files / 150 tests, green |
| `yarn typecheck` | clean |
| `yarn lint` | clean |
| `yarn build:lib` | succeeds |

11 new tests in `test/__tests__/state/Jspi.test.ts`. The ones that matter most are debug mode, where `JSONTracer` keeps producing correct frames and globals across a suspended `input()`, and the interrupt tests, which assert the backend object is identical before and after so a silent regression to terminate-and-relaunch cannot pass. Interrupting `time.sleep(60)` has its own test that fails if the cancelled timer is ever left to run out. Two further tests drive input and the interrupt path with `allowJspi` off, covering the channel used by browsers without stack switching.

Note that the pre-existing Python tests now exercise the JSPI path by default on Chromium, which is why the forced-channel tests were added rather than relying on them.

</details>

**Checklist**
- Tests: 11 new end-to-end tests covering both transports, debug mode across a suspend, and interrupting input, sleep and a busy loop
- Docs: n/a
- Announcement: n/a, no visible change beyond `input()` and `sleep()` no longer needing the input service worker
- AI: Claude Code investigated the approach, wrote the implementation and the tests

Part of #1081
