### PR TITLE
Register the input service worker only when a backend needs it

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,18 @@ yarn add @dodona/papyros
 
 ### Setup input handling
 
-Running interactive programs in the browser requires special handling of synchronous input.
-Papyros supports two approaches:
+`input()` and `time.sleep()` have to block a worker until the main thread answers, which a
+worker cannot normally do. Papyros has three ways to achieve it and picks one per backend.
+
+#### JSPI (no setup needed)
+
+Where the browser supports WebAssembly stack switching, Pyodide suspends the wasm stack and
+resumes when a promise settles. Nothing to configure, and no channel is involved. Chrome 137+
+and Firefox 153+ take this path. It applies to Python only: the JavaScript backend runs user
+code with no wasm on the stack, so nothing can suspend it.
+
+Set `papyros.runner.allowJspi = false` to force one of the channels below, for instance to
+work around a browser whose stack switching misbehaves.
 
 #### COOP/COEP headers
 Add the following HTTP headers to your server responses:
@@ -62,6 +72,39 @@ If you cannot set these headers, you can use a service worker to handle input.
 We provide a compiled and minified version of the `InputServiceWorker` in the `dist` folder.
 You need to serve this file from the root of your domain (i.e. `/input-sw.js`).
 You can then register the service worker in your application before launching: `papyros.serviceWorkerName = 'input-sw.js';`.
+
+Registration is lazy. Papyros only registers the service worker once a backend turns out to
+need the channel, so a Python scratchpad on a browser with JSPI never registers one at all.
+
+#### How a backend picks its transport
+
+```mermaid
+flowchart TD
+    launch["papyros.launch()"] --> sab{"SharedArrayBuffer?<br/>(COOP/COEP set)"}
+    sab -- yes --> atomics["Build atomics channel now"]
+    sab -- no --> maybe{"WebAssembly.Suspending<br/>and language is Python?"}
+    maybe -- no --> reg["Register service worker now,<br/>fatal if it fails"]
+    maybe -- yes --> defer["Defer: no channel yet"]
+
+    atomics --> worker
+    reg --> worker
+    defer --> worker["Start worker,<br/>load Pyodide"]
+
+    worker --> probe{"can_run_sync()<br/>inside an async def?"}
+    probe -- yes --> jspi["JSPI: input and sleep<br/>suspend on a promise"]
+    probe -- no --> late["Register service worker now<br/>if there is still no channel"]
+    late --> channel["Channel: input and sleep block<br/>on Atomics.wait or a sync XHR"]
+```
+
+The probe runs inside the worker after Pyodide has loaded, which is why the decision cannot be
+made up front: the main thread can see that the browser has the feature, but not that this
+Pyodide build and calling convention will actually suspend. Deferring registration is what lets
+the answer arrive late without having registered a service worker just in case.
+
+Interrupting is a separate axis. A program waiting on input or sleeping is always interrupted
+cheaply, whichever transport it uses. A program in a busy loop needs Pyodide's interrupt buffer,
+which needs `SharedArrayBuffer`; without one, stopping it replaces the worker and reloads the
+interpreter. JSPI does not change that.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ worker cannot normally do. Papyros has three ways to achieve it and picks one pe
 #### JSPI (no setup needed)
 
 Where the browser supports WebAssembly stack switching, Pyodide suspends the wasm stack and
-resumes when a promise settles. Nothing to configure, and no channel is involved. Chrome 137+
-and Firefox 153+ take this path. It applies to Python only: the JavaScript backend runs user
-code with no wasm on the stack, so nothing can suspend it.
+resumes when a promise settles. Nothing to configure, and no channel is involved. Chrome 137+,
+Firefox 153+ and Safari 27+ take this path, so the channels below are for older browsers. It
+applies to Python only: the JavaScript backend runs user code with no wasm on the stack, so
+nothing can suspend it, and it always uses a channel.
 
 Set `papyros.runner.allowJspi = false` to force one of the channels below, for instance to
 work around a browser whose stack switching misbehaves.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ need the channel, so a Python scratchpad on a browser with JSPI never registers 
 flowchart TD
     launch["papyros.launch()"] --> sab{"SharedArrayBuffer?<br/>(COOP/COEP set)"}
     sab -- yes --> atomics["Build atomics channel now"]
-    sab -- no --> maybe{"WebAssembly.Suspending<br/>and language is Python?"}
+    sab -- no --> maybe{"Stack switching in this browser,<br/>allowJspi, and language is Python?"}
     maybe -- no --> reg["Register service worker now,<br/>fatal if it fails"]
     maybe -- yes --> defer["Defer: no channel yet"]
 
@@ -96,10 +96,21 @@ flowchart TD
     late --> channel["Channel: input and sleep block<br/>on Atomics.wait or a sync XHR"]
 ```
 
-The probe runs inside the worker after Pyodide has loaded, which is why the decision cannot be
-made up front: the main thread can see that the browser has the feature, but not that this
-Pyodide build and calling convention will actually suspend. Deferring registration is what lets
-the answer arrive late without having registered a service worker just in case.
+"Stack switching in this browser" is `WebAssembly.Suspending` or the older
+`WebAssembly.Suspender`, matching how Pyodide itself detects it. That test is only a hint,
+so getting it wrong costs at most one service worker nobody uses: the probe inside the worker
+is what actually selects the transport.
+
+The probe runs after Pyodide has loaded, which is why the decision cannot be made up front. The
+main thread can see that the browser has the feature, but not that the Pyodide build being
+served and the calling convention used will actually suspend. `run_sync` is
+[documented as experimental](https://pyodide.org/en/stable/usage/api/python-api/ffi.html), and
+`can_run_sync()` is the supported way to ask, so Papyros asks rather than assumes. Deferring
+registration is what lets the answer arrive late without having registered a service worker
+just in case.
+
+If a backend needs the channel and it cannot be created, the error is passed to
+`papyros.errorHandler` and the channel stays null. Code still runs; only reading input fails.
 
 Interrupting is a separate axis. A program waiting on input or sleeping is always interrupted
 cheaply, whichever transport it uses. A program in a busy loop needs Pyodide's interrupt buffer,

--- a/src/communication/BackendManager.ts
+++ b/src/communication/BackendManager.ts
@@ -43,7 +43,7 @@ export abstract class BackendManager {
     private static halted: boolean;
     /**
      * The channel used to communicate with the SyncClients
-     * Assigned by Papyros.configureInput before any backend is created
+     * Assigned by Papyros once a backend turns out to need one
      */
     public static channel: Channel | null = null;
 

--- a/src/frontend/state/Papyros.ts
+++ b/src/frontend/state/Papyros.ts
@@ -5,11 +5,11 @@ import { InputOutput } from "./InputOutput";
 import { Constants } from "./Constants";
 import { Examples } from "./Examples";
 import { BackendManager } from "../../communication/BackendManager";
-import { makeChannel } from "../../sync/channel";
+import { Channel, makeChannel } from "../../sync/channel";
+import { ProgrammingLanguage } from "../../ProgrammingLanguage";
 import { I18n } from "./I18n";
 import { Test } from "./Test";
 import { PapyrosLaunchError, ServiceWorkerRegistrationError } from "./PapyrosErrors";
-import { ProgrammingLanguage } from "../../ProgrammingLanguage";
 
 export class Papyros extends State {
     readonly debugger: Debugger = new Debugger(this);
@@ -25,11 +25,16 @@ export class Papyros extends State {
     serviceWorkerName: string = "InputServiceWorker.js";
 
     /**
+     * In flight channel setup, so concurrent callers register the service worker once
+     */
+    private channelPromise?: Promise<Channel | null>;
+
+    /**
      * Launch this instance of Papyros, making it ready to run code
      * @return {Promise<Papyros>} Promise of launching, chainable
      */
     public async launch(): Promise<Papyros> {
-        if (!(await this.configureInput())) {
+        if (!this.canDeferChannel() && !(await this.ensureChannel())) {
             alert(this.i18n.t("Papyros.service_worker_error"));
         } else {
             try {
@@ -60,34 +65,51 @@ export class Papyros extends State {
         BackendManager.setWorkerUrl(language, url);
     }
 
+    private canDeferChannel(): boolean {
+        return (
+            typeof SharedArrayBuffer === "undefined" &&
+            typeof (WebAssembly as { Suspending?: unknown }).Suspending === "function" &&
+            this.runner.allowJspi &&
+            this.runner.programmingLanguage === ProgrammingLanguage.Python
+        );
+    }
+
     /**
-     * Configure how user input is handled within Papyros
-     * By default, we will try to use SharedArrayBuffers
-     * If this option is not available, the optional arguments in the channelOptions config are used
-     * They are needed to register a service worker to handle communication between threads
-     * @return {Promise<boolean>} Promise of configuring input
+     * Make sure a channel exists, registering the input service worker if that is what it takes.
+     * Idempotent, and safe to call from several places at once.
+     * @return {Promise<boolean>} Whether a channel is available
      */
-    private async configureInput(): Promise<boolean> {
-        if (typeof SharedArrayBuffer === "undefined") {
-            if (!this.serviceWorkerName || !("serviceWorker" in navigator)) {
-                return false;
-            }
-            try {
-                const registration = await navigator.serviceWorker.register(this.serviceWorkerName, { scope: "/" });
-                // The channel's scope becomes the base of a synchronous XHR inside the worker;
-                // a relative scope resolves against the worker's own base URL, which is opaque
-                // in a worker bootstrapped from a blob (see BackendManager.setWorkerUrl), so
-                // registration.scope (an absolute URL) is used instead
-                BackendManager.channel = makeChannel({ serviceWorker: { scope: registration.scope } })!;
-                await this.waitForActiveRegistration();
-            } catch (e) {
-                this.errorHandler(new ServiceWorkerRegistrationError("Error registering service worker", { cause: e }));
-                return false;
-            }
-        } else {
-            BackendManager.channel = makeChannel({ atomics: {} })!;
+    public async ensureChannel(): Promise<boolean> {
+        if (BackendManager.channel) {
+            return true;
         }
-        return true;
+        this.channelPromise ??= this.createChannel();
+        return (await this.channelPromise) !== null;
+    }
+
+    private async createChannel(): Promise<Channel | null> {
+        if (typeof SharedArrayBuffer !== "undefined") {
+            BackendManager.channel = makeChannel({ atomics: {} })!;
+            return BackendManager.channel;
+        }
+        if (!this.serviceWorkerName || !("serviceWorker" in navigator)) {
+            return null;
+        }
+        try {
+            const registration = await navigator.serviceWorker.register(this.serviceWorkerName, { scope: "/" });
+            await this.waitForActiveRegistration();
+            // The channel's scope becomes the base of a synchronous XHR inside the worker;
+            // a relative scope resolves against the worker's own base URL, which is opaque
+            // in a worker bootstrapped from a blob (see BackendManager.setWorkerUrl), so
+            // registration.scope (an absolute URL) is used instead
+            BackendManager.channel = makeChannel({ serviceWorker: { scope: registration.scope } })!;
+            return BackendManager.channel;
+        } catch (e) {
+            this.errorHandler(new ServiceWorkerRegistrationError("Error registering service worker", { cause: e }));
+            // Allow a later backend to try again rather than caching the failure forever
+            this.channelPromise = undefined;
+            return null;
+        }
     }
 
     private async waitForActiveRegistration(timeout: number = 5000): Promise<void> {

--- a/src/frontend/state/Papyros.ts
+++ b/src/frontend/state/Papyros.ts
@@ -65,10 +65,19 @@ export class Papyros extends State {
         BackendManager.setWorkerUrl(language, url);
     }
 
+    /**
+     * Whether registering the service worker can wait until a backend proves it needs one.
+     *
+     * This mirrors how Pyodide detects stack switching, which accepts the older Suspender
+     * shape as well as Suspending. It is only a hint: the worker's own probe decides the
+     * transport, so being wrong here costs at most one service worker nobody uses.
+     */
     private canDeferChannel(): boolean {
+        const wasm = WebAssembly as { Suspending?: unknown; Suspender?: unknown };
+        const stackSwitching = wasm.Suspending !== undefined || wasm.Suspender !== undefined;
         return (
             typeof SharedArrayBuffer === "undefined" &&
-            typeof (WebAssembly as { Suspending?: unknown }).Suspending === "function" &&
+            stackSwitching &&
             this.runner.allowJspi &&
             this.runner.programmingLanguage === ProgrammingLanguage.Python
         );
@@ -93,6 +102,11 @@ export class Papyros extends State {
             return BackendManager.channel;
         }
         if (!this.serviceWorkerName || !("serviceWorker" in navigator)) {
+            this.errorHandler(
+                new ServiceWorkerRegistrationError("No service worker available to handle input", {
+                    cause: new Error(`serviceWorkerName=${this.serviceWorkerName}`),
+                }),
+            );
             return null;
         }
         try {

--- a/src/frontend/state/Runner.ts
+++ b/src/frontend/state/Runner.ts
@@ -225,6 +225,13 @@ export class Runner extends State {
             this.allowJspi,
         );
         backend.usesPromiseTransport = await backend.workerProxy.usesJspi();
+        if (!backend.usesPromiseTransport) {
+            // This backend blocks on the channel, so it needs one to exist before it runs.
+            // Registration may not have happened yet: Papyros defers it when the browser
+            // can suspend the wasm stack, since Python then never touches it.
+            await this.papyros.ensureChannel();
+            backend.channel = BackendManager.channel;
+        }
         if (launchId === this.launchId) {
             this.updateRunModes();
             this.backendReady = true;

--- a/src/frontend/state/Runner.ts
+++ b/src/frontend/state/Runner.ts
@@ -229,9 +229,12 @@ export class Runner extends State {
             // This backend blocks on the channel, so it needs one to exist before it runs.
             // Registration may not have happened yet: Papyros defers it when the browser
             // can suspend the wasm stack, since Python then never touches it.
+            // A failure here is reported by ensureChannel and leaves the channel null, so
+            // running code still works and only reading input fails.
             await this.papyros.ensureChannel();
-            backend.channel = BackendManager.channel;
         }
+        // Assign either way, so a client that switched to JSPI drops a channel it no longer uses
+        backend.channel = BackendManager.channel;
         if (launchId === this.launchId) {
             this.updateRunModes();
             this.backendReady = true;

--- a/test/__tests__/state/Channel.test.ts
+++ b/test/__tests__/state/Channel.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { Papyros } from "../../../src/frontend/state/Papyros";
+import { ProgrammingLanguage } from "../../../src/ProgrammingLanguage";
+import { BackendManager } from "../../../src/communication/BackendManager";
+import { waitForInputReady, waitForOutput, waitForPapyrosReady } from "../../helpers";
+
+/**
+ * BackendManager.channel is static and shared, so clear it to observe what a launch
+ * actually needed rather than what an earlier test left behind.
+ */
+describe.sequential("lazy channel setup", () => {
+    beforeEach(() => {
+        BackendManager.channel = null;
+    });
+
+    it("does not build a channel for python when the stack can be suspended", async () => {
+        const papyros = new Papyros();
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+        const backend = await papyros.runner.backend;
+
+        expect(backend.usesPromiseTransport).toBe(true);
+        expect(BackendManager.channel).toBeNull();
+        expect(backend.channel).toBeNull();
+    }, 180000);
+
+    it("builds a channel for python when JSPI is disabled", async () => {
+        const papyros = new Papyros();
+        papyros.runner.allowJspi = false;
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+        const backend = await papyros.runner.backend;
+
+        expect(backend.usesPromiseTransport).toBe(false);
+        expect(BackendManager.channel).not.toBeNull();
+        expect(backend.channel).toBe(BackendManager.channel);
+    }, 180000);
+
+    it("builds a channel when javascript is selected, and input still works", async () => {
+        const papyros = new Papyros();
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.JavaScript;
+        const backend = await papyros.runner.backend;
+
+        expect(backend.usesPromiseTransport).toBe(false);
+        expect(BackendManager.channel).not.toBeNull();
+
+        papyros.runner.code = 'console.log("hello", prompt("name?"));';
+        await waitForInputReady();
+        const unsubscribe = papyros.io.subscribe(
+            () => (papyros.io.awaitingInput ? papyros.io.provideInput("channel") : ""),
+            "awaitingInput",
+        );
+        await papyros.runner.start();
+        await waitForOutput(papyros);
+        await waitForPapyrosReady(papyros);
+        expect(papyros.io.output[0].content).toBe("hello channel\n");
+        unsubscribe();
+    }, 180000);
+});

--- a/test/__tests__/state/Channel.test.ts
+++ b/test/__tests__/state/Channel.test.ts
@@ -5,8 +5,10 @@ import { BackendManager } from "../../../src/communication/BackendManager";
 import { waitForInputReady, waitForOutput, waitForPapyrosReady } from "../../helpers";
 
 /**
- * BackendManager.channel is static and shared, so clear it to observe what a launch
- * actually needed rather than what an earlier test left behind.
+ * BackendManager.channel is static and shared, and BackendManager caches one client per
+ * language, so clear the channel to observe what a launch actually needed rather than what an
+ * earlier test left behind. Runner.launch assigns backend.channel on every launch, including
+ * setting it back to null, so the cached client cannot carry a stale channel into these tests.
  */
 describe.sequential("lazy channel setup", () => {
     beforeEach(() => {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -21,12 +21,18 @@ export async function waitForPapyrosReady(papyros: Papyros, timeout = 2000): Pro
     }
 }
 
-export async function waitForInputReady(timeout = 2000): Promise<void> {
-    await navigator.serviceWorker.ready;
+/**
+ * Wait until a service worker controls this page, for tests that read input over the channel.
+ *
+ * Never awaits navigator.serviceWorker.ready: that only settles once a registration is active,
+ * and Papyros does not register one at all when the browser can suspend the wasm stack. Times
+ * out quietly instead, since a test that truly needs the channel fails on its own soon after.
+ */
+export async function waitForInputReady(timeout = 5000): Promise<void> {
     const start = Date.now();
     while (!navigator.serviceWorker.controller) {
         if (Date.now() - start > timeout) {
-            throw new Error("Timeout waiting for service worker to control this page");
+            return;
         }
         await new Promise(r => setTimeout(r, 20));
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,12 @@ export default defineConfig({
     worker: {
         format: "es",
     },
+    // pyodide is only imported from the worker entry, which the dependency scan does not crawl.
+    // Without this it is discovered once the first Python test starts a worker, and the reload
+    // that follows restarts tests midway through a run.
+    optimizeDeps: {
+        include: ["pyodide"],
+    },
     test: {
         browser: {
             enabled: true,


### PR DESCRIPTION
This pull request stops registering the input service worker unless a backend actually needs it. Phase 4 of #1081.

Registration used to happen in `Papyros.launch()`, before any worker existed, so every browser paid for it even though Python on a browser with stack switching never touches the channel. After this, a Python scratchpad registers no service worker at all on any engine that supports stack switching, which since Safari 27 means all current ones. The `__SyncMessageServiceWorkerInput__` failure family stops happening for that traffic rather than merely becoming survivable.

**Why it could not simply be decided up front**

The authoritative answer is `can_run_sync()` inside the worker once Pyodide has loaded. The main thread can only see that `WebAssembly.Suspending` exists, which says the browser has the feature, not that this Pyodide build and calling convention will suspend. So Papyros defers rather than guesses:

- `SharedArrayBuffer` available: build the atomics channel during launch as before. It costs nothing.
- Channel certainly needed (no stack switching, or the language is JavaScript, or `allowJspi` is off): register during launch, and a failure is still fatal, unchanged.
- Otherwise: start the worker with no channel. `Runner` asks for one only if the probe returns false, or when the JavaScript backend is selected, which can never use JSPI.

This works because `SyncClient.channel` is read at call time by `_writeMessage`, so assigning it after the client was constructed is enough.

`ensureChannel` is idempotent and safe to call concurrently, and it clears its cached promise on failure so a later backend can retry rather than inheriting a permanent failure.

**Documentation**

The README gains a mermaid diagram of launch order and transport selection. The ordering is the part that is genuinely hard to reconstruct from the code, and it is what made the original phase 4 design too conservative. The section also now covers JSPI, `allowJspi`, and the fact that interrupting is a separate axis from the input transport.

**Manual testing instructions**

- `yarn setup && yarn build:sw && yarn start`
- With devtools open on Application, Service Workers: load the scratchpad in Chrome or Firefox, run `print(input())`, answer it. Confirm no service worker is registered at any point.
- Switch the language to JavaScript, run `console.log(prompt("name?"))`, answer it. Confirm the service worker registers at that point and input works.
- Set `papyros.runner.allowJspi = false` before launching, run `print(input())`. Confirm the service worker registers and input works.
- Safari 27+ now supports JSPI too, so it behaves like Chrome here. To exercise the channel path on any browser, set `papyros.runner.allowJspi = false` before launching.

**Verification**

<details>
<summary>Suite, typecheck, lint</summary>

| Check | Result |
|---|---|
| `yarn vitest --run` | 13 files / 112 tests, green |
| `yarn typecheck` | clean |
| `yarn lint` | clean |

3 new tests in `test/__tests__/state/Channel.test.ts`, each clearing the shared `BackendManager.channel` first so they observe what the launch actually needed rather than what an earlier test left behind: Python with stack switching builds no channel at all, Python with `allowJspi` off builds one, and selecting JavaScript builds one and still reads input through it.

</details>

**Checklist**
- Tests: 3 new tests covering all three channel outcomes
- Docs: README rewritten around the three transports, with a mermaid diagram of launch order and transport selection
- Announcement: n/a
- AI: Claude Code wrote the implementation, the tests and the diagram

Closes #1081

