### PR TITLE
Skip the GitHub release for pre-release tags

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -70,11 +70,10 @@ jobs:
         run: npm publish --provenance --access public --tag "$DIST_TAG"
   release:
     needs: [verify, publish]
+    if: needs.verify.outputs.prerelease == 'false'
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    env:
-      PRERELEASE: ${{ needs.verify.outputs.prerelease }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -82,8 +81,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [ "$PRERELEASE" = "true" ]; then
-            gh release create "$GITHUB_REF_NAME" --generate-notes --verify-tag --prerelease
-          else
-            gh release create "$GITHUB_REF_NAME" --generate-notes --verify-tag
-          fi
+          gh release create "$GITHUB_REF_NAME" --generate-notes --verify-tag


### PR DESCRIPTION
This PR removes creating Github prereleases for npm prereleases. They're mostly for internal use, and fill up the release page a bit too much to my liking.

<details>

Pre-release tags (like the recent `v4.9.0-rc.*` ones) currently get a GitHub pre-release created alongside the NPM publish. Those RC builds are only used for internal testing, so they mostly clobber the releases page with noise.

This adds an `if: needs.verify.outputs.prerelease == 'false'` guard to the `release` job in the publish workflow, so a GitHub release is only created for stable tags. Pre-release tags still publish to NPM under the `next` dist-tag as before. Since the job can now only run for stable versions, the `--prerelease` branch in the `gh release create` step is gone too.

</details>

**Testing:** tag an RC (e.g. `v4.9.0-rc.4`): the publish workflow should skip the `release` job and no GitHub release should appear. A stable tag should still get its release as before.
