### PR TITLE
Translate the debugger's accessible names and upgrade the trace component

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@codemirror/state": "^6.3.2",
     "@codemirror/view": "^6.28.0",
     "@dodona/lit-state": "^1.1.1",
-    "@dodona/trace-component": "1.5.0",
+    "@dodona/trace-component": "1.6.0",
     "@material/web": "^2.4.0",
     "codemirror-readonly-ranges": "^0.1.0-alpha.2",
     "comlink": "^4.4.1",

--- a/src/frontend/state/Translations.ts
+++ b/src/frontend/state/Translations.ts
@@ -50,6 +50,7 @@ export const ENGLISH_TRANSLATION = {
             title: "Drag the slider to walk through your code.",
             text_1: "This window shows how your program works step by step. Explore to see how your program builds and stores information.",
             text_2: "You can also use the %{previous} and %{next} buttons to go to the previous or next step. The %{first} and %{last} buttons can be used to directly jump to the first or last step respectively.",
+            exception_title: "The debugger crashed",
             // Accessible names: announced by screen readers, never shown on screen.
             picker_label: "Execution steps",
             slider_label: "Execution step",
@@ -147,6 +148,7 @@ export const DUTCH_TRANSLATION = {
             title: "Verken je code stap voor stap",
             text_1: "Dit venster toont de werking van je programma in detail. Ontdek hoe je programma informatie opbouwt en bewaart.",
             text_2: "Gebruik de schuifbalk om door je code te wandelen. Je kan ook de %{previous} en %{next} knoppen gebruiken om naar de vorige of volgende stap te gaan. De %{first} en %{last} knoppen kunnen gebruikt worden om direct naar de eerste of laatste stap te gaan.",
+            exception_title: "De debugger is vastgelopen",
             // Toegankelijkheidslabels: worden voorgelezen door schermlezers, nooit getoond.
             picker_label: "Uitvoeringsstappen",
             slider_label: "Uitvoeringsstap",

--- a/src/frontend/state/Translations.ts
+++ b/src/frontend/state/Translations.ts
@@ -50,6 +50,17 @@ export const ENGLISH_TRANSLATION = {
             title: "Drag the slider to walk through your code.",
             text_1: "This window shows how your program works step by step. Explore to see how your program builds and stores information.",
             text_2: "You can also use the %{previous} and %{next} buttons to go to the previous or next step. The %{first} and %{last} buttons can be used to directly jump to the first or last step respectively.",
+            // Accessible names: announced by screen readers, never shown on screen.
+            picker_label: "Execution steps",
+            slider_label: "Execution step",
+            step_of: "Step %{step} of %{total}",
+            first_step: "First step",
+            previous_step: "Previous step",
+            next_step: "Next step",
+            last_step: "Last step",
+            current_step: "Current step",
+            call_stack: "Call stack",
+            heap_objects: "Heap objects",
         },
         editor: {
             test_code: {
@@ -136,6 +147,17 @@ export const DUTCH_TRANSLATION = {
             title: "Verken je code stap voor stap",
             text_1: "Dit venster toont de werking van je programma in detail. Ontdek hoe je programma informatie opbouwt en bewaart.",
             text_2: "Gebruik de schuifbalk om door je code te wandelen. Je kan ook de %{previous} en %{next} knoppen gebruiken om naar de vorige of volgende stap te gaan. De %{first} en %{last} knoppen kunnen gebruikt worden om direct naar de eerste of laatste stap te gaan.",
+            // Toegankelijkheidslabels: worden voorgelezen door schermlezers, nooit getoond.
+            picker_label: "Uitvoeringsstappen",
+            slider_label: "Uitvoeringsstap",
+            step_of: "Stap %{step} van %{total}",
+            first_step: "Eerste stap",
+            previous_step: "Vorige stap",
+            next_step: "Volgende stap",
+            last_step: "Laatste stap",
+            current_step: "Huidige stap",
+            call_stack: "Call stack",
+            heap_objects: "Objecten op de heap",
         },
         editor: {
             test_code: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,10 +105,10 @@
   dependencies:
     lit "^3.3.1"
 
-"@dodona/trace-component@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@dodona/trace-component/-/trace-component-1.5.0.tgz#416d292369bada5c7109d856c18aaa58e86733d2"
-  integrity sha512-ueBNuNeP1E6oAh4KKXzfypH2SkECbevzumN7HlK7U07OJuFSkvy2uJY6L3cUE6eF28AFfjHba7eCp96KHilwZQ==
+"@dodona/trace-component@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@dodona/trace-component/-/trace-component-1.6.0.tgz#76146bbdd51a306d42bef2d4cc47add9e9315ecf"
+  integrity sha512-rzOR8NUAFFN+palB4DLuEX00dFvu5lp+HL4TeZM0ggYANFESWsLt9scAPVpBIquabVuZs1JCGBsMn4YB8hBodw==
   dependencies:
     lit "^3.3.3"
 


### PR DESCRIPTION
Adds the eleven translation keys that trace-component 1.6.0 introduces, in `en` and `nl`, and upgrades `@dodona/trace-component` from 1.5.0 to 1.6.0 so that something reads them.

The trace component ships English defaults only, and takes its strings from Papyros through `getTranslations("Papyros.debugger")`. A missing key produces no error and no warning: it falls back to English silently. Without these, a screen reader user on the Dutch locale hears English labels.

Ten of the keys come from [trace-component#136](https://github.com/dodona-edu/trace-component/pull/136), which gives accessible names to the frame picker controls, the call stack and the heap. Those ten are never visible on screen; a screen reader announces them. The eleventh, `exception_title`, comes from [trace-component#143](https://github.com/dodona-edu/trace-component/pull/143) and is visible: it is the heading of the card that reports a crash.

| Key | `en` | `nl` |
| --- | --- | --- |
| `picker_label` | Execution steps | Uitvoeringsstappen |
| `slider_label` | Execution step | Uitvoeringsstap |
| `step_of` | Step %{step} of %{total} | Stap %{step} van %{total} |
| `first_step` | First step | Eerste stap |
| `previous_step` | Previous step | Vorige stap |
| `next_step` | Next step | Volgende stap |
| `last_step` | Last step | Laatste stap |
| `current_step` | Current step | Huidige stap |
| `call_stack` | Call stack | Call stack |
| `heap_objects` | Heap objects | Objecten op de heap |
| `exception_title` | The debugger crashed | De debugger is vastgelopen |

## Three Dutch terms to review

- `call_stack` is kept as "Call stack". Students meet the English term in course material. "Oproepstapel" is an alternative.
- `heap_objects` is "Objecten op de heap". "Heap-objecten" is an alternative.
- `exception_title` is "De debugger is vastgelopen". This one is on screen, so it is the one worth reading aloud before merging.

Change any of them if you prefer other terms.

## The version bump

The eleven keys are inert without it. Version 1.5.0 defines only the three help card keys (`title`, `text_1`, `text_2`) and ignores everything else, so merging the strings alone would leave the accessible names unnamed and the crash heading in English.

1.6.0 also brings the grid rendering, the keyboard-operable fold toggle and the ESM packaging fix. `Debugger.ts` echoes `frame-change` back into `.selectedFrame` through `activeFrame`, which is the pattern 1.6.0 explicitly handles — the component now moves its own frame, and an echo of the same value is a no-op. trace-component's own suite covers that case.

## Notes

- `test/__tests__/state/Translations.test.ts` already checks `en`/`nl` parity and treats every key under `Papyros.debugger.` as used, so the new keys need no test change.

## Checklist

- Tests: no new tests. The existing parity test covers the added keys. Typecheck is clean against 1.6.0, which also confirms its new `exports` map resolves here.
- Docs: n/a
- Announcement: n/a on its own, though the accessibility work is worth mentioning whenever the next release is announced.
- AI: Claude Code wrote the Dutch strings and the bump; the Dutch terms above want a human read.
