### PR TITLE
Activate delta frames and step-budget cancellation

### DIFF
--- a/src/backend/Backend.ts
+++ b/src/backend/Backend.ts
@@ -106,9 +106,10 @@ export abstract class Backend {
      * @param {SyncExtras} extras Helper properties to run code
      * @param {string} code The code to run
      * @param {string} mode The mode to run the code in
+     * @param {number} maxSteps Upper bound on the number of debug frames a backend should produce, if it supports one
      * @return {Promise<void>} Promise of execution
      */
-    public abstract runCode(extras: SyncExtras, code: string, mode?: string): Promise<void>;
+    public abstract runCode(extras: SyncExtras, code: string, mode?: string, maxSteps?: number): Promise<void>;
 
     /**
      * Generate linting suggestions for the given code

--- a/src/backend/workers/python/PythonWorker.ts
+++ b/src/backend/workers/python/PythonWorker.ts
@@ -85,7 +85,7 @@ export class PythonWorker extends Backend {
         return modes;
     }
 
-    public override async runCode(extras: SyncExtras, code: string, mode = "exec"): Promise<any> {
+    public override async runCode(extras: SyncExtras, code: string, mode = "exec", maxSteps?: number): Promise<any> {
         this.extras = extras;
         if (extras.interruptBuffer) {
             this.pyodide.setInterruptBuffer(extras.interruptBuffer);
@@ -94,6 +94,7 @@ export class PythonWorker extends Backend {
         return await this.papyros?.run_async.callKwargs({
             source_code: code,
             mode: mode,
+            max_steps: maxSteps,
         });
     }
 

--- a/src/backend/workers/python/build_package.py
+++ b/src/backend/workers/python/build_package.py
@@ -63,4 +63,4 @@ def install_dependencies(packages, out_dir):
     subprocess.check_call([sys.executable, "-m", "pip", "install", "-t", out_dir, *packages])
 
 if __name__ == "__main__":
-    create_package("python_package", "python-runner friendly_traceback pylint>=4,<5 tomli typing-extensions dodona-json-tracer>=1.0.0 svg-turtle", extra_deps="papyros")
+    create_package("python_package", "python-runner friendly_traceback pylint>=4,<5 tomli typing-extensions dodona-json-tracer>=1.1.0 svg-turtle", extra_deps="papyros")

--- a/src/backend/workers/python/papyros/papyros.py
+++ b/src/backend/workers/python/papyros/papyros.py
@@ -7,7 +7,6 @@ import sys
 import json
 import base64
 import doctest
-import inspect
 import re
 import python_runner
 import friendly_traceback
@@ -276,13 +275,9 @@ if __name__ == "{MODULE_NAME}":
                             self._emit_turtle_snapshot()
                             self.callback("frame", data=frame, contentType="application/json")
 
-                        # older pinned tracer versions don't accept frame_format/max_steps;
-                        # only request them once the installed tracer supports it
-                        tracer_kwargs = {"frame_callback": frame_callback, "module_name": MODULE_NAME}
-                        tracer_params = inspect.signature(JSONTracer.__init__).parameters
-                        if "frame_format" in tracer_params:
-                            tracer_kwargs["frame_format"] = "delta"
-                        if max_steps is not None and "max_steps" in tracer_params:
+                        tracer_kwargs = {"frame_callback": frame_callback, "module_name": MODULE_NAME,
+                                         "frame_format": "delta"}
+                        if max_steps is not None:
                             tracer_kwargs["max_steps"] = max_steps
                         result = JSONTracer(**tracer_kwargs).runscript(source_code)
                     else:

--- a/src/backend/workers/python/papyros/papyros.py
+++ b/src/backend/workers/python/papyros/papyros.py
@@ -250,7 +250,7 @@ if __name__ == "{MODULE_NAME}":
 """
         return super().pre_run(source_code, mode=mode, top_level_await=top_level_await)
 
-    async def run_async(self, source_code, mode="exec", top_level_await=True):
+    async def run_async(self, source_code, mode="exec", top_level_await=True, max_steps=None):
         with self._execute_context():
             try:
                 code_obj = self.pre_run(source_code, mode=mode, top_level_await=top_level_await)
@@ -276,11 +276,14 @@ if __name__ == "{MODULE_NAME}":
                             self._emit_turtle_snapshot()
                             self.callback("frame", data=frame, contentType="application/json")
 
-                        # older pinned tracer versions don't accept frame_format;
-                        # only request delta frames once the installed tracer supports it
+                        # older pinned tracer versions don't accept frame_format/max_steps;
+                        # only request them once the installed tracer supports it
                         tracer_kwargs = {"frame_callback": frame_callback, "module_name": MODULE_NAME}
-                        if "frame_format" in inspect.signature(JSONTracer.__init__).parameters:
+                        tracer_params = inspect.signature(JSONTracer.__init__).parameters
+                        if "frame_format" in tracer_params:
                             tracer_kwargs["frame_format"] = "delta"
+                        if max_steps is not None and "max_steps" in tracer_params:
+                            tracer_kwargs["max_steps"] = max_steps
                         result = JSONTracer(**tracer_kwargs).runscript(source_code)
                     else:
                         result = self.execute(code_obj, mode)
@@ -299,7 +302,7 @@ if __name__ == "{MODULE_NAME}":
                 except:
                     # If the module is truly not findable, raise the error again
                     raise mnf
-                return await self.run_async(source_code, mode=mode, top_level_await=top_level_await)
+                return await self.run_async(source_code, mode=mode, top_level_await=top_level_await, max_steps=max_steps)
             except BaseException as e:
                 # Sometimes KeyboardInterrupt is caught by Pyodide and raised as a PythonError
                 # with a js_error containing the reason

--- a/src/frontend/state/Debugger.ts
+++ b/src/frontend/state/Debugger.ts
@@ -86,7 +86,9 @@ export class Debugger extends State {
                 inputs: this.papyros.io.inputs.length,
                 files: this.fileHistory.length,
             });
-            if (this.frameStates.length + this.pendingFrameStates.length >= this.papyros.constants.maxDebugFrames) {
+            // the tracer stops itself at maxDebugFrames, so this only fires for
+            // a tracer that streams past its step budget
+            if (this.frameStates.length + this.pendingFrameStates.length > this.papyros.constants.maxDebugFrames) {
                 this.flushFrames();
                 this.papyros.runner.stop();
             } else if (!this.runActive) {

--- a/src/frontend/state/Runner.ts
+++ b/src/frontend/state/Runner.ts
@@ -244,7 +244,12 @@ export class Runner extends State {
         const backend = await this.backend;
         this.runStartTime = new Date().getTime();
         try {
-            await backend.call(backend.workerProxy.runCode, this.effectiveCode, mode);
+            await backend.call(
+                backend.workerProxy.runCode,
+                this.effectiveCode,
+                mode,
+                this.papyros.constants.maxDebugFrames,
+            );
         } catch (error: any) {
             if (error.type === "InterruptError") {
                 // Error signaling forceful interrupt

--- a/test/__tests__/state/Debugger.test.ts
+++ b/test/__tests__/state/Debugger.test.ts
@@ -2,6 +2,7 @@ import {describe, it, expect} from "vitest";
 import {ProgrammingLanguage} from "../../../src/ProgrammingLanguage";
 import {Papyros} from "../../../src/frontend/state/Papyros";
 import {RunMode} from "../../../src/backend/Backend";
+import {RunState} from "../../../src/frontend/state/Runner";
 import {NonExceptionFrame} from "@dodona/trace-component/dist/trace_types";
 import {waitForInputReady, waitForOutput, waitForPapyrosReady} from "../../helpers";
 
@@ -108,6 +109,25 @@ for i in range(50):
         // frameStates stayed in sync with the trace
         papyros.debugger.activeFrame = papyros.debugger.trace.length - 1;
         expect(papyros.debugger.debugLine).toBe(last.line);
+    });
+
+    it("caps a debug run at maxDebugFrames without stalling", async () => {
+        const papyros = new Papyros();
+        await papyros.launch();
+        papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+        papyros.constants.maxDebugFrames = 5;
+        papyros.runner.code = `total = 0
+for i in range(50):
+    total += i`;
+        await papyros.runner.start(RunMode.Debug);
+        await waitForPapyrosReady(papyros);
+
+        // The tracer keeps producing frames past the cap (no max_steps support
+        // yet), so the frontend forcibly stops the run; it must still settle
+        // cleanly instead of getting stuck in a stopping state
+        expect(papyros.runner.state).toBe(RunState.Ready);
+        expect(papyros.runner.stateMessage).toMatch(/^Code interrupted after/);
+        expect(papyros.debugger.trace.length).toBe(5);
     });
 
     it("resets when deactivated", async () => {

--- a/test/__tests__/state/Debugger.test.ts
+++ b/test/__tests__/state/Debugger.test.ts
@@ -122,11 +122,10 @@ for i in range(50):
         await papyros.runner.start(RunMode.Debug);
         await waitForPapyrosReady(papyros);
 
-        // The tracer keeps producing frames past the cap (no max_steps support
-        // yet), so the frontend forcibly stops the run; it must still settle
-        // cleanly instead of getting stuck in a stopping state
+        // The tracer stops at the frame budget on its own, so the run finishes
+        // normally rather than being interrupted by the frontend
         expect(papyros.runner.state).toBe(RunState.Ready);
-        expect(papyros.runner.stateMessage).toMatch(/^Code interrupted after/);
+        expect(papyros.runner.stateMessage).toMatch(/^Code executed in/);
         expect(papyros.debugger.trace.length).toBe(5);
     });
 


### PR DESCRIPTION
Turns on the two tracer features that #1101 prepared for: the incremental (delta) frame format, and `max_steps`, which lets the tracer stop a runaway run itself instead of waiting for the frontend to notice.

Both things this PR was waiting on have happened: `dodona-json-tracer` **1.1.0** is on PyPI, and #1101 is merged. CI is green, and because `test.yaml` runs `yarn setup`, that green run built the worker tarball against 1.1.0 and ran the suite against the activated path rather than the inert one.

> [!IMPORTANT]
> After this merges, re-run `yarn setup` so your local worker tarball picks up tracer 1.1.0. The prebuilt tarball is gitignored, so nothing rebuilds it for you.

## Changes

- `papyros.py`: `run_async` accepts `max_steps`, forwarded from `runCode`, and `JSONTracer` is constructed with `frame_format="delta"` and `max_steps` passed straight through.
- `Runner.ts` / `Backend.ts` / `PythonWorker.ts`: thread `papyros.constants.maxDebugFrames` through `runCode(extras, code, mode, maxSteps)` down to `run_async`. The configured frontend value is passed rather than duplicated on the worker side, so the two cannot drift.

- `Debugger.ts`: the frontend's own cap now fires at `> maxDebugFrames` instead of `>=`. With `max_steps` active the tracer emits exactly `maxDebugFrames` frames and stops, so the old `>=` fired `runner.stop()` on the very frame the run was already ending on. That interrupt had nothing left to interrupt: `stop()` sat in its 5 s deadlock wait, restarted the backend, and reported "Code interrupted after" for a run that had finished normally. At `>` the cap is a genuine fallback — it can only fire if a tracer streams past its own budget.

<details>
<summary>How that surfaced</summary>

It cost ~2.3 s per capped run locally and much more on a loaded runner, which is what made `Debugger.test.ts` time out on `waitForPapyrosReady` after #1099 turned on parallel test files. The two affected tests are back to ~2.0 s, in line with the rest of the file.
</details>

This PR originally also bumped the tracer pin in `build_package.py`. #1107 has since moved the worker's dependencies into `requirements.txt`, already pinned at `dodona-json-tracer==1.1.0`, so that hunk is gone and the merge with `main` resolves to main's version of the file.

The second commit removes the `inspect.signature` feature detection that guarded both kwargs. It existed so the worker stayed correct against a tracer that predated them, and the pin is now `==1.1.0`, where both exist unconditionally, so there is nothing left to detect. The unused `import inspect` went with it. This came out of a Copilot comment on #1101 that suggested caching the introspection instead; caching would have saved microseconds once per run, while the check itself had simply become dead.

## Manual testing instructions

- Run `yarn setup`, then debug a program with a loop of a few thousand iterations. It should stop at the frame budget and settle on `Ready` with "Code executed in ...", not hang in `Stopping`.
- Debug a short program and step through it. The rendering is unchanged; the delta format is applied in `DebuggerFrames.materializeFrame` from #1101, so a visible difference here would be a bug.

## Checklist

- Tests: added a `Debugger.test.ts` case covering the maxDebugFrames cap, asserting the run settles on `Ready` on its own. Full suite green locally against a worker tarball built with tracer 1.1.0.
- Docs: n/a
- Announcement: n/a (a performance change, not a visible one)
- AI: Claude Code implemented and tested the change; human review pending

