### PR TITLE
Fail the build loudly instead of silently shipping a broken package

### DIFF
--- a/scripts/build_library.sh
+++ b/scripts/build_library.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # clean directory
 rm -rf dist

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+set -euo pipefail
 cd src/backend/workers/python
 python3 build_package.py

--- a/src/backend/workers/python/build_package.py
+++ b/src/backend/workers/python/build_package.py
@@ -18,6 +18,17 @@ def tarfile_filter(tar_info):
         return None
     return tar_info
 
+def relative_files(root):
+    """Paths of every file under root, relative to it, ignoring what the tarball filter drops."""
+    found = set()
+    for dir_path, dir_names, file_names in os.walk(root):
+        dir_names[:] = [d for d in dir_names if d != "__pycache__"]
+        for file_name in file_names:
+            if file_name.endswith(".pyc"):
+                continue
+            found.add(os.path.relpath(os.path.join(dir_path, file_name), root))
+    return found
+
 def create_package(package_name, dependencies, extra_deps):
     shutil.rmtree(package_name, ignore_errors=True)
     install_dependencies(dependencies.split(" "), package_name)
@@ -30,8 +41,9 @@ def create_package(package_name, dependencies, extra_deps):
         # on any entry, even when every file's contents copied fine; the
         # check below is what actually decides if the copy succeeded
         pass
-    if not os.path.isdir(dest_dir) or not os.listdir(dest_dir):
-        raise RuntimeError(f"failed to copy {extra_deps!r} into {dest_dir!r}")
+    missing = sorted(relative_files(extra_deps) - relative_files(dest_dir))
+    if missing:
+        raise RuntimeError(f"failed to copy {len(missing)} file(s) from {extra_deps!r} into {dest_dir!r}: {missing}")
     # Bundle CPython's turtle.py (removed from Pyodide's stdlib, required by svg-turtle).
     # Locate via sysconfig rather than `import turtle`, which would pull in tkinter.
     turtle_src = os.path.join(sysconfig.get_path("stdlib"), "turtle.py")

--- a/src/backend/workers/python/build_package.py
+++ b/src/backend/workers/python/build_package.py
@@ -21,13 +21,17 @@ def tarfile_filter(tar_info):
 def create_package(package_name, dependencies, extra_deps):
     shutil.rmtree(package_name, ignore_errors=True)
     install_dependencies(dependencies.split(" "), package_name)
+    dest_dir = os.path.join(package_name, extra_deps)
+    shutil.rmtree(dest_dir, ignore_errors=True)
     try:
-        dest_dir = os.path.join(package_name, extra_deps)
-        shutil.rmtree(dest_dir, ignore_errors=True)
         shutil.copytree(extra_deps, dest_dir)
-    except Exception as e:
-        # Always seems to result in a harmless permission denied error
+    except shutil.Error:
+        # copytree raises if copying file metadata (e.g. macOS xattrs) fails
+        # on any entry, even when every file's contents copied fine; the
+        # check below is what actually decides if the copy succeeded
         pass
+    if not os.path.isdir(dest_dir) or not os.listdir(dest_dir):
+        raise RuntimeError(f"failed to copy {extra_deps!r} into {dest_dir!r}")
     # Bundle CPython's turtle.py (removed from Pyodide's stdlib, required by svg-turtle).
     # Locate via sysconfig rather than `import turtle`, which would pull in tkinter.
     turtle_src = os.path.join(sysconfig.get_path("stdlib"), "turtle.py")
@@ -43,11 +47,6 @@ def install_dependencies(packages, out_dir):
     if not isinstance(packages, list):
         packages = [packages]
     subprocess.check_call([sys.executable, "-m", "pip", "install", "-t", out_dir, *packages])
-
-def check_tar(tarname, out_dir="."):
-    with open(tarname, "rb") as t:
-        shutil.unpack_archive(tarname, out_dir, 'gztar')
-
 
 if __name__ == "__main__":
     create_package("python_package", "python-runner friendly_traceback pylint>=4,<5 tomli typing-extensions dodona-json-tracer>=1.0.0 svg-turtle", extra_deps="papyros")


### PR DESCRIPTION
This pull request makes the build pipeline fail loudly instead of shipping a broken package. `build_library.sh` and `setup.sh` ran without `set -e`, so a failing `python3 build_package.py` or `tsc` still exited 0. Since `prepack` runs `build_library.sh` right before `npm publish --provenance` in the publish workflow, a failed Python bundle could have been published as a release.

Changes:
- `set -euo pipefail` in `scripts/build_library.sh` and `scripts/setup.sh`.
- `build_package.py` no longer swallows every exception around copying the local `papyros/` sources into the tarball. The "harmless permission denied error" the old comment mentioned turned out to be `shutil.Error`: `copytree` can raise it purely from a metadata-copy failure (macOS xattrs) even when every file's contents copied fine. The except is narrowed to exactly that, and afterwards the destination must exist and be non-empty or the build hard-fails.
- Removed `check_tar`, dead code with an unused file handle.

**Manual testing instructions**
- `bash scripts/build_library.sh` completes and the tarball contains all `papyros/` modules (verified: 9 files + dir).
- Make `build_package.py` exit non-zero, run the script again: it now stops with a non-zero exit and no `dist` (verified during development, change reverted).

**Checklist**
- Tests: n/a (build tooling; verified manually as above)
- Docs: n/a
- Announcement: n/a
- AI: Claude Code implemented and verified the change