### PR TITLE
Validate translations in a test

### DIFF
--- a/src/frontend/state/Translations.ts
+++ b/src/frontend/state/Translations.ts
@@ -1,19 +1,17 @@
-// Empty strings are considered missing by i18n-extract
-// Therefore the ready-key is an explicit space now, which is still invisible
-
+/**
+ * Every key here must exist in both locales and be used somewhere in src, except for the
+ * CodeMirror block, whose English phrases CodeMirror already ships. Translations.test.ts
+ * enforces both.
+ */
 export const ENGLISH_TRANSLATION = {
     Papyros: {
         Papyros: "Papyros",
-        code: "Code",
         code_placeholder: "Write your %{programmingLanguage} code here and click 'Run' to execute...",
-        input: "Input",
         input_placeholder: {
             interactive: "Provide input and press enter to send",
             batch:
                 "Provide all input required by your code here.\n" + "You can enter multiple lines by pressing enter.",
         },
-        input_disabled: "You can only provide input when your code requires it in interactive mode",
-        output: "Output",
         output_placeholder: "The output of your code will appear here.",
         debug_placeholder: "The debugger output will appear here.",
         stop: "Stop",
@@ -27,10 +25,6 @@ export const ENGLISH_TRANSLATION = {
             ready: "",
         },
         programming_language: "Programming language",
-        programming_languages: {
-            Python: "Python",
-            JavaScript: "JavaScript",
-        },
         locales: {
             en: "English",
             nl: "Nederlands",
@@ -41,10 +35,8 @@ export const ENGLISH_TRANSLATION = {
         },
         enter: "Enter",
         examples: "Examples",
-        dark_mode: "Dark mode",
         output_overflow: "Output truncated. No more results will be shown.",
         output_overflow_download: "Click here to download the results.",
-        no_output: "The code did not produce any output.",
         service_worker_error: "The service worker failed to load.",
         launch_error: "Papyros failed to load. Do you want to reload?",
         url_fetch_error: "Failed to fetch URL: %{url}",
@@ -54,8 +46,6 @@ export const ENGLISH_TRANSLATION = {
             debug: "Debug",
             run: "Run",
         },
-        used_input: "This line has already been used as input.",
-        used_input_with_prompt: "This line was used as input for the following prompt: %{prompt}",
         debugger: {
             title: "Drag the slider to walk through your code.",
             text_1: "This window shows how your program works step by step. Explore to see how your program builds and stores information.",
@@ -79,7 +69,6 @@ export const ENGLISH_TRANSLATION = {
         add_file_placeholder: "filename\u2026",
         files_download: "Download",
         files_binary: "Binary file",
-        files_empty: "Empty file",
         output_tab_output: "Output",
         output_tab_turtle: "Turtle",
     },
@@ -95,24 +84,20 @@ export const ENGLISH_TRANSLATION = {
         "match case": "match case",
         replace: "Replace",
         "replace all": "Replace all",
-        close: "Sluiten",
+        close: "Close",
     },
 };
 
 export const DUTCH_TRANSLATION = {
     Papyros: {
         Papyros: "Papyros",
-        code: "Code",
         code_placeholder: "Schrijf hier je %{programmingLanguage} code en klik op 'Uitvoeren' om uit te voeren...",
-        input: "Invoer",
         input_placeholder: {
             interactive: "Geef invoer in en druk op enter",
             batch:
                 "Geef hier alle invoer die je code nodig heeft vooraf in.\n" +
                 "Je kan verschillende lijnen ingeven door op enter te drukken.",
         },
-        input_disabled: "Je kan enkel invoer invullen als je code erom vraagt in interactieve modus",
-        output: "Uitvoer",
         output_placeholder: "Hier komt de uitvoer van je code.",
         debug_placeholder: "Hier komt de uitvoer van de debugger.",
         stop: "Stop",
@@ -126,10 +111,6 @@ export const DUTCH_TRANSLATION = {
         finished: "Code uitgevoerd in %{time} s",
         interrupted: "Code onderbroken na %{time} s",
         programming_language: "Programmeertaal",
-        programming_languages: {
-            Python: "Python",
-            JavaScript: "JavaScript",
-        },
         locales: {
             en: "English",
             nl: "Nederlands",
@@ -140,10 +121,8 @@ export const DUTCH_TRANSLATION = {
         },
         enter: "Enter",
         examples: "Voorbeelden",
-        dark_mode: "Donkere modus",
         output_overflow: "Uitvoer ingekort. Er zullen geen nieuwe resultaten getoond worden.",
         output_overflow_download: "Klik hier om de resultaten te downloaden.",
-        no_output: "De code produceerde geen uitvoer.",
         service_worker_error: "Er liep iets fout bij het laden van de service worker.",
         launch_error: "Er liep iets fout bij het laden van Papyros. Wil je herladen?",
         url_fetch_error: "Kon URL niet ophalen: %{url}",
@@ -153,8 +132,6 @@ export const DUTCH_TRANSLATION = {
             debug: "Debuggen",
             run: "Uitvoeren",
         },
-        used_input: "Deze regel werd al gebruikt als invoer.",
-        used_input_with_prompt: "Deze regel werd gebruikt als invoer voor de volgende vraag: %{prompt}",
         debugger: {
             title: "Verken je code stap voor stap",
             text_1: "Dit venster toont de werking van je programma in detail. Ontdek hoe je programma informatie opbouwt en bewaart.",
@@ -178,7 +155,6 @@ export const DUTCH_TRANSLATION = {
         add_file_placeholder: "bestandsnaam\u2026",
         files_download: "Downloaden",
         files_binary: "Binair bestand",
-        files_empty: "Leeg bestand",
         output_tab_output: "Uitvoer",
         output_tab_turtle: "Turtle",
     },

--- a/test/__tests__/state/Translations.test.ts
+++ b/test/__tests__/state/Translations.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { DUTCH_TRANSLATION, ENGLISH_TRANSLATION } from "../../../src/frontend/state/Translations";
+import type { Translations } from "../../../src/frontend/state/I18n";
+
+const sources = import.meta.glob("../../../src/**/*.ts", {
+    query: "?raw",
+    import: "default",
+    eager: true,
+}) as Record<string, string>;
+
+/** CodeMirror ships English phrases of its own, so only other locales override them. */
+const ENGLISH_OPTIONAL_PREFIXES = ["CodeMirror."];
+
+function flatten(translations: Translations, prefix = ""): string[] {
+    return Object.entries(translations).flatMap(([key, value]) =>
+        typeof value === "string" ? [prefix + key] : flatten(value, `${prefix}${key}.`),
+    );
+}
+
+function matchAll(pattern: RegExp): string[] {
+    return Object.entries(sources)
+        .filter(([path]) => !path.endsWith("/Translations.ts"))
+        .flatMap(([, source]) => [...source.matchAll(pattern)].map((match) => match[1]));
+}
+
+/** Keys passed to t() as a plain string, the only ones that can be checked exactly. */
+function usedKeys(): string[] {
+    return matchAll(/\.t\(\s*"([^"]+)"/g);
+}
+
+/**
+ * Prefixes of keys that are resolved at runtime, either by interpolating into the phrase
+ * (`t(`Papyros.states.${state}`)`) or by handing a whole subtree to another component
+ * (`getTranslations("CodeMirror")`). Every key below such a prefix counts as used.
+ */
+function usedPrefixes(): string[] {
+    return [
+        ...matchAll(/\.t\(\s*`([^`$]*)\$\{/g),
+        ...matchAll(/getTranslations\(\s*"([^"]+)"/g).map((key) => `${key}.`),
+    ];
+}
+
+describe("translations", () => {
+    const english = flatten(ENGLISH_TRANSLATION);
+    const dutch = flatten(DUTCH_TRANSLATION);
+
+    it("translates every English key into Dutch", () => {
+        expect(english.filter((key) => !dutch.includes(key))).toEqual([]);
+    });
+
+    it("has an English phrase for every Dutch key", () => {
+        const missing = dutch
+            .filter((key) => !english.includes(key))
+            .filter((key) => !ENGLISH_OPTIONAL_PREFIXES.some((prefix) => key.startsWith(prefix)));
+        expect(missing).toEqual([]);
+    });
+
+    it("defines every key used in the source", () => {
+        expect(usedKeys().filter((key) => !english.includes(key))).toEqual([]);
+    });
+
+    it("uses every key it defines", () => {
+        const used = usedKeys();
+        const prefixes = usedPrefixes();
+        const unused = english
+            .filter((key) => !used.includes(key))
+            .filter((key) => !prefixes.some((prefix) => key.startsWith(prefix)));
+        expect(unused).toEqual([]);
+    });
+});


### PR DESCRIPTION
This pull request reintroduces the translation validation that was dropped during the webcomponent refactor, as a vitest case rather than a standalone script and workflow.

It checks four things: every English key exists in Dutch, every Dutch key exists in English, every key used in `src` is defined, and every defined key is used.

Running it found 11 keys that are no longer used anywhere, removed here from both locales. Two unrelated fixes in the same file: the header comment still described `i18n-extract` behaviour that no longer applies, and `CodeMirror.close` in the English block read `"Sluiten"`.

<details>
<summary>The 11 removed keys, and what replaced each</summary>

None of these became hardcoded English. Each is either replaced by another translated key, replaced by something language neutral, or gone from the UI.

| Key | Where it went | Translated? |
|---|---|---|
| `code`, `input`, `output` | Panel headings in the old two column layout. `App.ts` renders unlabelled containers now, and the panes carry their own tab labels `editor_tab_code`, `output_tab_output`, `output_tab_turtle` | Yes, via the tab keys |
| `programming_languages.Python`, `.JavaScript` | `ProgrammingLanguagePicker` renders `${lang}` straight from the enum, whose values are the strings `"Python"` and `"JavaScript"` | N/a, proper nouns. The removed phrases were identical in both locales |
| `dark_mode` | There is no dark mode toggle anymore. `ThemePicker` is an icon button opening six theme swatches | N/a, no text |
| `used_input`, `used_input_with_prompt` | A `✔` gutter marker and a line highlight, from `lineEffectExtension({ marker: "✔" })` in `Extensions.ts:134` | N/a, a glyph with no tooltip |
| `files_empty` | `FileViewer` has no empty file branch. An empty text file just opens the editor with empty content | N/a, no text |
| `no_output` | `Output.ts` shows `output_placeholder` whenever nothing is rendered | Yes, but see below |
| `input_disabled` | Nothing. `InteractiveInput` sets `?disabled` on the field and button | See below |

Two strings the refactor dropped without replacing, neither of them a translation problem and neither introduced here:

- `no_output` said "The code did not produce any output." The placeholder shown instead is "The output of your code will appear here.", so the UI no longer distinguishes "not run yet" from "ran and printed nothing".
- `input_disabled` explained why the input field was unavailable. The field now just greys out.

Nine of the eleven went dead in `a9777c9` and `8ef92b0`, both part of #878, which is also the PR that removed the validation script. `files_empty` went dead in `0da4cc4`.

I also swept the components for hardcoded English in `aria-label`, `title`, `alt` and `placeholder`. The only hits are two `title=` bindings in `Output.ts` carrying backend error text, and `BatchInput`'s placeholder, which comes from `this.t(...)`.

</details>

**Manual testing instructions**
- `npx vitest run test/__tests__/state/Translations.test.ts` passes, 4 tests
- Delete any key from `DUTCH_TRANSLATION` and it fails on the parity check
- Add an unused key to `ENGLISH_TRANSLATION` and it fails on the unused check
- The language picker and debugger still render their labels in both locales

**Checklist**
- Tests: this pull request is the test
- Docs: n/a
- Announcement: n/a
- AI: Claude Code wrote the test and made the removals, after checking each removed key against both this repo and dodona

Closes #879
