### PR TITLE
Surface backend launch failures instead of hanging forever

### DIFF
--- a/src/frontend/components/code_runner/RunState.ts
+++ b/src/frontend/components/code_runner/RunState.ts
@@ -25,7 +25,7 @@ export class RunStateEl extends PapyrosElement {
 
         return html`
             ${
-                this.papyros.runner.state === RunState.Ready
+                [RunState.Ready, RunState.Error].includes(this.papyros.runner.state)
                     ? ""
                     : html` <md-circular-progress indeterminate></md-circular-progress> `
             }

--- a/src/frontend/state/Runner.ts
+++ b/src/frontend/state/Runner.ts
@@ -17,6 +17,7 @@ export enum RunState {
     AwaitingInput = "awaiting_input",
     Stopping = "stopping",
     Ready = "ready",
+    Error = "error",
 }
 
 /**
@@ -194,22 +195,31 @@ export class Runner extends State {
         this.backendReady = false;
         const launchId = ++this.launchId;
         const backend = BackendManager.getBackend(this.programmingLanguage);
-        // Use a Promise to immediately enable running while downloading
-        // eslint-disable-next-line no-async-promise-executor
-        this.backend = new Promise(async (resolve) => {
-            const workerProxy = backend.workerProxy;
-            // Allow passing messages between worker and main thread
-            await workerProxy.launch(
-                proxy((e: BackendEvent) => BackendManager.publish(e)),
-                this.pyodideAssetURL,
-            );
-            if (launchId === this.launchId) {
-                this.updateRunModes();
-                this.backendReady = true;
-            }
-            return resolve(backend);
-        });
+        // Expose the promise before it settles so runs can already be queued while downloading
+        const backendLaunched = this.launchBackend(backend, launchId);
+        this.backend = backendLaunched;
         this.setState(RunState.Ready);
+        try {
+            await backendLaunched;
+        } catch (error) {
+            if (launchId === this.launchId) {
+                this.setState(RunState.Error);
+            }
+            throw error;
+        }
+    }
+
+    private async launchBackend(backend: SyncClient<Backend>, launchId: number): Promise<SyncClient<Backend>> {
+        // Allow passing messages between worker and main thread
+        await backend.workerProxy.launch(
+            proxy((e: BackendEvent) => BackendManager.publish(e)),
+            this.pyodideAssetURL,
+        );
+        if (launchId === this.launchId) {
+            this.updateRunModes();
+            this.backendReady = true;
+        }
+        return backend;
     }
 
     /**
@@ -446,12 +456,16 @@ export class Runner extends State {
         );
     }
     private updateRunModes(): void {
-        this.backend.then(async (backend) => {
-            const proxy = backend.workerProxy;
+        this.backend
+            .then(async (backend) => {
+                const proxy = backend.workerProxy;
 
-            if (proxy) {
-                this.runModes = await proxy.runModes(this.effectiveCode);
-            }
-        });
+                if (proxy) {
+                    this.runModes = await proxy.runModes(this.effectiveCode);
+                }
+            })
+            .catch(() => {
+                // Launch failures surface through launch()
+            });
     }
 }

--- a/src/frontend/state/Runner.ts
+++ b/src/frontend/state/Runner.ts
@@ -456,16 +456,15 @@ export class Runner extends State {
         );
     }
     private updateRunModes(): void {
+        // Launch failures surface through launch(), so only they are swallowed here
         this.backend
+            .catch(() => undefined)
             .then(async (backend) => {
-                const proxy = backend.workerProxy;
+                const proxy = backend?.workerProxy;
 
                 if (proxy) {
                     this.runModes = await proxy.runModes(this.effectiveCode);
                 }
-            })
-            .catch(() => {
-                // Launch failures surface through launch()
             });
     }
 }

--- a/src/frontend/state/Translations.ts
+++ b/src/frontend/state/Translations.ts
@@ -23,6 +23,7 @@ export const ENGLISH_TRANSLATION = {
             loading: "Loading",
             awaiting_input: "Awaiting input",
             ready: "",
+            error: "Failed to load",
         },
         programming_language: "Programming language",
         locales: {
@@ -107,6 +108,7 @@ export const DUTCH_TRANSLATION = {
             loading: "Aan het laden",
             awaiting_input: "Aan het wachten op invoer",
             ready: "",
+            error: "Laden mislukt",
         },
         finished: "Code uitgevoerd in %{time} s",
         interrupted: "Code onderbroken na %{time} s",

--- a/test/__tests__/state/LaunchFailure.test.ts
+++ b/test/__tests__/state/LaunchFailure.test.ts
@@ -7,19 +7,24 @@ import { PapyrosLaunchError } from "../../../src/frontend/state/PapyrosErrors";
 
 // Fails fast instead of letting a regression hit the suite timeout
 function withTimeout<T>(promise: Promise<T>, ms: number, what: string): Promise<T> {
-    return Promise.race([
-        promise,
-        new Promise<T>((_, reject) => setTimeout(() => reject(new Error(`${what} did not settle within ${ms} ms`)), ms)),
-    ]);
+    let timer: ReturnType<typeof setTimeout>;
+    const timeout = new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${what} did not settle within ${ms} ms`)), ms);
+    });
+    return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }
 
 describe("Papyros launch failure", () => {
     it("surfaces a failed backend launch instead of hanging", async () => {
-        BackendManager.registerBackend(ProgrammingLanguage.Python, () => ({
-            workerProxy: {
-                launch: () => Promise.reject(new Error("worker failed to start")),
-            },
-        }) as any);
+        BackendManager.registerBackend(
+            ProgrammingLanguage.Python,
+            () =>
+                ({
+                    workerProxy: {
+                        launch: () => Promise.reject(new Error("worker failed to start")),
+                    },
+                }) as any,
+        );
         vi.spyOn(window, "confirm").mockReturnValue(false);
 
         const papyros = new Papyros();
@@ -36,7 +41,8 @@ describe("Papyros launch failure", () => {
         expect(papyros.runner.backendReady).toBe(false);
 
         // Callers awaiting the backend must reject instead of waiting forever
-        await expect(withTimeout(papyros.runner.backend, 2000, "runner.backend"))
-            .rejects.toThrow("worker failed to start");
+        await expect(withTimeout(papyros.runner.backend, 2000, "runner.backend")).rejects.toThrow(
+            "worker failed to start",
+        );
     });
 });

--- a/test/__tests__/state/LaunchFailure.test.ts
+++ b/test/__tests__/state/LaunchFailure.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { Papyros } from "../../../src/frontend/state/Papyros";
+import { ProgrammingLanguage } from "../../../src/ProgrammingLanguage";
+import { BackendManager } from "../../../src/communication/BackendManager";
+import { RunState } from "../../../src/frontend/state/Runner";
+import { PapyrosLaunchError } from "../../../src/frontend/state/PapyrosErrors";
+
+// Fails fast instead of letting a regression hit the suite timeout
+function withTimeout<T>(promise: Promise<T>, ms: number, what: string): Promise<T> {
+    return Promise.race([
+        promise,
+        new Promise<T>((_, reject) => setTimeout(() => reject(new Error(`${what} did not settle within ${ms} ms`)), ms)),
+    ]);
+}
+
+describe("Papyros launch failure", () => {
+    it("surfaces a failed backend launch instead of hanging", async () => {
+        BackendManager.registerBackend(ProgrammingLanguage.Python, () => ({
+            workerProxy: {
+                launch: () => Promise.reject(new Error("worker failed to start")),
+            },
+        }) as any);
+        vi.spyOn(window, "confirm").mockReturnValue(false);
+
+        const papyros = new Papyros();
+        const errorHandler = vi.fn();
+        papyros.setErrorHandler(errorHandler);
+
+        await withTimeout(papyros.launch(), 2000, "Papyros.launch()");
+
+        expect(errorHandler).toHaveBeenCalledOnce();
+        const error = errorHandler.mock.calls[0][0];
+        expect(error).toBeInstanceOf(PapyrosLaunchError);
+        expect((error.cause as Error).message).toBe("worker failed to start");
+        expect(papyros.runner.state).toBe(RunState.Error);
+        expect(papyros.runner.backendReady).toBe(false);
+
+        // Callers awaiting the backend must reject instead of waiting forever
+        await expect(withTimeout(papyros.runner.backend, 2000, "runner.backend"))
+            .rejects.toThrow("worker failed to start");
+    });
+});


### PR DESCRIPTION
This pull request makes a failed backend launch fail loudly instead of silently hanging the whole app.

`Runner.launch()` built the backend promise with an async executor. When `workerProxy.launch` rejected (Pyodide CDN unreachable, python package tarball 404, worker construction failure), that promise never settled: every later `await this.backend` (start, stop, lint, file operations) hung forever, and `Papyros.launch()`'s catch block never fired because it resolved as soon as the promise was assigned. So the `PapyrosLaunchError` path, the reload prompt, and the Sentry error handler were all dead for the most common launch failure.

Changes:
- The backend promise is now a plain async method call, so a launch failure rejects it and every pending or future `await` on it fails instead of waiting forever.
- `Runner.launch()` still flips the run state to Ready immediately (runs can queue while the backend downloads), but only resolves once the backend is actually up, and rethrows on failure so `Papyros.launch()` reports it through `PapyrosLaunchError`, the error handler, and the reload prompt.
- New `RunState.Error` state (with en/nl translations) so the status line shows "Failed to load" instead of a spinner that never stops; a superseded launch cannot set it.
- `updateRunModes` ignores a rejected backend promise, since the failure is already reported by `launch()`.

**Manual testing instructions**
- Block access to the Pyodide CDN (or make `python_package.tar.gz.load_by_url` 404) and load Papyros: the error handler fires, the reload prompt appears, and the status line shows "Failed to load" instead of loading forever.
- Normal launch: run, interrupt, and debug code as usual; switching programming language still works.

**Checklist**
- Tests: regression test with a backend whose launch rejects, asserting the error handler receives a `PapyrosLaunchError`, the run state becomes Error, and the backend promise rejects (guarded by `Promise.race` timeouts so a regression fails fast). Verified it fails on `main`. Full suite green: 89 tests in 10 files.
- Docs: n/a
- Announcement: n/a (error handling fix in embedded component)
- AI: Claude Code implemented the fix and test