### PR TITLE
Trim the registry-url comment to the current rationale

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -60,12 +60,8 @@ jobs:
         with:
           node-version: 24.x
           cache: yarn
-          # No registry-url: it writes an .npmrc with an _authToken referencing
-          # the NODE_AUTH_TOKEN env var, which yarn crashes on when unset (and
-          # setup-node v7 runs yarn for cache resolution before exporting a
-          # placeholder). Auth is npm trusted publishing: the CLI exchanges the
-          # workflow's OIDC id-token and injects the resulting npm token itself,
-          # and the registry defaults to registry.npmjs.org.
+          # No registry-url: auth uses npm trusted publishing (OIDC), which
+          # needs no .npmrc, and the registry defaults to registry.npmjs.org.
       - name: Install and Build
         run: |
           yarn install --frozen-lockfile


### PR DESCRIPTION
This pull request shortens the comment added in #1090 to just the present-tense rationale; the setup-node v6/v7 history it recounted lives in that PR and its commit message.