### PR TITLE
Fix missing and misplaced linting annotations

### DIFF
--- a/src/backend/workers/python/papyros/linting.py
+++ b/src/backend/workers/python/papyros/linting.py
@@ -51,13 +51,16 @@ def process_pylint_output(linting_output):
         msg_id, line_nr, column_nr, end_line, end_column, category, message = parts
         if not line_nr.isdigit() or not column_nr.isdigit() or category not in SEVERITIES:
             continue
+        line_nr = int(line_nr)
+        column_nr = int(column_nr)
         if msg_id == SYNTAX_ERROR_ID:
             # Unwrap the parse error to hide the name of the temporary file we linted
             match = SYNTAX_ERROR_MESSAGE.match(message)
             if match:
                 message = match.group("message")
-        line_nr = int(line_nr)
-        column_nr = int(column_nr)
+            # Parse errors carry the 1-based offset of the SyntaxError they come from,
+            # while every other message reports a 0-based column
+            column_nr = max(column_nr - 1, 0)
         diagnostics.append({
             "lineNr": line_nr,
             "columnNr": column_nr,

--- a/src/backend/workers/python/papyros/linting.py
+++ b/src/backend/workers/python/papyros/linting.py
@@ -1,5 +1,6 @@
 # Ensure pylint can find the plugin files
 import os
+import re
 import sys
 from tempfile import NamedTemporaryFile
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -10,6 +11,11 @@ from pylint.reporters.text import TextReporter
 
 PYLINT_RC_FILE = os.path.abspath("/tmp/papyros/pylint_config.rc")
 PYLINT_PLUGINS = "pylint_ast_checker,pylint_turtle_brain"
+# The path is omitted as it is the only field that can contain a colon itself
+PYLINT_MSG_TEMPLATE = "{msg_id}:{line}:{column}:{end_line}:{end_column}:{category}:{msg}"
+SYNTAX_ERROR_ID = "E0001"
+# Pylint reports parse errors as "Parsing failed: '<message> (<file name>, line <nr>)'"
+SYNTAX_ERROR_MESSAGE = re.compile(r"^Parsing failed: '(?P<message>.*) \(.*, line \d+\)'$")
 
 def lint(code):
     # Use temporary file to prevent Astroid cache from running into issues
@@ -21,7 +27,7 @@ def lint(code):
             "-j", "1", # ensure no parallellism is used as we don't have such resources in a worker
             "--rcfile", PYLINT_RC_FILE,
             "--load-plugins", PYLINT_PLUGINS,
-            "--msg-template", "{path}:{line}:{column}:{end_line}:{end_column}:{category}:{msg}",
+            "--msg-template", PYLINT_MSG_TEMPLATE,
             tmpf.name], reporter=TextReporter(pylint_output), exit=False)
 
     return process_pylint_output(pylint_output.getvalue())
@@ -29,20 +35,26 @@ def lint(code):
 def process_pylint_output(linting_output):
     diagnostics = []
     for line in linting_output.split("\n"):
-        line: str = line.rstrip()
-        # {path}:{line}:{column}:{end_line}:{end_column}:{category}:{msg}
-        if line.count(":") == 6:
-            _, line_nr, column_nr, end_line, end_column, severity, message = line.rstrip().split(":")
-            line_nr = int(line_nr)
-            column_nr = int(column_nr)
-            # If Pylint doesn't know the exact cause, just omit it
-            message = message.replace("(<unknown>, ", "(")
-            diagnostics.append({
-                "lineNr": line_nr,
-                "columnNr": column_nr,
-                "endLineNr": int(end_line) if end_line else line_nr,
-                "endColumnNr": int(end_column) if end_column else column_nr,
-                "severity": severity,
-                 "message": message
-            })
+        # The message can contain colons itself, so only split off the fields in front of it
+        parts = line.rstrip().split(":", 6)
+        if len(parts) != 7:
+            continue
+        msg_id, line_nr, column_nr, end_line, end_column, severity, message = parts
+        if not line_nr.isdigit() or not column_nr.isdigit():
+            continue
+        if msg_id == SYNTAX_ERROR_ID:
+            # Unwrap the parse error to hide the name of the temporary file we linted
+            match = SYNTAX_ERROR_MESSAGE.match(message)
+            if match:
+                message = match.group("message")
+        line_nr = int(line_nr)
+        column_nr = int(column_nr)
+        diagnostics.append({
+            "lineNr": line_nr,
+            "columnNr": column_nr,
+            "endLineNr": int(end_line) if end_line else line_nr,
+            "endColumnNr": int(end_column) if end_column else column_nr,
+            "severity": severity,
+            "message": message
+        })
     return diagnostics

--- a/src/backend/workers/python/papyros/linting.py
+++ b/src/backend/workers/python/papyros/linting.py
@@ -16,6 +16,15 @@ PYLINT_MSG_TEMPLATE = "{msg_id}:{line}:{column}:{end_line}:{end_column}:{categor
 SYNTAX_ERROR_ID = "E0001"
 # Pylint reports parse errors as "Parsing failed: '<message> (<file name>, line <nr>)'"
 SYNTAX_ERROR_MESSAGE = re.compile(r"^Parsing failed: '(?P<message>.*) \(.*, line \d+\)'$")
+# CodeMirror only renders these four severities, so map Pylint's categories onto them
+SEVERITIES = {
+    "fatal": "error",
+    "error": "error",
+    "warning": "warning",
+    "refactor": "info",
+    "convention": "info",
+    "info": "info",
+}
 
 def lint(code):
     # Use temporary file to prevent Astroid cache from running into issues
@@ -39,8 +48,8 @@ def process_pylint_output(linting_output):
         parts = line.rstrip().split(":", 6)
         if len(parts) != 7:
             continue
-        msg_id, line_nr, column_nr, end_line, end_column, severity, message = parts
-        if not line_nr.isdigit() or not column_nr.isdigit():
+        msg_id, line_nr, column_nr, end_line, end_column, category, message = parts
+        if not line_nr.isdigit() or not column_nr.isdigit() or category not in SEVERITIES:
             continue
         if msg_id == SYNTAX_ERROR_ID:
             # Unwrap the parse error to hide the name of the temporary file we linted
@@ -54,7 +63,7 @@ def process_pylint_output(linting_output):
             "columnNr": column_nr,
             "endLineNr": int(end_line) if end_line else line_nr,
             "endColumnNr": int(end_column) if end_column else column_nr,
-            "severity": severity,
+            "severity": SEVERITIES[category],
             "message": message
         })
     return diagnostics

--- a/test/__tests__/state/Runner.test.ts
+++ b/test/__tests__/state/Runner.test.ts
@@ -149,6 +149,17 @@ print
         expect(diagnostics[0].message).toBe("Statement seems to have no effect");
     });
 
+    it("should show syntax errors", async () => {
+        const papyros = new Papyros();
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+        papyros.runner.code = `print 'hello'
+`;
+        const diagnostics = await papyros.runner.lintSource();
+        expect(diagnostics.length).toBe(1);
+        expect(diagnostics[0].message).toBe("Missing parentheses in call to 'print'. Did you mean print(...)?");
+    });
+
     it("should run doctests", async () => {
         const papyros = new Papyros();
         await papyros.launch();

--- a/test/__tests__/state/Runner.test.ts
+++ b/test/__tests__/state/Runner.test.ts
@@ -158,6 +158,8 @@ print
         const diagnostics = await papyros.runner.lintSource();
         expect(diagnostics.length).toBe(1);
         expect(diagnostics[0].message).toBe("Missing parentheses in call to 'print'. Did you mean print(...)?");
+        // The error is reported on the p of print, not after it
+        expect(diagnostics[0].columnNr).toBe(0);
     });
 
     it("should report style issues as info", async () => {

--- a/test/__tests__/state/Runner.test.ts
+++ b/test/__tests__/state/Runner.test.ts
@@ -160,6 +160,18 @@ print
         expect(diagnostics[0].message).toBe("Missing parentheses in call to 'print'. Did you mean print(...)?");
     });
 
+    it("should report style issues as info", async () => {
+        const papyros = new Papyros();
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+        papyros.runner.code = `def foo():
+    return 1
+`;
+        const diagnostics = await papyros.runner.lintSource();
+        expect(diagnostics.length).toBe(1);
+        expect(diagnostics[0].severity).toBe("info");
+    });
+
     it("should run doctests", async () => {
         const papyros = new Papyros();
         await papyros.launch();


### PR DESCRIPTION
This pull request fixes three bugs that together left the Python editor with almost no visible linting annotations.

**Syntax errors were never annotated.** `process_pylint_output` recognised a diagnostic by counting colons, expecting exactly the six that separate the fields of the message template. Pylint wraps a parse error as `Parsing failed: '<message> (<file>, line <nr>)'`, so those lines carry extra colons and were dropped. Pylint has reported syntax errors this way since 2.15, so they have been missing for a long time. The fields in front of the message are now split off instead, keyed on the message id rather than the path, which was the only field that could contain a colon itself. The wrapper is stripped as well, since it exposed the name of the temporary file we lint.

**Convention and refactor messages were invisible.** Pylint's category was passed straight through as the severity. CodeMirror only styles `hint`, `info`, `warning` and `error`, so `convention` and `refactor` diagnostics reached the editor without an underline and without a gutter marker: present in the document, but invisible. `WorkerDiagnostic` already declared `severity` as `"info" | "warning" | "error"`, so the categories are now mapped onto that, with convention and refactor becoming `info`.

**Syntax errors were marked one character too far to the right.** Pylint reports the column of a parse error as the offset of the `SyntaxError` it comes from, which is 1-based, while every other message carries a 0-based column.

Closes #233: the marker now sits on the `p` of `print` rather than after it, which is the fallback that issue asks for. The preferred wave line under the character is not possible yet, as pylint reports no end position for parse errors.

**Manual testing instructions**
- `print 'hello'` marks the `p` of `print` with `Missing parentheses in call to 'print'. Did you mean print(...)?`
- `if x = 2:` marks the `x` with `invalid syntax. Maybe you meant '==' or ':=' instead of '='?`
- `def foo():` followed by `    return 1` shows a grey underline for `Disallowed name "foo"`
- Undefined variables and unused imports keep their orange and red underlines

**Checklist**
- Tests: added cases in `Runner.test.ts` for a syntax error being reported with the right message and column, and for a convention message arriving as `info`
- Docs: n/a
- Announcement: 🐛 Syntax errors and style suggestions are annotated in the code editor again
- AI: Claude Code diagnosed the three bugs and wrote the fixes and tests
