### PR TITLE
Fix crash bugs in the JavaScript worker's console and error handling

### DIFF
--- a/src/backend/workers/javascript/JavaScriptWorker.ts
+++ b/src/backend/workers/javascript/JavaScriptWorker.ts
@@ -33,7 +33,9 @@ export class JavaScriptWorker extends Backend {
                     }
                     return aString;
                 } else {
-                    return JSON.stringify(a);
+                    // bigint, symbol, function and boolean: JSON.stringify throws
+                    // on a bigint and returns undefined for a symbol or function
+                    return String(a);
                 }
             })
             .join(" ");

--- a/src/backend/workers/javascript/JavaScriptWorker.ts
+++ b/src/backend/workers/javascript/JavaScriptWorker.ts
@@ -16,21 +16,24 @@ export class JavaScriptWorker extends Backend {
     private static stringify(...args: any[]): string {
         const asString = args
             .map((a) => {
-                if (Array.isArray(a)) {
+                if (a === null || a === undefined) {
+                    return String(a);
+                } else if (Array.isArray(a)) {
                     return JSON.stringify(a);
                 } else if (typeof a === "string") {
                     return a;
                 } else if (typeof a === "number") {
                     return a + "";
-                } else if (typeof a === "object" && "toString" in a) {
-                    let aString = (a as any).toString();
+                } else if (typeof a === "object") {
+                    // objects with no prototype (eg. Object.create(null)) have no toString
+                    let aString = typeof a.toString === "function" ? a.toString() : JSON.stringify(a);
                     if (aString === "[object Object]") {
                         // useless toString, so use JSON
                         aString = JSON.stringify(a);
                     }
                     return aString;
                 } else {
-                    return JSON.stringify(args);
+                    return JSON.stringify(a);
                 }
             })
             .join(" ");
@@ -118,14 +121,18 @@ export class JavaScriptWorker extends Backend {
                 data: "RunCode",
             });
             result = await (0, eval)(code);
-        } catch (error: any) {
-            // try to create a friendly traceback
-            Error.captureStackTrace(error);
+        } catch (thrown: any) {
+            // normalize non-Error throwables (eg. throw null / throw "oops") into a real error
+            const error = thrown instanceof Error ? thrown : new Error(JavaScriptWorker.stringify(thrown));
+            // stack is missing on some engines and captureStackTrace is V8-only; never clobber a real stack
+            if (!error.stack && typeof Error.captureStackTrace === "function") {
+                Error.captureStackTrace(error);
+            }
             result = await this.onEvent({
                 type: BackendEventType.Error,
                 contentType: "application/json",
                 data: {
-                    name: error.constructor.name,
+                    name: error.name,
                     what: error.message,
                     traceback: error.stack,
                 },

--- a/test/__tests__/JavaScriptWorker.test.ts
+++ b/test/__tests__/JavaScriptWorker.test.ts
@@ -48,6 +48,18 @@ describe("JavaScriptWorker", () => {
         expect(errorEvent(events)).toBeUndefined();
     });
 
+    it("logs values JSON cannot represent without crashing", async () => {
+        const events = await run("console.log(10n, Symbol('tag'), true);");
+        expect(outputText(events)).toBe("10 Symbol(tag) true\n");
+        expect(errorEvent(events)).toBeUndefined();
+    });
+
+    it("logs functions by their source", async () => {
+        const events = await run("console.log(function foo() {});");
+        expect(outputText(events)).toContain("foo");
+        expect(errorEvent(events)).toBeUndefined();
+    });
+
     it("keeps the original stack trace of a thrown Error", async () => {
         const events = await run("function fail() { throw new Error('boom'); }\nfail();");
         const error = errorEvent(events);
@@ -69,5 +81,12 @@ describe("JavaScriptWorker", () => {
         const error = errorEvent(events);
         expect(error).toBeTruthy();
         expect(error!.data.what).toBe("oops");
+    });
+
+    it("reports a clean error when throwing a bigint", async () => {
+        const events = await run("throw 10n;");
+        const error = errorEvent(events);
+        expect(error).toBeTruthy();
+        expect(error!.data.what).toBe("10");
     });
 });

--- a/test/__tests__/JavaScriptWorker.test.ts
+++ b/test/__tests__/JavaScriptWorker.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { JavaScriptWorker } from "../../src/backend/workers/javascript/JavaScriptWorker";
+import { BackendEvent, BackendEventType } from "../../src/communication/BackendEvent";
+import { SyncExtras } from "../../src/sync/expose";
+
+// Bypasses the SyncClient/expose plumbing so runCode can be driven directly in tests
+class TestableJavaScriptWorker extends JavaScriptWorker {
+    protected override expose() {
+        return (f: any) => f;
+    }
+}
+
+async function run(code: string): Promise<BackendEvent[]> {
+    const events: BackendEvent[] = [];
+    const worker = new TestableJavaScriptWorker();
+    await worker.launch((e) => events.push(e), undefined);
+    await worker.runCode({} as SyncExtras, code);
+    return events;
+}
+
+function outputText(events: BackendEvent[]): string {
+    return events
+        .filter((e) => e.type === BackendEventType.Output)
+        .map((e) => e.data)
+        .join("");
+}
+
+function errorEvent(events: BackendEvent[]): BackendEvent | undefined {
+    return events.find((e) => e.type === BackendEventType.Error);
+}
+
+describe("JavaScriptWorker", () => {
+    it("logs null without crashing", async () => {
+        const events = await run("console.log(null);");
+        expect(outputText(events)).toBe("null\n");
+        expect(errorEvent(events)).toBeUndefined();
+    });
+
+    it("logs undefined without crashing", async () => {
+        const events = await run("console.log(undefined);");
+        expect(outputText(events)).toBe("undefined\n");
+        expect(errorEvent(events)).toBeUndefined();
+    });
+
+    it("logs plain objects without crashing", async () => {
+        const events = await run("console.log({});");
+        expect(outputText(events)).toBe("{}\n");
+        expect(errorEvent(events)).toBeUndefined();
+    });
+
+    it("keeps the original stack trace of a thrown Error", async () => {
+        const events = await run("function fail() { throw new Error('boom'); }\nfail();");
+        const error = errorEvent(events);
+        expect(error).toBeTruthy();
+        expect(error!.data.what).toBe("boom");
+        // the stack must still point at the throw site, not the worker's catch block
+        expect(error!.data.traceback).toContain("fail");
+    });
+
+    it("reports a clean error when throwing null", async () => {
+        const events = await run("throw null;");
+        const error = errorEvent(events);
+        expect(error).toBeTruthy();
+        expect(error!.data.what).toBe("null");
+    });
+
+    it("reports a clean error when throwing a string", async () => {
+        const events = await run("throw 'oops';");
+        const error = errorEvent(events);
+        expect(error).toBeTruthy();
+        expect(error!.data.what).toBe("oops");
+    });
+});


### PR DESCRIPTION
This pull request fixes three crash bugs in `JavaScriptWorker.ts`, the backend that runs user JavaScript code:

1. `console.log(null)` (and `console.log(undefined)`) crashed the worker: `typeof null === "object"`, so the code fell into the `"toString" in a` check, and `in` throws on `null`. Also fixed the same helper for objects with no prototype (eg. `Object.create(null)`, no `toString`) and a latent bug in the final fallback branch that stringified the whole `args` array instead of the single value.
2. `Error.captureStackTrace(error)` ran unconditionally in the catch handler, overwriting a student's real stack trace with one pointing at the worker's own catch block, and it's V8-only (throws or no-ops elsewhere). It now only fires when the error has no stack yet and the engine supports it.
3. The catch handler assumed every thrown value was an Error (`error.constructor.name`, `error.message`, `error.stack`), so `throw null` / `throw undefined` / `throw "text"` / `throw 42` crashed the handler itself instead of reporting a normal error. Non-Error throwables are now normalized into a real `Error` with a clean message before reporting.

No test exercised this file before; added `test/__tests__/JavaScriptWorker.test.ts`, instantiating the worker directly (same pattern as `MockBackend`, overriding `expose()` to skip the SyncClient plumbing).

**Manual testing instructions**
- Run the JavaScript playground, execute `console.log(null)` and `console.log(undefined)` — output prints instead of crashing.
- Execute code that throws inside a named function — the reported traceback still names that function, not the worker's internals.
- Execute `throw null` / `throw "oops"` — a clean error is reported instead of a crash.

**Checklist**
- Tests: added `test/__tests__/JavaScriptWorker.test.ts`, covering `console.log(null/undefined/{})`, a thrown Error keeping its original stack, and `throw null` / `throw "string"` producing clean error events.
- Docs: n/a
- Announcement: 🐛 fixed several JavaScript playground crashes on `console.log(null)`/`console.log(undefined)` and on throwing non-Error values
- AI: Claude Code found, fixed, and wrote tests for all three bugs; human reviewed