### PR TITLE
Fix the publish workflow for setup-node v7

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -60,7 +60,12 @@ jobs:
         with:
           node-version: 24.x
           cache: yarn
-          registry-url: 'https://registry.npmjs.org'
+          # No registry-url: it writes an .npmrc with an _authToken referencing
+          # the NODE_AUTH_TOKEN env var, which yarn crashes on when unset (and
+          # setup-node v7 runs yarn for cache resolution before exporting a
+          # placeholder). Auth is npm trusted publishing: the CLI exchanges the
+          # workflow's OIDC id-token and injects the resulting npm token itself,
+          # and the registry defaults to registry.npmjs.org.
       - name: Install and Build
         run: |
           yarn install --frozen-lockfile


### PR DESCRIPTION
**TODO (author) — drafted by Claude: proofread, verify and remove this line.**

This pull request removes `registry-url` from the publish job's setup-node step, fixing at the root the failure that broke trace-component's v1.5.0 release before dodona-edu/trace-component#132 worked around it: with `registry-url` set, setup-node writes an `.npmrc` whose `_authToken` references `${NODE_AUTH_TOKEN}`, yarn 1 hard-errors on the unset variable, and setup-node v7 runs yarn for cache resolution before exporting the placeholder that v6 provided. papyros' publish workflow has the identical pattern, so its next npm release would fail the same way.

That `.npmrc` is legacy token-flow boilerplate. Publishing authenticates via npm trusted publishing: the npm CLI exchanges the workflow's OIDC id-token and injects the resulting registry token into its own configuration ([npm/cli `lib/utils/oidc.js`](https://github.com/npm/cli/blob/latest/lib/utils/oidc.js), which overwrites any configured `_authToken`), and the registry already defaults to `registry.npmjs.org`. Without `registry-url` there is no breakable file and no dummy value to maintain. Same change on the trace-component side: dodona-edu/trace-component#133.

**Manual testing instructions**
- Next `v*` release should publish normally via trusted publishing

**Checklist**
- Tests: n/a (workflow only; behavior verified against the npm CLI source and trace-component's release logs)
- Docs: n/a
- Announcement: n/a
- AI: Claude Code traced the root cause through the setup-node and npm CLI sources