### PR TITLE
Materialize incremental debug frames from the tracer's delta format

### DIFF
--- a/src/backend/workers/python/papyros/papyros.py
+++ b/src/backend/workers/python/papyros/papyros.py
@@ -7,6 +7,7 @@ import sys
 import json
 import base64
 import doctest
+import inspect
 import re
 import python_runner
 import friendly_traceback
@@ -275,7 +276,12 @@ if __name__ == "{MODULE_NAME}":
                             self._emit_turtle_snapshot()
                             self.callback("frame", data=frame, contentType="application/json")
 
-                        result = JSONTracer(frame_callback=frame_callback, module_name=MODULE_NAME).runscript(source_code)
+                        # older pinned tracer versions don't accept frame_format;
+                        # only request delta frames once the installed tracer supports it
+                        tracer_kwargs = {"frame_callback": frame_callback, "module_name": MODULE_NAME}
+                        if "frame_format" in inspect.signature(JSONTracer.__init__).parameters:
+                            tracer_kwargs["frame_format"] = "delta"
+                        result = JSONTracer(**tracer_kwargs).runscript(source_code)
                     else:
                         result = self.execute(code_obj, mode)
                     while isinstance(result, Awaitable):

--- a/src/frontend/state/Debugger.ts
+++ b/src/frontend/state/Debugger.ts
@@ -4,6 +4,7 @@ import { Frame } from "@dodona/trace-component/dist/trace_types";
 import { State, stateProperty } from "@dodona/lit-state";
 import { Papyros } from "./Papyros";
 import { CODE_TAB, FileEntry, parseFileEntries } from "./InputOutput";
+import { materializeFrame } from "./DebuggerFrames";
 export type FrameState = {
     line: number;
     outputs: number;
@@ -25,6 +26,7 @@ export class Debugger extends State {
     private papyros: Papyros;
     private pendingFrames: Frame[] = [];
     private pendingFrameStates: FrameState[] = [];
+    private lastMaterializedFrame: Frame | undefined = undefined;
     private flushTimer: ReturnType<typeof setTimeout> | undefined = undefined;
     private runActive: boolean = false;
     @stateProperty
@@ -75,7 +77,8 @@ export class Debugger extends State {
         });
         BackendManager.subscribe(BackendEventType.Frame, (e) => {
             this.activeFrame ??= 0;
-            const frame = JSON.parse(e.data);
+            const frame = materializeFrame(this.lastMaterializedFrame, JSON.parse(e.data));
+            this.lastMaterializedFrame = frame;
             this.pendingFrames.push(frame);
             this.pendingFrameStates.push({
                 line: frame.line,
@@ -124,6 +127,7 @@ export class Debugger extends State {
         }
         this.pendingFrames = [];
         this.pendingFrameStates = [];
+        this.lastMaterializedFrame = undefined;
         this.frameStates = [];
         this.currentOutputs = 0;
         this.currentInputs = 0;

--- a/src/frontend/state/DebuggerFrames.ts
+++ b/src/frontend/state/DebuggerFrames.ts
@@ -31,6 +31,9 @@ export type DeltaFrame = {
  * @return {Frame} The full frame
  */
 export function materializeFrame(previous: Frame | undefined, parsed: unknown): Frame {
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        throw new PapyrosError("Received a frame that is not an object");
+    }
     const raw = parsed as Record<string, unknown>;
     if (raw.delta !== true) {
         return raw as Frame;

--- a/src/frontend/state/DebuggerFrames.ts
+++ b/src/frontend/state/DebuggerFrames.ts
@@ -1,0 +1,65 @@
+import { Frame, Heap, TraceSubElement } from "@dodona/trace-component/dist/trace_types";
+import { PapyrosError } from "./PapyrosErrors";
+
+/**
+ * A frame in the tracer's opt-in delta-v1 wire format. Carries everything a
+ * full frame does except `globals` and `heap`, replaced by the changes
+ * needed to derive them from the previous materialized frame.
+ */
+export type DeltaFrame = {
+    delta: true;
+    line: number;
+    event: string;
+    func_name: string;
+    stack_to_render: unknown;
+    ordered_globals: string[];
+    globals_set: Record<string, TraceSubElement>;
+    globals_del: string[];
+    heap_set: Heap;
+    heap_del: string[];
+    [key: string]: unknown;
+};
+
+/**
+ * Turn a frame as received from the worker into a full Frame for the trace
+ * component. Full frames (no `delta` marker) pass through unchanged. Delta
+ * frames are applied on top of `previous`, reusing unchanged heap entries by
+ * reference so the trace only grows by what actually changed between steps.
+ * @param {Frame | undefined} previous The last materialized frame, or
+ * undefined at the start of a run
+ * @param {unknown} parsed The frame as parsed from the worker's JSON
+ * @return {Frame} The full frame
+ */
+export function materializeFrame(previous: Frame | undefined, parsed: unknown): Frame {
+    const raw = parsed as Record<string, unknown>;
+    if (raw.delta !== true) {
+        return raw as Frame;
+    }
+    if (!previous || !("globals" in previous) || !("heap" in previous)) {
+        throw new PapyrosError("Received a delta frame with no full frame to apply it to");
+    }
+    const deltaFrame = raw as DeltaFrame;
+
+    const globals = { ...previous.globals };
+    for (const name of deltaFrame.globals_del) {
+        delete globals[name];
+    }
+    Object.assign(globals, deltaFrame.globals_set);
+
+    const heap = { ...previous.heap };
+    for (const id of deltaFrame.heap_del) {
+        delete heap[id];
+    }
+    Object.assign(heap, deltaFrame.heap_set);
+
+    const materialized = { ...raw } as Record<string, unknown>;
+    delete materialized.delta;
+    delete materialized.globals_set;
+    delete materialized.globals_del;
+    delete materialized.heap_set;
+    delete materialized.heap_del;
+    materialized.globals = globals;
+    materialized.heap = heap;
+
+    return materialized as Frame;
+}

--- a/test/__tests__/state/DebuggerFrames.test.ts
+++ b/test/__tests__/state/DebuggerFrames.test.ts
@@ -23,6 +23,15 @@ describe("materializeFrame", () => {
         expect(materialized).toEqual(frame);
     });
 
+    it.each([
+        ["null", null],
+        ["an array", []],
+        ["a number", 5],
+        ["a string", "frame"],
+    ])("throws when the parsed frame is %s", (_label, parsed) => {
+        expect(() => materializeFrame(fullFrame(), parsed)).toThrow(PapyrosError);
+    });
+
     it("throws when a delta frame has no previous frame", () => {
         const delta = {
             delta: true,

--- a/test/__tests__/state/DebuggerFrames.test.ts
+++ b/test/__tests__/state/DebuggerFrames.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import { materializeFrame } from "../../../src/frontend/state/DebuggerFrames";
+import { NonExceptionFrame } from "@dodona/trace-component/dist/trace_types";
+import { PapyrosError } from "../../../src/frontend/state/PapyrosErrors";
+
+function fullFrame(overrides: Partial<NonExceptionFrame> = {}): NonExceptionFrame {
+    return {
+        line: 1,
+        event: "step_line",
+        func_name: "<module>",
+        globals: { x: 1, y: ["REF", 1] },
+        ordered_globals: ["x", "y"],
+        stack_to_render: [],
+        heap: { "1": ["LIST", 1, 2, 3] },
+        ...overrides,
+    };
+}
+
+describe("materializeFrame", () => {
+    it("passes full frames through unchanged", () => {
+        const frame = fullFrame();
+        const materialized = materializeFrame(undefined, frame);
+        expect(materialized).toEqual(frame);
+    });
+
+    it("throws when a delta frame has no previous frame", () => {
+        const delta = {
+            delta: true,
+            line: 2,
+            event: "step_line",
+            func_name: "<module>",
+            stack_to_render: [],
+            ordered_globals: ["x"],
+            globals_set: { x: 2 },
+            globals_del: [],
+            heap_set: {},
+            heap_del: [],
+        };
+        expect(() => materializeFrame(undefined, delta)).toThrow(PapyrosError);
+    });
+
+    it("applies globals_set/globals_del and heap_set/heap_del onto the previous frame", () => {
+        const previous = fullFrame();
+        const delta = {
+            delta: true,
+            line: 2,
+            event: "step_line",
+            func_name: "<module>",
+            stack_to_render: [],
+            ordered_globals: ["x", "z"],
+            globals_set: { x: 2, z: 3 },
+            globals_del: ["y"],
+            heap_set: { "2": ["LIST", 4, 5] },
+            heap_del: ["1"],
+        };
+
+        const materialized = materializeFrame(previous, delta) as NonExceptionFrame;
+
+        expect(materialized.line).toBe(2);
+        expect(materialized.globals).toEqual({ x: 2, z: 3 });
+        expect(materialized.heap).toEqual({ "2": ["LIST", 4, 5] });
+        expect(materialized).not.toHaveProperty("delta");
+        expect(materialized).not.toHaveProperty("globals_set");
+        expect(materialized).not.toHaveProperty("globals_del");
+        expect(materialized).not.toHaveProperty("heap_set");
+        expect(materialized).not.toHaveProperty("heap_del");
+    });
+
+    it("keeps unchanged heap entries as the same object reference (structural sharing)", () => {
+        const previous = fullFrame({ heap: { "1": ["LIST", 1, 2, 3], "2": ["LIST", 9] } });
+        const delta = {
+            delta: true,
+            line: 2,
+            event: "step_line",
+            func_name: "<module>",
+            stack_to_render: [],
+            ordered_globals: ["x", "y"],
+            globals_set: {},
+            globals_del: [],
+            heap_set: { "2": ["LIST", 9, 10] },
+            heap_del: [],
+        };
+
+        const materialized = materializeFrame(previous, delta) as NonExceptionFrame;
+
+        expect(materialized.heap["1"]).toBe(previous.heap["1"]);
+        expect(materialized.heap["2"]).not.toBe(previous.heap["2"]);
+        expect(materialized.heap["2"]).toEqual(["LIST", 9, 10]);
+    });
+
+    it("chains multiple deltas, sharing entries untouched across the whole chain", () => {
+        const first = fullFrame({ heap: { "1": ["LIST", 1], "2": ["LIST", 2] } });
+        const secondDelta = {
+            delta: true,
+            line: 2,
+            event: "step_line",
+            func_name: "<module>",
+            stack_to_render: [],
+            ordered_globals: ["x", "y"],
+            globals_set: { x: 2 },
+            globals_del: [],
+            heap_set: { "3": ["LIST", 3] },
+            heap_del: [],
+        };
+        const second = materializeFrame(first, secondDelta) as NonExceptionFrame;
+
+        const thirdDelta = {
+            delta: true,
+            line: 3,
+            event: "step_line",
+            func_name: "<module>",
+            stack_to_render: [],
+            ordered_globals: ["x", "y"],
+            globals_set: {},
+            globals_del: [],
+            heap_set: {},
+            heap_del: ["3"],
+        };
+        const third = materializeFrame(second, thirdDelta) as NonExceptionFrame;
+
+        expect(third.heap["1"]).toBe(first.heap["1"]);
+        expect(third.heap["2"]).toBe(first.heap["2"]);
+        expect(third.heap["3"]).toBeUndefined();
+    });
+
+    it("a later full frame resets reconstruction state instead of being applied as a delta", () => {
+        const previous = fullFrame();
+        const nextFull = fullFrame({ line: 5, globals: { a: 1 }, heap: { "9": ["LIST", 1] } });
+
+        const materialized = materializeFrame(previous, nextFull);
+
+        expect(materialized).toEqual(nextFull);
+    });
+
+    it("carries extra full-frame keys like exception_msg through verbatim", () => {
+        const previous = fullFrame();
+        const delta = {
+            delta: true,
+            line: 4,
+            event: "exception",
+            func_name: "<module>",
+            stack_to_render: [],
+            ordered_globals: ["x", "y"],
+            globals_set: {},
+            globals_del: [],
+            heap_set: {},
+            heap_del: [],
+            exception_msg: "boom",
+        };
+
+        const materialized = materializeFrame(previous, delta) as NonExceptionFrame;
+
+        expect(materialized.exception_msg).toBe("boom");
+    });
+});


### PR DESCRIPTION
## Motivation

Fixes the frontend half of dodona-edu/papyros#653: every traced step currently ships the full heap and globals over the worker/main-thread boundary, and papyros retains all of it in `debugger.trace`. For heavy programs that's up to 230 MB of JSON parsed and held on the main thread. `dodona-json-tracer` is gaining an opt-in `frame_format="delta"` constructor kwarg in a parallel PR (release 1.1.0) that streams only what changed between steps; this PR teaches papyros to request it when available and to reconstruct full frames from the deltas.

## Wire format (delta-v1)

- A frame **without** `"delta": true` is a full frame exactly as today; it replaces all reconstruction state. The first frame of a run and `uncaught_exception` frames are always full, and old tracer versions that only ever send full frames keep working unchanged.
- A frame **with** `"delta": true` carries `line`, `event`, `func_name`, `stack_to_render` and `ordered_globals` (full copies), `globals_set`/`globals_del` and `heap_set`/`heap_del` (the changes), plus any other full-frame keys (e.g. `exception_msg`) verbatim. It omits `globals` and `heap`.
- Materialization: full frame = the delta frame minus `delta`/`globals_set`/`globals_del`/`heap_set`/`heap_del`, with `globals` = previous globals minus `globals_del` then spread with `globals_set`, and `heap` = previous heap minus `heap_del` then spread with `heap_set`. Unchanged heap entries keep the **same object reference** as the previous frame — that structural sharing is the actual memory win, so nothing is deep-cloned.

## Implementation

- `src/frontend/state/DebuggerFrames.ts`: new pure `materializeFrame(previous, parsed)` function implementing the contract above. A delta frame with no previous frame throws `PapyrosError` — that shouldn't happen given the wire-format guarantees, so it's treated as a hard error rather than silently dropped.
- `src/frontend/state/Debugger.ts`: frames from the `BackendEventType.Frame` subscription are run through `materializeFrame` before being buffered; the last materialized frame is tracked and reset alongside the rest of the debugger state (`reset()` / on `Start`). The trace-component package still only ever sees full `Frame` objects.
- `src/backend/workers/python/papyros/papyros.py`: the worker feature-detects `frame_format` on `JSONTracer.__init__` via `inspect.signature` and only passes `frame_format="delta"` when the installed tracer supports it.

## Rollout

This is opt-in and feature-detected, so it's safe to merge now:

- `dodona-json-tracer>=1.0.0` in `src/backend/workers/python/build_package.py` is **intentionally not bumped** — 1.1.0 isn't on PyPI yet. With the currently pinned 1.0.0, `frame_format` isn't a constructor parameter, the feature-detection is false, and the worker behaves exactly as before.
- The delta path activates automatically in a follow-up PR once dodona-json-tracer 1.1.0 ships: bump the pin, rebuild the worker tarball, done — no frontend changes needed.
- Rollback is a one-line revert: stop passing the `frame_format` kwarg (or re-pin the tracer below 1.1.0) and the worker goes back to full frames only.

## Performance

Benchmarked on an M-series Mac: tracer-side numbers from native CPython 3.14, consumer-side numbers from Node.js (Pyodide/WASM, the actual production environment, is roughly 3x slower than native CPython — so the ratios below matter more than the absolute times). All wall-clock numbers are the median of 3 runs (5 runs for the Node.js parse benchmarks).

### Wire bytes and consumer parse+materialize cost (Node.js)

| case | full parse | delta parse+materialize | speedup | full bytes | delta bytes | byte ratio |
|---|---|---|---|---|---|---|
| pokemon (10000 frames) | 1045.3 ms | 38.5 ms | 27.2x | 227.0 MB | 15.8 MB | 14.4x |
| quad n=50 | 0.90 ms | 0.15 ms | 6.0x | 0.252 MB | 0.035 MB | 7.2x |
| quad n=100 | 3.40 ms | 0.31 ms | 11.1x | 0.955 MB | 0.069 MB | 13.8x |
| quad n=200 | 13.51 ms | 0.59 ms | 22.9x | 3.912 MB | 0.139 MB | 28.1x |
| quad n=400 | 53.04 ms | 1.16 ms | 45.6x | 15.893 MB | 0.278 MB | 57.1x |

### Retained-memory footprint

`materializeFrame` uses structural sharing — it reuses the same object reference for every heap/global entry that didn't change, rather than cloning. Counting each distinct retained value once by reference (matching what `materializeFrame` actually keeps) instead of naively re-stringifying every materialized frame:

| case | full retained | delta retained, naive re-stringify | delta retained, structural sharing | reduction vs. full |
|---|---|---|---|---|
| pokemon | 227.0 MB | 199.5 MB | 13.7 MB | 16.5x |
| quad n=50 | 0.252 MB | 0.177 MB | 0.019 MB | 13.3x |
| quad n=100 | 0.955 MB | 0.674 MB | 0.038 MB | 25.5x |
| quad n=200 | 3.912 MB | 2.790 MB | 0.075 MB | 51.9x |
| quad n=400 | 15.893 MB | 11.409 MB | 0.151 MB | 105.2x |

The "naive re-stringify" column shows why deep-cloning materialized frames would erase most of the win; "structural sharing" is what `debugger.trace` actually retains once unchanged entries keep their existing reference instead of being rebuilt — a 13-105x reduction over full, growing with program/state size since a bigger unchanged working set means more sharing.

### Tracer-side, for reference (full detail in dodona-edu/json-tracer#21)

| | full | delta | ratio |
|---|---|---|---|
| pokemon tracer wall time | 8.68 s | 6.46 s | 0.74x |
| pokemon bytes streamed | 227.0 MB | 15.8 MB | 14.4x smaller |

Bytes over the wire, parse+materialize time, and retained memory are the point of this change, and all three improve by an order of magnitude or more on real, heap-heavy programs; the tracer's own wall time also improves, but more modestly (~15-26%), since encoding the object graph — not `json.dumps` output size — still dominates its per-frame cost. See dodona-edu/json-tracer#21's Performance section for a note on a pre-existing, format-agnostic id-numbering caveat in the tracer's encoder surfaced during verification — it's harmless to consumers, since content is always correctly refreshed via `heap_set`/`globals_set` regardless of numbering.
## Verification

- `yarn vitest run`: 112 passed before this change, 119 passed after (112 pre-existing + 7 new `materializeFrame` unit tests covering full-frame passthrough, delta application, structural sharing across a chain of deltas, a later full frame resetting state, and pass-through of extra keys like `exception_msg`).
- `yarn lint` and `yarn typecheck` clean on the touched files.
- `python3 -m py_compile` on the modified worker file.
- No standalone Python worker test suite exists in this repo; the `debugger.test.ts` vitest suite exercises the built worker tarball end-to-end and passes unchanged (the tarball still ships tracer 1.0.0, so this only confirms the feature-detection path is inert as intended).
