### PR TITLE
Fix debugger UX issues: icons, text selection and input mode toggle

### DIFF
--- a/src/frontend/components/Input.ts
+++ b/src/frontend/components/Input.ts
@@ -23,6 +23,17 @@ export class Input extends PapyrosElement {
 
             md-outlined-segmented-button-set {
                 margin-top: 0.5rem;
+                --md-outlined-segmented-button-selected-container-color: var(--md-sys-color-primary-container);
+                --md-outlined-segmented-button-selected-label-text-color: var(--md-sys-color-on-primary-container);
+                --md-outlined-segmented-button-selected-hover-label-text-color: var(
+                    --md-sys-color-on-primary-container
+                );
+                --md-outlined-segmented-button-selected-focus-label-text-color: var(
+                    --md-sys-color-on-primary-container
+                );
+                --md-outlined-segmented-button-selected-pressed-label-text-color: var(
+                    --md-sys-color-on-primary-container
+                );
             }
         `;
     }
@@ -45,10 +56,12 @@ export class Input extends PapyrosElement {
             }
             <md-outlined-segmented-button-set @segmented-button-set-selection=${this.selectMode}>
                 <md-outlined-segmented-button
+                    no-checkmark
                     label=${this.t("Papyros.input_modes.interactive")}
                     ?selected=${this.mode === InputMode.interactive}
                 ></md-outlined-segmented-button>
                 <md-outlined-segmented-button
+                    no-checkmark
                     label=${this.t("Papyros.input_modes.batch")}
                     ?selected=${this.mode === InputMode.batch}
                 ></md-outlined-segmented-button>

--- a/src/frontend/components/Input.ts
+++ b/src/frontend/components/Input.ts
@@ -3,20 +3,14 @@ import { css, CSSResult, html, TemplateResult } from "lit";
 import "./input/BatchInput";
 import "./input/InteractiveInput";
 import { PapyrosElement } from "./PapyrosElement";
-import "@material/web/switch/switch";
+import "@material/web/labs/segmentedbuttonset/outlined-segmented-button-set";
+import "@material/web/labs/segmentedbutton/outlined-segmented-button";
 import { InputMode } from "../state/InputOutput";
 
 @customElement("p-input")
 export class Input extends PapyrosElement {
     static get styles(): CSSResult {
         return css`
-            label {
-                display: flex;
-                align-items: center;
-                gap: 0.5rem;
-                margin-top: 0.5rem;
-            }
-
             :host {
                 width: 100%;
                 height: fit-content;
@@ -26,6 +20,10 @@ export class Input extends PapyrosElement {
             p-batch-input {
                 height: 200px;
             }
+
+            md-outlined-segmented-button-set {
+                margin-top: 0.5rem;
+            }
         `;
     }
 
@@ -33,12 +31,9 @@ export class Input extends PapyrosElement {
         return this.papyros.io.inputMode;
     }
 
-    get otherMode(): InputMode {
-        return this.mode === InputMode.batch ? InputMode.interactive : InputMode.batch;
-    }
-
-    toggleMode(): void {
-        this.papyros.io.inputMode = this.otherMode;
+    private selectMode(e: CustomEvent<{ index: number; selected: boolean }>): void {
+        if (!e.detail.selected) return;
+        this.papyros.io.inputMode = e.detail.index === 0 ? InputMode.interactive : InputMode.batch;
     }
 
     protected override render(): TemplateResult {
@@ -48,10 +43,16 @@ export class Input extends PapyrosElement {
                     ? html`<p-batch-input .papyros=${this.papyros}></p-batch-input>`
                     : html`<p-interactive-input .papyros=${this.papyros}></p-interactive-input>`
             }
-            <label>
-                <md-switch .selected=${this.mode === InputMode.batch} @change=${() => this.toggleMode()}></md-switch>
-                ${this.t(`Papyros.switch_input_mode_to.${this.otherMode}`)}
-            </label>
+            <md-outlined-segmented-button-set @segmented-button-set-selection=${this.selectMode}>
+                <md-outlined-segmented-button
+                    label=${this.t("Papyros.input_modes.interactive")}
+                    ?selected=${this.mode === InputMode.interactive}
+                ></md-outlined-segmented-button>
+                <md-outlined-segmented-button
+                    label=${this.t("Papyros.input_modes.batch")}
+                    ?selected=${this.mode === InputMode.batch}
+                ></md-outlined-segmented-button>
+            </md-outlined-segmented-button-set>
         `;
     }
 }

--- a/src/frontend/components/code_mirror/BatchInputEditor.ts
+++ b/src/frontend/components/code_mirror/BatchInputEditor.ts
@@ -1,6 +1,7 @@
 import { customElement, property } from "lit/decorators.js";
 import { CodeMirrorEditor } from "./CodeMirrorEditor";
-import { EditorView, keymap } from "@codemirror/view";
+import { keymap } from "@codemirror/view";
+import { EditorState } from "@codemirror/state";
 import { css, CSSResult } from "lit";
 import { defaultKeymap } from "@codemirror/commands";
 import { setUsedLines, usedLineExtension } from "./Extensions";
@@ -27,7 +28,7 @@ export class BatchInputEditor extends CodeMirrorEditor {
     @property({ type: Boolean })
     set readOnly(value: boolean) {
         this.configure({
-            debugging: value ? EditorView.editable.of(false) : [],
+            debugging: value ? EditorState.readOnly.of(true) : [],
         });
     }
 

--- a/src/frontend/components/code_mirror/CodeEditor.ts
+++ b/src/frontend/components/code_mirror/CodeEditor.ts
@@ -81,6 +81,9 @@ export class CodeEditor extends CodeMirrorEditor {
                 vertical-align: middle;
                 padding: 0 4px;
                 cursor: pointer;
+                border: none;
+                background: none;
+                color: inherit;
             }
 
             .papyros-icon-link:hover {

--- a/src/frontend/components/code_mirror/CodeEditor.ts
+++ b/src/frontend/components/code_mirror/CodeEditor.ts
@@ -77,7 +77,8 @@ export class CodeEditor extends CodeMirrorEditor {
             }
 
             .papyros-icon-link {
-                font-size: 16px;
+                display: inline-flex;
+                vertical-align: middle;
                 padding: 0 4px;
                 cursor: pointer;
             }

--- a/src/frontend/components/code_mirror/CodeMirrorEditor.ts
+++ b/src/frontend/components/code_mirror/CodeMirrorEditor.ts
@@ -3,6 +3,16 @@ import { customElement } from "lit/decorators.js";
 import { EditorView, ViewUpdate, placeholder } from "@codemirror/view";
 import { Compartment, EditorState, Extension, StateEffect } from "@codemirror/state";
 
+// Keep gutters out of native text selection: with drawSelection() active the
+// browser's own selection is invisible over the code, so a page-wide select-all
+// would highlight (and copy) only the line numbers.
+const gutterSelectionTheme = EditorView.theme({
+    ".cm-gutters": {
+        userSelect: "none",
+        "-webkit-user-select": "none",
+    },
+});
+
 @customElement("p-code-mirror-editor")
 export class CodeMirrorEditor extends LitElement {
     private __value: string = "";
@@ -20,15 +30,17 @@ export class CodeMirrorEditor extends LitElement {
     }
 
     public set readonly(readonly: boolean) {
+        // EditorState.readOnly instead of EditorView.editable: the view stays
+        // focusable, so keyboard selection (e.g. cmd+a) keeps working.
         this.configure({
-            editable: EditorView.editable.of(!readonly),
+            readonly: EditorState.readOnly.of(readonly),
         });
         this.__readonly = readonly;
     }
 
     protected dispatchChange(): void {
         if (!this.view) return;
-        this.configure({ editable: EditorView.editable.of(false) });
+        this.configure({ readonly: EditorState.readOnly.of(true) });
         this.view.dispatch({
             changes: {
                 from: 0,
@@ -36,7 +48,7 @@ export class CodeMirrorEditor extends LitElement {
                 insert: this.__value,
             },
         });
-        this.configure({ editable: EditorView.editable.of(!this.__readonly) });
+        this.configure({ readonly: EditorState.readOnly.of(this.__readonly) });
     }
 
     public get value(): string {
@@ -64,6 +76,7 @@ export class CodeMirrorEditor extends LitElement {
                 doc: this.__value,
                 extensions: [
                     EditorView.updateListener.of(this.onViewUpdate.bind(this)),
+                    gutterSelectionTheme,
                     [...this.compartments.keys().map((k) => this.compartments.get(k)!.of([]))],
                 ],
             }),

--- a/src/frontend/components/code_mirror/Extensions.ts
+++ b/src/frontend/components/code_mirror/Extensions.ts
@@ -163,18 +163,22 @@ export function testCodeWidgetExtension(
             const buttons = document.createElement("div");
             buttons.classList.add("papyros-test-code-buttons");
 
-            const editButton = document.createElement("a");
+            const editButton = document.createElement("button");
+            editButton.type = "button";
             editButton.classList.add("papyros-icon-link");
             editButton.innerHTML = EDIT_ICON_SVG;
             editButton.addEventListener("click", handleEdit);
             editButton.title = translations.edit;
+            editButton.setAttribute("aria-label", translations.edit);
             buttons.appendChild(editButton);
 
-            const deleteButton = document.createElement("a");
+            const deleteButton = document.createElement("button");
+            deleteButton.type = "button";
             deleteButton.classList.add("papyros-icon-link");
             deleteButton.innerHTML = REMOVE_ICON_SVG;
             deleteButton.addEventListener("click", handleRemove);
             deleteButton.title = translations.remove;
+            deleteButton.setAttribute("aria-label", translations.remove);
             buttons.appendChild(deleteButton);
 
             element.appendChild(buttons);

--- a/src/frontend/components/code_mirror/Extensions.ts
+++ b/src/frontend/components/code_mirror/Extensions.ts
@@ -138,6 +138,14 @@ export const [testLineExtension, setTestLines, testLineState] = lineEffectExtens
     gutterClass: "",
 });
 
+// Inline SVGs instead of unicode glyphs (🖉, ⨯), which many system fonts lack.
+const EDIT_ICON_SVG =
+    '<svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true">' +
+    '<path d="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"/></svg>';
+const REMOVE_ICON_SVG =
+    '<svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true">' +
+    '<path d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"/></svg>';
+
 export function testCodeWidgetExtension(
     translations: { description: string; edit: string; remove: string },
     handleEdit: () => void,
@@ -157,14 +165,14 @@ export function testCodeWidgetExtension(
 
             const editButton = document.createElement("a");
             editButton.classList.add("papyros-icon-link");
-            editButton.innerHTML = "🖉";
+            editButton.innerHTML = EDIT_ICON_SVG;
             editButton.addEventListener("click", handleEdit);
             editButton.title = translations.edit;
             buttons.appendChild(editButton);
 
             const deleteButton = document.createElement("a");
             deleteButton.classList.add("papyros-icon-link");
-            deleteButton.innerHTML = "⨯";
+            deleteButton.innerHTML = REMOVE_ICON_SVG;
             deleteButton.addEventListener("click", handleRemove);
             deleteButton.title = translations.remove;
             buttons.appendChild(deleteButton);

--- a/src/frontend/state/Translations.ts
+++ b/src/frontend/state/Translations.ts
@@ -29,9 +29,9 @@ export const ENGLISH_TRANSLATION = {
             en: "English",
             nl: "Nederlands",
         },
-        switch_input_mode_to: {
-            interactive: "Switch to interactive mode",
-            batch: "Switch to batch input",
+        input_modes: {
+            interactive: "Interactive input",
+            batch: "Input in advance",
         },
         enter: "Enter",
         examples: "Examples",
@@ -115,9 +115,9 @@ export const DUTCH_TRANSLATION = {
             en: "English",
             nl: "Nederlands",
         },
-        switch_input_mode_to: {
-            interactive: "Wisselen naar interactieve invoer",
-            batch: "Geef invoer vooraf in",
+        input_modes: {
+            interactive: "Interactieve invoer",
+            batch: "Invoer vooraf ingeven",
         },
         enter: "Enter",
         examples: "Voorbeelden",


### PR DESCRIPTION
This pull request fixes three UX issues noticed while debugging on Dodona:

- The edit button of the test-code widget rendered as a tofu rectangle because it used the unicode glyph 🖉 (U+1F589), which most system fonts lack. Both gutter buttons now use inline SVG icons.
- Pressing cmd+a selected the line numbers instead of the code. Two causes: gutters were part of the native text selection (which drawSelection() paints invisibly over the code, so only the numbers appeared selected), and debug mode used EditorView.editable(false), which makes the editor unfocusable so CodeMirror's own select-all never ran. Gutters now have user-select: none and read-only mode uses EditorState.readOnly, keeping the editor focusable and selectable. The batch input editor in debug mode got the same treatment.
- The input mode switch labeled the action ("Switch to interactive input") while its position showed the state, and the label changed on every toggle. It is replaced by a segmented button showing both modes ("Interactive input" / "Input in advance") with the active one highlighted. The translation key was renamed from switch_input_mode_to to input_modes.

**Manual testing instructions**
- Debug code with appended test code: the widget above the test lines should show a pencil and a cross icon in the gutter
- While debugging, click in the (read-only) editor and press cmd+a / ctrl+a: the code should be selected, without line numbers, and copy should yield only the code
- Below the input pane, switch between "Interactive input" and "Input in advance": both options stay visible and the active one is highlighted

**Checklist**
- Tests: n/a (verified by driving the app in headless Chromium; existing translations test covers the renamed key)
- Docs: n/a
- Announcement: 🐛 Fixed several debugger UX issues: missing icons, select-all behavior and a clearer input mode toggle
- AI: Claude Code implemented the fixes and verified them in the running app
