### PR TITLE
Pin the worker's Python dependencies and track them with Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -30,3 +30,12 @@ updates:
   open-pull-requests-limit: 98
   labels:
     - "dependencies"
+- package-ecosystem: pip
+  directory: "/src/backend/workers/python"
+  schedule:
+    interval: monthly
+    time: "13:00"
+    timezone: Europe/Brussels
+  open-pull-requests-limit: 98
+  labels:
+    - "dependencies"

--- a/src/backend/workers/python/build_package.py
+++ b/src/backend/workers/python/build_package.py
@@ -29,9 +29,9 @@ def relative_files(root):
             found.add(os.path.relpath(os.path.join(dir_path, file_name), root))
     return found
 
-def create_package(package_name, dependencies, extra_deps):
+def create_package(package_name, extra_deps):
     shutil.rmtree(package_name, ignore_errors=True)
-    install_dependencies(dependencies.split(" "), package_name)
+    install_dependencies(package_name)
     dest_dir = os.path.join(package_name, extra_deps)
     shutil.rmtree(dest_dir, ignore_errors=True)
     try:
@@ -57,10 +57,9 @@ def create_package(package_name, dependencies, extra_deps):
         tar.add(package_name, arcname="", recursive=True, filter=tarfile_filter)
     shutil.rmtree(package_name)
 
-def install_dependencies(packages, out_dir):
-    if not isinstance(packages, list):
-        packages = [packages]
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "-t", out_dir, *packages])
+def install_dependencies(out_dir):
+    requirements = os.path.join(os.path.dirname(os.path.abspath(__file__)), "requirements.txt")
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "-t", out_dir, "-r", requirements])
 
 if __name__ == "__main__":
-    create_package("python_package", "python-runner friendly_traceback pylint>=4,<5 tomli typing-extensions dodona-json-tracer>=1.0.0 svg-turtle", extra_deps="papyros")
+    create_package("python_package", extra_deps="papyros")

--- a/src/backend/workers/python/requirements.txt
+++ b/src/backend/workers/python/requirements.txt
@@ -1,0 +1,7 @@
+python-runner==0.6.1
+friendly_traceback==0.7.61
+pylint==4.0.6
+tomli==2.4.1
+typing-extensions==4.16.0
+dodona-json-tracer==1.1.0
+svg-turtle==1.2.0


### PR DESCRIPTION
*This pull request moves the Python worker package's dependencies out of an inline string in `build_package.py` into `src/backend/workers/python/requirements.txt`, pinned to exact versions, and registers that directory with Dependabot's `pip` ecosystem.

Until now the dependency list was a space-separated string passed inside the script's `__main__` block, mostly unpinned and invisible to any tooling. Builds silently picked up whatever PyPI resolved that day. With exact pins, upgrades become explicit Dependabot PRs (same monthly cadence and `dependencies` label as the npm updates) that CI's browser tests can validate against Pyodide before anything changes in the shipped tarball.

Pinned versions are what pip resolved today: `python-runner==0.6.1`, `friendly_traceback==0.7.61`, `pylint==4.0.6`, `tomli==2.4.1`, `typing-extensions==4.16.0`, `dodona-json-tracer==1.1.0`, `svg-turtle==1.2.0`. All satisfy the previous range constraints (`pylint>=4,<5`, `dodona-json-tracer>=1.0.0`).

**Manual testing instructions**
- `cd src/backend/workers/python && python3 build_package.py` exits 0 and regenerates `python_package.tar.gz.load_by_url` with `papyros/`, `turtle.py`, `pyodide_worker_runner.py` and the dependency dirs inside.

**Notes**
- The old `pylint>=4,<5` ceiling is no longer expressed anywhere: when pylint 5 releases, Dependabot will propose it as a PR, which makes that upgrade an explicit reviewed decision instead of a silent constraint. Transitive dependencies stay unpinned; pip resolves them at build time as before.
- #1103 raises the json-tracer floor to 1.1.0 in the same line this PR deletes, so whichever merges second has a trivial conflict.
- Tests: covered by the existing build verification in CI; no new tests.
- AI: Claude Code implemented this change (Sonnet subagent).