### PR TITLE
Quiet down and speed up the test suite

### DIFF
--- a/src/communication/BackendManager.ts
+++ b/src/communication/BackendManager.ts
@@ -1,7 +1,6 @@
 import { Backend } from "../backend/Backend";
 import { ProgrammingLanguage } from "../ProgrammingLanguage";
 import { BackendEvent, BackendEventType } from "./BackendEvent";
-import { LogType, papyrosLog } from "../util/Logging";
 import { Channel } from "../sync/channel";
 import { SyncClient } from "../sync/SyncClient";
 /**
@@ -97,7 +96,6 @@ export abstract class BackendManager {
      * @param {BackendEventType} e The event to publish
      */
     public static publish(e: BackendEvent): void {
-        papyrosLog(LogType.Debug, "Publishing event: ", e);
         if (e.type === BackendEventType.Start) {
             BackendManager.halted = false;
         }

--- a/src/communication/BackendManager.ts
+++ b/src/communication/BackendManager.ts
@@ -93,7 +93,7 @@ export abstract class BackendManager {
 
     /**
      * Publish an event, notifying all listeners for its type
-     * @param {BackendEventType} e The event to publish
+     * @param {BackendEvent} e The event to publish
      */
     public static publish(e: BackendEvent): void {
         if (e.type === BackendEventType.Start) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,8 +24,9 @@ export default defineConfig({
         },
         testTimeout: 100000, // loading pyodide can take a while
         sequence: {
-            concurrent: false, // disable running tests in parallel
+            // tests within a file share the static BackendManager, so they cannot overlap
+            concurrent: false,
         },
-        fileParallelism: false, // disable running tests in parallel
+        maxWorkers: 4, // launching pyodide is CPU-bound, more workers do not help
     },
 });


### PR DESCRIPTION
This pull request removes the per-event debug log from `BackendManager.publish` and lets vitest run test files in parallel.

`publish` logged every event through `papyrosLog(LogType.Debug, ...)`, which is gated on `NODE_ENV !== "production"` and so always fires under test. On CI that produced 677 pretty-printed event blocks, roughly 4000 of the 4270 lines in the Test step, mostly full `step_line` payloads from the debugger and turtle tests. It looks like a CI-only problem because the local default reporter hides stdout for passing tests, but `--reporter=verbose` shows the same output locally.

Dropping `fileParallelism: false` runs all 112 tests in 56s locally, against 218s for the 111 tests in the last serial run of main on CI.

**Manual testing instructions**
- `yarn test` passes with no `Publishing event:` blocks in the output
- CI has 4 vCPUs against the 10 measured here, so expect roughly 218s to 90-110s rather than a proportional drop

**Checklist**
- Tests: no new tests, the existing 112 pass in parallel
- Docs: n/a
- Announcement: n/a
- AI: Claude Code diagnosed the log source and the per-test Pyodide floor, measured the timings, and made both changes
