### PR TITLE
Stream turtle drawings as incremental SVG patches

### DIFF
--- a/scripts/bench_turtle.py
+++ b/scripts/bench_turtle.py
@@ -89,7 +89,7 @@ def load_worker_package():
         sys.exit(f"missing {os.path.relpath(PACKAGE, REPO)} — run `yarn setup` first")
     target = tempfile.mkdtemp(prefix="papyros-bench-")
     with tarfile.open(PACKAGE) as tar:
-        tar.extractall(target)
+        tar.extractall(target, filter="data")
     sys.path.insert(0, target)
 
 

--- a/scripts/bench_turtle.py
+++ b/scripts/bench_turtle.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Benchmark turtle snapshotting during a debug session.
+
+Papyros takes a snapshot of the turtle drawing after every debug frame. This
+compares how much that costs with the two possible strategies:
+
+  full   re-render the whole SVG document per frame and base64 it
+         (what Papyros did before dodona-edu/papyros#1020 was addressed)
+  patch  render only the canvas items that changed and stream them as patches
+         (papyros/turtle_svg.py, what Papyros does now)
+
+It also asserts that replaying the patches reproduces exactly the document the
+full strategy produces, so the fast path is not quietly drawing something else.
+
+Numbers are CPython, not Pyodide/WASM: expect the real browser to be several
+times slower, and both strategies to be affected in the same way.
+
+Usage:
+    python3 scripts/bench_turtle.py                  # the program from issue #1020
+    python3 scripts/bench_turtle.py --program square
+    python3 scripts/bench_turtle.py --program my_turtle_program.py
+    python3 scripts/bench_turtle.py --mode patch     # only the new strategy
+
+Requires the Python worker bundle, so run `yarn setup` first.
+"""
+
+import argparse
+import base64
+import importlib.util
+import json
+import os
+import sys
+import tarfile
+import tempfile
+import time
+import types
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WORKER = os.path.join(REPO, "src", "backend", "workers", "python")
+PACKAGE = os.path.join(WORKER, "python_package.tar.gz.load_by_url")
+
+# The spirograph from https://github.com/dodona-edu/papyros/issues/1020,
+# which took about three minutes to debug.
+SPIRO = """
+from turtle import Turtle, Screen
+
+def drawCircles(t, size, steps, shift):
+    for _ in range(steps):
+        t.circle(size)
+        size -= shift
+
+def drawSpecial(t, size, repeat, steps, shift):
+    for _ in range(repeat):
+        drawCircles(t, size, steps, shift)
+        t.right(360 / repeat)
+
+spiro = [
+    ['white', 100, 10, 4], ['yellow', 80, 4, 10], ['blue', 60, 4, 5],
+    ['orange', 40, 4, 19], ['pink', 20, 4, 20],
+]
+
+window = Screen()
+window.setup(400, 1000)
+window.bgcolor('#663399')
+
+turtle = Turtle()
+for color, rotate, steps, shift in spiro:
+    turtle.color(color)
+    drawSpecial(turtle, 100, 10, steps, shift)
+"""
+
+SQUARE = """
+import turtle
+
+t = turtle.Turtle()
+for _ in range(40):
+    for _ in range(4):
+        t.forward(100)
+        t.right(90)
+    t.right(9)
+"""
+
+PROGRAMS = {"spiro": SPIRO, "square": SQUARE}
+
+
+def load_worker_package():
+    """Unpack the Python worker bundle and put it on the path."""
+    if not os.path.exists(PACKAGE):
+        sys.exit(f"missing {os.path.relpath(PACKAGE, REPO)} — run `yarn setup` first")
+    target = tempfile.mkdtemp(prefix="papyros-bench-")
+    with tarfile.open(PACKAGE) as tar:
+        tar.extractall(target)
+    sys.path.insert(0, target)
+
+
+def load_papyros_modules():
+    """Load the turtle modules from src/ (not from the bundle, which may be stale).
+
+    They live in the ``papyros`` package, whose ``__init__`` pulls in Pyodide, so
+    they are loaded into a stand-in package that only holds these two modules.
+    """
+    package = types.ModuleType("papyros_turtle")
+    package.__path__ = [os.path.join(WORKER, "papyros")]
+    sys.modules["papyros_turtle"] = package
+    for name in ("turtle_svg", "turtle_hook"):
+        path = os.path.join(WORKER, "papyros", f"{name}.py")
+        spec = importlib.util.spec_from_file_location(f"papyros_turtle.{name}", path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[f"papyros_turtle.{name}"] = module
+        spec.loader.exec_module(module)
+    return sys.modules["papyros_turtle.turtle_hook"]
+
+
+def install_turtle(turtle_hook):
+    """Set up turtle exactly like the worker does, and return the import hook."""
+    hook = turtle_hook.TurtleImportHook()
+    hook.papyros = None
+    sys.modules.pop("turtle", None)
+    sys.meta_path = [h for h in sys.meta_path if not isinstance(h, turtle_hook.TurtleImportHook)]
+    sys.meta_path.insert(0, hook)
+    return hook
+
+
+def replay(patches):
+    """The frontend's TurtleSvgBuilder, in Python (src/frontend/state/TurtleSvg.ts)."""
+    fragments, order, open_, close = {}, None, "", ""
+    for patch in patches:
+        if patch.get("clear"):
+            fragments, order = {}, None
+        if "open" in patch:
+            open_, close = patch["open"], patch.get("close", "")
+        for index, fragment in patch.get("set", []):
+            fragments[index] = fragment
+        if "order" in patch:
+            order = patch["order"]
+    if not open_:
+        return None
+    order = order if order is not None else sorted(fragments)
+    return open_ + "".join(fragments.get(i, "") for i in order) + close
+
+
+def run(source, mode, module_name="sandbox"):
+    """Trace ``source`` and snapshot the drawing after every frame."""
+    from tracer import JSONTracer
+
+    turtle_hook = load_papyros_modules()
+    hook = install_turtle(turtle_hook)
+
+    snapshots = []      # what a frame contributed to the payload sent to the frontend
+    snapshot_time = 0.0
+    frames = 0
+
+    def take_snapshot():
+        nonlocal snapshot_time
+        if hook.render is None:
+            return
+        start = time.perf_counter()
+        if mode == "patch":
+            patch = hook.svg_stream.patch()
+            payload = None if patch is None else json.dumps(patch)
+        else:
+            from svg_turtle import SvgTurtle
+
+            svg = SvgTurtle._pen.to_svg()
+            encoded = base64.b64encode(svg.encode("utf-8")).decode("utf-8")
+            # The old code only sent a snapshot when the document changed.
+            payload = None if encoded == take_snapshot.previous else encoded
+            take_snapshot.previous = encoded
+        snapshot_time += time.perf_counter() - start
+        if payload is not None:
+            snapshots.append(payload)
+
+    take_snapshot.previous = None
+
+    def frame_callback(_frame):
+        nonlocal frames
+        frames += 1
+        take_snapshot()
+
+    start = time.perf_counter()
+    JSONTracer(frame_callback=frame_callback, module_name=module_name).runscript(source)
+    take_snapshot()  # the snapshot Papyros emits when the program ends
+    total = time.perf_counter() - start
+
+    from svg_turtle import SvgTurtle
+
+    document = SvgTurtle._pen.to_svg()
+    if mode == "patch":
+        rebuilt = replay([json.loads(p) for p in snapshots])
+        if rebuilt != document:
+            sys.exit("FAIL: replaying the patches does not reproduce svg-turtle's document")
+    return {
+        "frames": frames,
+        "total": total,
+        "snapshot_time": snapshot_time,
+        "snapshots": len(snapshots),
+        "bytes": sum(len(p) for p in snapshots),
+        "document": len(document),
+    }
+
+
+def report(mode, result):
+    print(f"  {mode:<6}  {result['snapshot_time']:7.2f}s snapshotting"
+          f"  {result['total'] - result['snapshot_time']:8.2f}s tracing"
+          f"  {result['total']:8.2f}s total"
+          f"  {result['snapshots']:6d} snapshots"
+          f"  {result['bytes'] / 1024 / 1024:8.1f} MiB streamed to the frontend")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--program", default="spiro",
+                        help="spiro (default), square, or a path to a Python file")
+    parser.add_argument("--mode", default="both", choices=("both", "full", "patch"))
+    args = parser.parse_args()
+
+    if args.program in PROGRAMS:
+        source = PROGRAMS[args.program]
+    else:
+        with open(args.program) as f:
+            source = f.read()
+
+    load_worker_package()
+    modes = ("full", "patch") if args.mode == "both" else (args.mode,)
+
+    print(f"program: {args.program}")
+    results = {}
+    for mode in modes:
+        results[mode] = run(source, mode)
+        report(mode, results[mode])
+
+    first = results[modes[0]]
+    print(f"\n{first['frames']} debug frames, final drawing {first['document'] / 1024:.0f} KiB of SVG")
+    if len(modes) == 2:
+        full, patch = results["full"], results["patch"]
+        print(f"speedup: {full['snapshot_time'] / max(patch['snapshot_time'], 1e-9):.0f}x less time snapshotting, "
+              f"{full['bytes'] / max(patch['bytes'], 1):.0f}x fewer bytes to the frontend")
+        print("(patches reproduce svg-turtle's document exactly)")
+    print("\nNote: 'tracing' is everything json-tracer does per frame and is untouched by this\n"
+          "benchmark; for turtle programs it is dominated by the closure-discovery walk in\n"
+          "json_tracer.visit_all_locally_reachable_function_objs.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/backend/workers/python/papyros/papyros.py
+++ b/src/backend/workers/python/papyros/papyros.py
@@ -49,7 +49,6 @@ class Papyros(python_runner.PyodideRunner):
         self._tracking_files = False
         self._original_open = builtins.open
         self._last_emitted_snapshot = None
-        self._last_emitted_turtle_svg = None
         self._turtle_hook = TurtleImportHook()
         self._install_open_tracking()
         self.limit = limit
@@ -95,19 +94,21 @@ class Papyros(python_runner.PyodideRunner):
         self.override_turtle()
 
     def _emit_turtle_snapshot(self):
-        if not self._turtle_hook.render:
+        hook = self._turtle_hook
+        if not hook.render or hook.svg_stream is None:
             return
-        from svg_turtle import SvgTurtle
-        svg_string = SvgTurtle._pen.to_svg()
-        if svg_string and svg_string != self._last_emitted_turtle_svg:
-            self._last_emitted_turtle_svg = svg_string
-            img = base64.b64encode(svg_string.encode("utf-8")).decode("utf-8")
-            self.callback("turtle", data=img, contentType="image/svg+xml;base64")
+        # Only the canvas items that changed since the previous snapshot are
+        # rendered and sent; the frontend replays the patches. Re-rendering the
+        # whole drawing here is what made debugging turtle programs quadratic.
+        patch = hook.svg_stream.patch()
+        if patch is not None:
+            self.callback("turtle", data=json.dumps(patch), contentType="text/json")
 
     def override_turtle(self):
         hook = self._turtle_hook
         hook.papyros = self
         hook.render = None
+        hook.svg_stream = None
         # Remove turtle from sys.modules so the hook intercepts the next import
         sys.modules.pop('turtle', None)
         if hook not in sys.meta_path:
@@ -222,7 +223,6 @@ class Papyros(python_runner.PyodideRunner):
         self._tracked_files.clear()
         self._tracking_files = True
         self._last_emitted_snapshot = None
-        self._last_emitted_turtle_svg = None
         with (
             redirect_stdout(python_runner.output.SysStream("output", self.output_buffer)),
             redirect_stderr(python_runner.output.SysStream("error", self.output_buffer)),

--- a/src/backend/workers/python/papyros/turtle_hook.py
+++ b/src/backend/workers/python/papyros/turtle_hook.py
@@ -1,5 +1,7 @@
 import sys
 
+from .turtle_svg import TrackedCanvas, TurtleSvgStream
+
 
 class TurtleImportHook:
     """Import hook that lazily sets up SVG-based turtle graphics.
@@ -14,6 +16,7 @@ class TurtleImportHook:
     def __init__(self):
         self.papyros = None
         self.render = None
+        self.svg_stream = None
         self._loading = False
         self._turtle_module = None
 
@@ -33,7 +36,6 @@ class TurtleImportHook:
         self._loading = True
         try:
             from svg_turtle import SvgTurtle
-            from svg_turtle.canvas import Canvas
 
             if self._turtle_module is None:
                 # svg_turtle stubs tkinter as a side effect of import; must precede `import turtle`
@@ -43,7 +45,8 @@ class TurtleImportHook:
             turtle_mod = self._turtle_module
             sys.modules['turtle'] = turtle_mod
 
-            canvas = Canvas(400, 400)
+            canvas = TrackedCanvas(400, 400)
+            self.svg_stream = TurtleSvgStream(canvas)
             screen = SvgTurtle._Screen(canvas)
             screen.cv.config(bg="")
 

--- a/src/backend/workers/python/papyros/turtle_hook.py
+++ b/src/backend/workers/python/papyros/turtle_hook.py
@@ -73,9 +73,10 @@ class TurtleImportHook:
                     return v
                 w = resolve(width)
                 h = resolve(height)
-                canvas.options['width'] = w
-                canvas.options['height'] = h
-                canvas.options['scrollregion'] = (-w // 2, -h // 2, w // 2, h // 2)
+                # Through config() rather than canvas.options directly, so the
+                # TrackedCanvas re-renders everything for the new dimensions.
+                canvas.config(width=w, height=h,
+                              scrollregion=(-w // 2, -h // 2, w // 2, h // 2))
                 screen.canvwidth = w
                 screen.canvheight = h
 

--- a/src/backend/workers/python/papyros/turtle_svg.py
+++ b/src/backend/workers/python/papyros/turtle_svg.py
@@ -1,0 +1,161 @@
+"""Incremental SVG rendering for the svg-turtle canvas.
+
+svg-turtle's ``to_svg()`` rebuilds the entire SVG document from every canvas
+item on every call. Papyros takes a snapshot after every debug frame, which
+makes debugging a turtle program O(frames x items): for the spirograph of
+dodona-edu/papyros#1020 that is ~1130 full re-renders of a 260 KiB document,
+each of which is then base64-encoded and shipped to the main thread.
+
+Here every canvas item is rendered once and its SVG fragment is cached, so a
+snapshot only pays for the items that actually changed. Snapshots are emitted
+as patches that the frontend replays, which keeps the transferred and retained
+bytes linear in the size of the drawing instead of quadratic.
+"""
+
+from svgwrite import Drawing
+from svg_turtle.canvas import Canvas
+
+
+class TrackedCanvas(Canvas):
+    """Canvas that remembers which items changed since the last snapshot."""
+
+    def __init__(self, width=400, height=250):
+        super().__init__(width, height)
+        self._dirty = set()
+        self._cleared = False
+        self._order_changed = True
+        self._frame_changed = True
+
+    def call(self, method_name, *args, **kwargs):
+        item_id = super().call(method_name, *args, **kwargs)
+        self._dirty.add(item_id)
+        self._order_changed = True
+        return item_id
+
+    def coords(self, item, *coords):
+        result = super().coords(item, *coords)
+        if coords:
+            self._dirty.add(item)
+        return result
+
+    def itemconfigure(self, item, **kwargs):
+        super().itemconfigure(item, **kwargs)
+        self._dirty.add(item)
+
+    def delete(self, item):
+        super().delete(item)
+        if item == "all":
+            self._dirty.clear()
+            self._cleared = True
+            self._order_changed = True
+        else:
+            self._dirty.add(item)
+
+    def config(self, **kwargs):
+        super().config(**kwargs)
+        # Width, height and scrollregion feed into the coordinates of every
+        # item, and the background colour into the document itself, so every
+        # cached fragment has to be rendered again.
+        self._frame_changed = True
+        self._order_changed = True
+        self._dirty.update(range(len(self.items)))
+
+    def tag_raise(self, item):
+        super().tag_raise(item)
+        self._order_changed = True
+
+    def take_changes(self):
+        """Return what changed since the previous call and start tracking anew.
+
+        :return: (cleared, dirty item indices, order changed, document changed)
+        """
+        changes = (self._cleared, self._dirty, self._order_changed, self._frame_changed)
+        self._dirty = set()
+        self._cleared = False
+        self._order_changed = False
+        self._frame_changed = False
+        return changes
+
+
+class TurtleSvgStream:
+    """Turns canvas mutations into incremental SVG patches.
+
+    A patch is a JSON-friendly dict holding any of:
+
+    ``clear``         drop all fragments held so far (the canvas was reset)
+    ``open``/``close``  the document surrounding the fragments; sent whenever
+                      the canvas size or background changes, so in practice once
+    ``set``           ``[[item index, svg fragment], ...]`` for changed items
+    ``order``         all item indices in painting order, when that order changed
+
+    Replaying every patch of a run in order and joining the fragments yields
+    exactly the document ``SvgTurtle.to_svg()`` would have returned at that
+    point; ``scripts/bench_turtle.py`` asserts that equivalence.
+    """
+
+    def __init__(self, canvas):
+        self._canvas = canvas
+        self._fragments = {}
+        self._order = None
+        # A throwaway drawing, used only as an element factory: svg-turtle
+        # renders an item by adding it to a Drawing, so we add it to this one
+        # and take the element back out again.
+        self._scratch = Drawing(size=(1, 1))
+        self._scratch_size = len(self._scratch.elements)
+
+    def patch(self):
+        """Return the changes since the previous call, or None when there are none."""
+        cleared, dirty, order_changed, frame_changed = self._canvas.take_changes()
+        patch = {}
+        if cleared:
+            self._fragments.clear()
+            self._order = None
+            patch["clear"] = True
+        if frame_changed:
+            patch["open"], patch["close"] = self._document_frame()
+
+        changed = []
+        for index in sorted(dirty):
+            if index >= len(self._canvas.items):
+                continue  # the item was dropped by a canvas reset
+            fragment = self._render(index)
+            previous = self._fragments.get(index)
+            if fragment == previous:
+                continue
+            self._fragments[index] = fragment
+            if fragment == "" and previous is None:
+                continue  # invisible item the frontend never heard about
+            changed.append([index, fragment])
+        if changed:
+            patch["set"] = changed
+
+        if order_changed:
+            order = self._painting_order()
+            if order != self._order:
+                self._order = order
+                patch["order"] = order
+        return patch or None
+
+    def _render(self, index):
+        """Render one canvas item to an SVG fragment ("" when it is invisible)."""
+        scratch = self._scratch
+        del scratch.elements[self._scratch_size:]
+        self._canvas.add_svg_element(self._canvas.items[index], scratch)
+        if len(scratch.elements) == self._scratch_size:
+            return ""
+        return scratch.elements[-1].tostring()
+
+    def _painting_order(self):
+        items = self._canvas.items
+        # Stable, so this matches svg-turtle sorting the items themselves.
+        return sorted(range(len(items)), key=lambda index: items[index].z_order)
+
+    def _document_frame(self):
+        """The document that wraps the fragments, split around its content."""
+        canvas = self._canvas
+        drawing = Drawing(size=(canvas.winfo_width(), canvas.winfo_height()))
+        bgcolor = canvas.options.get("bg")
+        if bgcolor:
+            drawing.add(drawing.rect(fill=bgcolor, size=("100%", "100%")))
+        head, _, tail = drawing.tostring().rpartition("</svg>")
+        return head, "</svg>" + tail

--- a/src/frontend/components/Output.ts
+++ b/src/frontend/components/Output.ts
@@ -3,6 +3,7 @@ import { css, CSSResult, html, TemplateResult } from "lit";
 import { FriendlyError, OutputEntry, OutputType, OUTPUT_TAB, TURTLE_TAB } from "../state/InputOutput";
 import { PapyrosElement } from "./PapyrosElement";
 import { tabButtonStyles } from "./shared-styles";
+import { TurtlePatch, TurtleSvgBuilder } from "../state/TurtleSvg";
 import "@material/web/icon/icon";
 
 @customElement("p-output")
@@ -88,6 +89,9 @@ export class Output extends PapyrosElement {
         `;
     }
 
+    /** Replays the turtle patches; kept across renders so following a run stays incremental. */
+    private turtleSvg = new TurtleSvgBuilder();
+
     private get maxOutputLength(): number {
         if (this.papyros.debugger.active && this.papyros.debugger.debugOutputs !== undefined) {
             return this.papyros.debugger.debugOutputs;
@@ -143,24 +147,25 @@ export class Output extends PapyrosElement {
     }
 
     get renderedOutputs(): TemplateResult[] {
-        let outputsToRender: OutputEntry[];
         if (this.papyros.io.activeOutputTab === TURTLE_TAB) {
-            // Latest snapshot within this.outputs (which is sliced by the debugger's current
-            // step via maxOutputLength) — so stepping the debugger shows the drawing build up.
-            const lastIdx = this.outputs.findLastIndex((o) => o.type === OutputType.turtle);
-            outputsToRender = lastIdx >= 0 ? [this.outputs[lastIdx]] : [];
-        } else {
-            outputsToRender = this.outputs.filter((o) => o.type !== OutputType.turtle);
+            // Replay every patch within this.outputs (which is sliced by the debugger's
+            // current step via maxOutputLength) — so stepping the debugger shows the
+            // drawing build up.
+            const patches = this.outputs
+                .filter((o) => o.type === OutputType.turtle)
+                .map((o) => o.content as TurtlePatch);
+            const svg = this.turtleSvg.build(patches);
+            return svg === undefined
+                ? []
+                : [html`<img class="turtle" src="data:image/svg+xml,${encodeURIComponent(svg)}"></img>`];
         }
+        const outputsToRender: OutputEntry[] = this.outputs.filter((o) => o.type !== OutputType.turtle);
         return outputsToRender.map((o) => {
             if (o.type === OutputType.stdout) {
                 return html`${o.content}`;
             } else if (o.type === OutputType.img) {
                 const mimeType = o.contentType ?? "image/png";
-                return html`<img src="data:${mimeType},${o.content}"></img>`;
-            } else if (o.type === OutputType.turtle) {
-                const mimeType = o.contentType ?? "image/svg+xml;base64";
-                return html`<img class="turtle" src="data:${mimeType},${o.content}"></img>`;
+                return html`<img src="data:${mimeType},${o.content as string}"></img>`;
             } else if (o.type === OutputType.stderr) {
                 if (typeof o.content === "string") {
                     return html`<span class="error">${o.content}</span>`;

--- a/src/frontend/state/InputOutput.ts
+++ b/src/frontend/state/InputOutput.ts
@@ -5,6 +5,7 @@ import { isValidFileName, parseData } from "../../util/Util";
 import { Papyros } from "./Papyros";
 import { RunState } from "./Runner";
 import { ServiceWorkerInputError } from "./PapyrosErrors";
+import { TurtlePatch } from "./TurtleSvg";
 
 /**
  * Shape of Error objects that are easy to interpret
@@ -45,7 +46,7 @@ export enum OutputType {
 
 export type OutputEntry = {
     type: OutputType;
-    content: string | FriendlyError;
+    content: string | FriendlyError | TurtlePatch;
     contentType?: string;
 };
 
@@ -131,8 +132,7 @@ export class InputOutput extends State {
             }
         });
         BackendManager.subscribe(BackendEventType.Turtle, (e) => {
-            const data = parseData(e.data, e.contentType);
-            this.logTurtle(data, e.contentType);
+            this.logTurtle(parseData(e.data, e.contentType));
         });
         BackendManager.subscribe(BackendEventType.Error, (e) => {
             const data = parseData(e.data, e.contentType);
@@ -179,9 +179,9 @@ export class InputOutput extends State {
         this.output = [...this.output, { type: OutputType.img, content: imageData, contentType }];
     }
 
-    public logTurtle(imageData: string, contentType: string = "image/svg+xml;base64"): void {
+    public logTurtle(patch: TurtlePatch): void {
         const isFirstSnapshot = !this.hasTurtleOutput;
-        this.output = [...this.output, { type: OutputType.turtle, content: imageData, contentType }];
+        this.output = [...this.output, { type: OutputType.turtle, content: patch }];
         this.hasTurtleOutput = true;
         if (isFirstSnapshot && this.activeOutputTab === OUTPUT_TAB && !this.outputTabManuallySet) {
             this.activeOutputTab = TURTLE_TAB;

--- a/src/frontend/state/TurtleSvg.ts
+++ b/src/frontend/state/TurtleSvg.ts
@@ -1,0 +1,92 @@
+/**
+ * The turtle drawing arrives from the worker as incremental patches instead of
+ * a full SVG document per snapshot: the worker renders every canvas item once
+ * and only sends the ones that changed (see papyros/turtle_svg.py). Replaying
+ * the patches of a run reproduces exactly the document svg-turtle would have
+ * produced at that point.
+ *
+ * Debugging streams one snapshot per frame, so this is what keeps a turtle
+ * debug session linear rather than quadratic in the size of the drawing.
+ */
+export interface TurtlePatch {
+    /** Drop everything received so far; the canvas was reset. */
+    clear?: boolean;
+    /** Document around the fragments. Sent when the canvas size or background changes. */
+    open?: string;
+    close?: string;
+    /** Fragments for the canvas items that changed, as [item index, svg]. */
+    set?: [number, string][];
+    /** All item indices in painting order, sent only when that order changed. */
+    order?: number[];
+}
+
+/**
+ * Replays turtle patches into an SVG document.
+ *
+ * Successive builds over a growing list of patches only apply the new ones, so
+ * following a run costs no more than a single replay in total. Handing it a
+ * list that is not an extension of the previous one (scrubbing the debugger
+ * backwards, or a new run) transparently replays from the start.
+ */
+export class TurtleSvgBuilder {
+    private fragments: string[] = [];
+    private order: number[] | undefined = undefined;
+    private open: string = "";
+    private close: string = "";
+    private applied: number = 0;
+    private lastApplied: TurtlePatch | undefined = undefined;
+
+    public build(patches: TurtlePatch[]): string | undefined {
+        if (!this.canExtend(patches)) {
+            this.reset();
+        }
+        for (let i = this.applied; i < patches.length; i++) {
+            this.apply(patches[i]);
+        }
+        this.applied = patches.length;
+        this.lastApplied = patches[patches.length - 1];
+
+        if (!this.open) {
+            return undefined;
+        }
+        const order = this.order ?? this.fragments.map((_, i) => i);
+        return this.open + order.map((i) => this.fragments[i] ?? "").join("") + this.close;
+    }
+
+    private canExtend(patches: TurtlePatch[]): boolean {
+        return this.applied <= patches.length && (this.applied === 0 || patches[this.applied - 1] === this.lastApplied);
+    }
+
+    private reset(): void {
+        this.fragments = [];
+        this.order = undefined;
+        this.open = "";
+        this.close = "";
+        this.applied = 0;
+        this.lastApplied = undefined;
+    }
+
+    private apply(patch: TurtlePatch): void {
+        if (patch.clear) {
+            this.fragments = [];
+            this.order = undefined;
+        }
+        if (patch.open !== undefined) {
+            this.open = patch.open;
+            this.close = patch.close ?? "";
+        }
+        for (const [index, fragment] of patch.set ?? []) {
+            this.fragments[index] = fragment;
+        }
+        if (patch.order !== undefined) {
+            this.order = patch.order;
+        }
+    }
+}
+
+/**
+ * One-shot replay, for callers that do not follow a run incrementally.
+ */
+export function buildTurtleSvg(patches: TurtlePatch[]): string | undefined {
+    return new TurtleSvgBuilder().build(patches);
+}

--- a/test/__tests__/state/Turtle.test.ts
+++ b/test/__tests__/state/Turtle.test.ts
@@ -140,6 +140,27 @@ turtle.done()`;
         expect(turtleSvg(papyros)).toContain("<svg");
     });
 
+    it("re-sends the document when setup() runs mid-debug", async () => {
+        const papyros = new Papyros();
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+        // Frames are snapshotted from the moment turtle is imported, so by the
+        // time setup() runs the 400x400 document has already been streamed and
+        // the resize must invalidate it (and every fragment's coordinates).
+        papyros.runner.code = `import turtle
+t = turtle.Turtle()
+t.forward(50)
+turtle.setup(800, 600)
+t.forward(50)
+turtle.done()`;
+        await papyros.runner.start(RunMode.Debug);
+        await waitForPapyrosReady(papyros);
+        await waitForOutput(papyros);
+        const svg = turtleSvg(papyros);
+        expect(svg).toMatch(/width="800"/);
+        expect(svg).toMatch(/height="600"/);
+    });
+
     it("streams a debug session incrementally instead of a document per frame", async () => {
         const papyros = new Papyros();
         await papyros.launch();

--- a/test/__tests__/state/Turtle.test.ts
+++ b/test/__tests__/state/Turtle.test.ts
@@ -4,7 +4,22 @@ import {ProgrammingLanguage} from "../../../src/ProgrammingLanguage";
 import {RunState} from "../../../src/frontend/state/Runner";
 import {RunMode} from "../../../src/backend/Backend";
 import {OutputType} from "../../../src/frontend/state/InputOutput";
+import {buildTurtleSvg, TurtlePatch} from "../../../src/frontend/state/TurtleSvg";
 import {waitForOutput, waitForPapyrosReady} from "../../helpers";
+
+/**
+ * The drawing is streamed as incremental patches, so the document a user sees
+ * is the replay of every patch produced so far.
+ */
+function turtlePatches(papyros: Papyros): TurtlePatch[] {
+    return papyros.io.output.filter(o => o.type === OutputType.turtle).map(o => o.content as TurtlePatch);
+}
+
+function turtleSvg(papyros: Papyros): string {
+    const svg = buildTurtleSvg(turtlePatches(papyros));
+    expect(svg).toBeDefined();
+    return svg!;
+}
 
 describe("Turtle", () => {
     it("can load turtle and generate an SVG image", async () => {
@@ -21,11 +36,10 @@ turtle.done()`;
         await waitForPapyrosReady(papyros);
         await waitForOutput(papyros);
         expect(papyros.runner.state).toBe(RunState.Ready);
-        const turtleOutputs = papyros.io.output.filter(o => o.type === OutputType.turtle);
-        expect(turtleOutputs.length).toBeGreaterThan(0);
-        expect(turtleOutputs[0].contentType).toBe("image/svg+xml;base64");
-        const decoded = atob(turtleOutputs[0].content as string);
-        expect(decoded).toContain("<svg");
+        expect(turtlePatches(papyros).length).toBeGreaterThan(0);
+        const svg = turtleSvg(papyros);
+        expect(svg).toContain("<svg");
+        expect(svg).toContain("<polyline");
     });
 
     it("emits incremental snapshots on sleep", async () => {
@@ -43,13 +57,16 @@ turtle.done()`;
         await papyros.runner.start();
         await waitForPapyrosReady(papyros);
         await waitForOutput(papyros, 2);
-        const turtleOutputs = papyros.io.output.filter(o => o.type === OutputType.turtle);
-        expect(turtleOutputs.length).toBeGreaterThanOrEqual(2);
-        // Each snapshot should be a valid base64-encoded SVG
-        for (const img of turtleOutputs) {
-            expect(img.contentType).toBe("image/svg+xml;base64");
-            expect(atob(img.content as string)).toContain("<svg");
+        const patches = turtlePatches(papyros);
+        expect(patches.length).toBeGreaterThanOrEqual(2);
+        // Replaying a prefix of the patches yields the drawing at that point, which is
+        // how the debugger shows the drawing build up step by step.
+        for (let i = 1; i <= patches.length; i++) {
+            expect(buildTurtleSvg(patches.slice(0, i))).toContain("<svg");
         }
+        // Only the first patch carries the document itself; the rest are increments.
+        expect(patches[0].open).toBeDefined();
+        expect(patches.slice(1).every(p => p.open === undefined)).toBe(true);
     });
 
     it("honors turtle.setup() canvas dimensions", async () => {
@@ -63,11 +80,9 @@ turtle.done()`;
         await papyros.runner.start();
         await waitForPapyrosReady(papyros);
         await waitForOutput(papyros);
-        const turtleOutputs = papyros.io.output.filter(o => o.type === OutputType.turtle);
-        expect(turtleOutputs.length).toBeGreaterThan(0);
-        const decoded = atob(turtleOutputs[turtleOutputs.length - 1].content as string);
-        expect(decoded).toMatch(/width="800"/);
-        expect(decoded).toMatch(/height="400"/);
+        const svg = turtleSvg(papyros);
+        expect(svg).toMatch(/width="800"/);
+        expect(svg).toMatch(/height="400"/);
     });
 
     it("treats fractional setup() values as fractions of a 1000px reference", async () => {
@@ -83,11 +98,9 @@ turtle.done()`;
         await papyros.runner.start();
         await waitForPapyrosReady(papyros);
         await waitForOutput(papyros);
-        const turtleOutputs = papyros.io.output.filter(o => o.type === OutputType.turtle);
-        expect(turtleOutputs.length).toBeGreaterThan(0);
-        const decoded = atob(turtleOutputs[turtleOutputs.length - 1].content as string);
-        expect(decoded).toMatch(/width="500"/);
-        expect(decoded).toMatch(/height="250"/);
+        const svg = turtleSvg(papyros);
+        expect(svg).toMatch(/width="500"/);
+        expect(svg).toMatch(/height="250"/);
     });
 
     it("honors Screen().setup() and recenters the origin", async () => {
@@ -106,12 +119,10 @@ turtle.done()`;
         await papyros.runner.start();
         await waitForPapyrosReady(papyros);
         await waitForOutput(papyros);
-        const turtleOutputs = papyros.io.output.filter(o => o.type === OutputType.turtle);
-        expect(turtleOutputs.length).toBeGreaterThan(0);
-        const decoded = atob(turtleOutputs[turtleOutputs.length - 1].content as string);
-        expect(decoded).toMatch(/width="1000"/);
-        expect(decoded).toMatch(/height="1000"/);
-        expect(decoded).toContain("500.5,500.5");
+        const svg = turtleSvg(papyros);
+        expect(svg).toMatch(/width="1000"/);
+        expect(svg).toMatch(/height="1000"/);
+        expect(svg).toContain("500.5,500.5");
     });
 
     it("emits turtle image in debug mode", async () => {
@@ -125,9 +136,40 @@ turtle.done()`;
         await papyros.runner.start(RunMode.Debug);
         await waitForPapyrosReady(papyros);
         await waitForOutput(papyros);
-        const turtleOutputs = papyros.io.output.filter(o => o.type === OutputType.turtle);
-        expect(turtleOutputs.length).toBeGreaterThan(0);
-        expect(turtleOutputs[0].contentType).toBe("image/svg+xml;base64");
-        expect(atob(turtleOutputs[0].content as string)).toContain("<svg");
+        expect(turtlePatches(papyros).length).toBeGreaterThan(0);
+        expect(turtleSvg(papyros)).toContain("<svg");
+    });
+
+    it("streams a debug session incrementally instead of a document per frame", async () => {
+        const papyros = new Papyros();
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+        // Enough drawing that re-sending the whole document per frame would show up:
+        // this used to cost one full SVG (plus base64) for every debug frame.
+        // The pen is lifted between strokes so each one is its own canvas item;
+        // a single continuous stroke is one item that grows every frame and is
+        // re-sent in full, which caps the saving at ~5-7x instead of ~80x.
+        papyros.runner.code = `import turtle
+t = turtle.Turtle()
+for i in range(40):
+    t.penup()
+    t.goto(-100 + i * 5, -50)
+    t.pendown()
+    t.forward(60)
+turtle.done()`;
+        await papyros.runner.start(RunMode.Debug);
+        await waitForPapyrosReady(papyros);
+        await waitForOutput(papyros);
+
+        const patches = turtlePatches(papyros);
+        const svg = turtleSvg(papyros);
+        expect(patches.length).toBeGreaterThan(10);
+        expect(svg.length).toBeGreaterThan(1000);
+
+        // Regression guard for dodona-edu/papyros#1020: the bytes crossing the worker
+        // boundary must stay proportional to the drawing, not to frames x drawing.
+        const streamed = patches.reduce((total, p) => total + JSON.stringify(p).length, 0);
+        expect(streamed).toBeLessThan(svg.length * 4);
+        expect(streamed).toBeLessThan((patches.length * svg.length) / 4);
     });
 });


### PR DESCRIPTION
This pull request makes turtle debugging stream the drawing as incremental SVG patches instead of re-rendering and re-sending the full document after every debug frame.

Papyros snapshots the turtle drawing after every debug frame. Until now each snapshot re-rendered the entire SVG document and base64-encoded it, making a debug session O(frames x drawing size): for the spirograph of #1020 that is ~1120 full renders of a 257 KiB document, 21 s of pure snapshotting (native CPython, several times more in Pyodide) and 44 MiB shipped to and retained on the main thread.

Now the worker renders each canvas item once, caches its fragment, and emits only what changed as a JSON patch (`papyros/turtle_svg.py`); the frontend replays the patches (`frontend/state/TurtleSvg.ts`). Replaying every patch of a run reproduces svg-turtle's document byte for byte, which `scripts/bench_turtle.py` asserts. On the #1020 spirograph: 185x less snapshot time (21.2 s to 0.11 s) and 83x fewer bytes streamed (44.4 MiB to 0.5 MiB).

Known limit: one long continuous stroke is a single canvas item that grows point by point and is re-sent in full each frame, capping the saving at roughly 5-7x for such drawings. A string-splice delta could fix this but was judged not worth the complexity.

**Manual testing instructions**
- Debug the spirograph program from #1020: generation should take seconds instead of minutes, and stepping through frames should show the drawing build up correctly
- Run a turtle program normally (not debugging) and check the drawing still renders in the Turtle tab
- Run `python3 scripts/bench_turtle.py` after `yarn setup` to reproduce the numbers and the byte-identical replay assertion

**Checklist**
- Tests: existing turtle suite adapted to the patch format, plus a new regression test asserting the streamed bytes stay proportional to the drawing rather than frames x drawing
- Docs: n/a
- Announcement: n/a
- AI: Claude Code implemented the change and benchmarks, human reviewed

Closes #1020