### PR TITLE
Stop bundling demo example code into library consumers

### DIFF
--- a/src/frontend/components/app/App.ts
+++ b/src/frontend/components/app/App.ts
@@ -13,6 +13,9 @@ import { State } from "@dodona/lit-state";
 import "@material/web/iconbutton/icon-button";
 import "@material/web/icon/icon";
 import { ThemeOption } from "../../state/Constants";
+import { ProgrammingLanguage } from "../../../ProgrammingLanguage";
+import { JAVASCRIPT_EXAMPLES } from "./examples/JavaScriptExamples";
+import { PYTHON_EXAMPLES } from "./examples/PythonExamples";
 
 @customElement("p-app")
 export class App extends PapyrosElement {
@@ -124,6 +127,8 @@ export class App extends PapyrosElement {
 
     public override connectedCallback(): void {
         super.connectedCallback();
+        this.papyros.examples.setExamples(ProgrammingLanguage.JavaScript, JAVASCRIPT_EXAMPLES);
+        this.papyros.examples.setExamples(ProgrammingLanguage.Python, PYTHON_EXAMPLES);
         this.initializeLocalStorageProperty(this.papyros.i18n, "locale");
         this.initializeLocalStorageProperty(this.papyros.runner, "code");
         this.initializeLocalStorageProperty(this.papyros.runner, "programmingLanguage");

--- a/src/frontend/state/Examples.ts
+++ b/src/frontend/state/Examples.ts
@@ -1,8 +1,6 @@
 import { State, StateMap, stateProperty } from "@dodona/lit-state";
 import { ProgrammingLanguage } from "../../ProgrammingLanguage";
 import { Papyros } from "./Papyros";
-import { JAVASCRIPT_EXAMPLES } from "../components/app/examples/JavaScriptExamples";
-import { PYTHON_EXAMPLES } from "../components/app/examples/PythonExamples";
 
 export class Examples extends State {
     papyros: Papyros;
@@ -12,8 +10,6 @@ export class Examples extends State {
     constructor(papyros: Papyros) {
         super();
         this.papyros = papyros;
-        this.setExamples(ProgrammingLanguage.JavaScript, JAVASCRIPT_EXAMPLES);
-        this.setExamples(ProgrammingLanguage.Python, PYTHON_EXAMPLES);
     }
 
     public setExamples(language: ProgrammingLanguage, examples: Record<string, string>): void {


### PR DESCRIPTION
This pull request stops library consumers from bundling the demo app's example code fragments.

The `Examples` state imported `JAVASCRIPT_EXAMPLES` and `PYTHON_EXAMPLES` from `components/app/examples/` and registered them in its constructor. Since `Papyros` hard-instantiates `Examples`, every consumer of `@dodona/papyros` (Dodona included) shipped the papyros.dodona.be example fragments in its bundle, even though nothing outside the demo app reads them.

`Examples` now starts empty and the demo `App` registers both example sets in `connectedCallback`, before local-storage restoration and first render. The `setExamples` API is unchanged, so hosts that want their own examples can still provide them.