### PR TITLE
Update the debugger dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@codemirror/state": "^6.3.2",
     "@codemirror/view": "^6.28.0",
     "@dodona/lit-state": "^1.1.1",
-    "@dodona/trace-component": "1.4.2",
+    "@dodona/trace-component": "1.5.0",
     "@material/web": "^2.4.0",
     "codemirror-readonly-ranges": "^0.1.0-alpha.2",
     "comlink": "^4.4.1",

--- a/src/backend/workers/python/build_package.py
+++ b/src/backend/workers/python/build_package.py
@@ -50,4 +50,4 @@ def check_tar(tarname, out_dir="."):
 
 
 if __name__ == "__main__":
-    create_package("python_package", "python-runner friendly_traceback pylint>=4,<5 tomli typing-extensions json-tracer>=0.7.0 svg-turtle", extra_deps="papyros")
+    create_package("python_package", "python-runner friendly_traceback pylint>=4,<5 tomli typing-extensions dodona-json-tracer>=1.0.0 svg-turtle", extra_deps="papyros")

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,10 +105,10 @@
   dependencies:
     lit "^3.3.1"
 
-"@dodona/trace-component@1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@dodona/trace-component/-/trace-component-1.4.2.tgz#b5ac12c0e3e9327191ac0ccf4a3fbd178790eadc"
-  integrity sha512-84pGj5ePOPnxzpWjDHLysXzwgVpu7lqPokRatMq//1XlJg5O9OB/oNVlFn1U2OSC8hr7o1Ostj1MDlaSF0EZvw==
+"@dodona/trace-component@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@dodona/trace-component/-/trace-component-1.5.0.tgz#416d292369bada5c7109d856c18aaa58e86733d2"
+  integrity sha512-ueBNuNeP1E6oAh4KKXzfypH2SkECbevzumN7HlK7U07OJuFSkvy2uJY6L3cUE6eF28AFfjHba7eCp96KHilwZQ==
   dependencies:
     lit "^3.3.3"
 


### PR DESCRIPTION
This pull request picks up the two releases carrying the debugger performance work for #1020:

- `dodona-json-tracer` 1.0.0 in `build_package.py` — the tracer's new PyPI name (access to the old `json-tracer` account was lost; the import name is unchanged). It brings the closure-walk skip and the module-check hoist (dodona-edu/json-tracer#11, spirograph benchmark 224s → 4.1s with byte-identical traces) and hides the internal `__firstlineno__`/`__static_attributes__` attributes Python 3.13+ adds to every class (dodona-edu/json-tracer#13).
- `@dodona/trace-component` 1.5.0 — incremental layout building on appended debug frames instead of a quadratic rebuild (dodona-edu/trace-component#129).

After pulling this, run `yarn setup` to rebuild the worker package tarball, or the old tracer stays in your local build.

**Manual testing instructions**
- Debug the spirograph from #1020: frames should stream dramatically faster and stay smooth on long sessions
- Debug a program defining a class: no `__firstlineno__` / `__static_attributes__` entries on the class

**Checklist**
- Tests: full vitest suite passes against the rebuilt tarball and the new trace-component
- Docs: n/a
- Announcement: ✨ Debugging is much faster, especially for turtle exercises
- AI: Claude Code implemented the underlying fixes in both libraries and wired up the bumps