### PR TITLE
Scope the event bus, backends and channel to each Papyros instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ src/backend/workers/python/python_package/
 src/backend/workers/python/python_package.tar.gz.load_by_url
 
 __screenshots__/
+.vitest-attachments/

--- a/README.md
+++ b/README.md
@@ -159,6 +159,14 @@ Each expects a `papyros` state instance, but defaults to the global `papyros`.
 <p-output></p-output>
 ```
 
+### Multiple instances
+
+The global `papyros` is just a default instance. Every `new Papyros()` owns its own event
+bus, backend workers and input channel, so several instances can run code on the same page
+at the same time, even in the same language. The one service worker registration a page can
+have is shared between them. Call `papyros.dispose()` to terminate an instance's workers
+when it is removed from the page.
+
 ---
 
 ## Theming
@@ -210,6 +218,7 @@ A `Papyros` instance contains multiple logical parts:
 
 * `papyros.constants`: general settings, constants, and themes (can be overridden).
 * `papyros.debugger`: debug frames and currently active frame.
+* `papyros.events`: the event bus delivering backend events (output, errors, frames, ...) to this instance's state.
 * `papyros.examples`: available code examples.
 * `papyros.i18n`: translations (extend or override as needed).
 * `papyros.io`: input/output handling. Subscribe to `awaitingInput` to supply input when needed.

--- a/src/communication/BackendEvent.ts
+++ b/src/communication/BackendEvent.ts
@@ -11,8 +11,6 @@ export enum BackendEventType {
     Interrupt = "interrupt",
     Loading = "loading",
     Frame = "frame",
-    FrameChange = "frame-change",
-    Stop = "stop",
     Files = "files",
     Turtle = "turtle",
 }

--- a/src/communication/BackendManager.ts
+++ b/src/communication/BackendManager.ts
@@ -1,27 +1,18 @@
 import { Backend } from "../backend/Backend";
 import { ProgrammingLanguage } from "../ProgrammingLanguage";
-import { BackendEvent, BackendEventType } from "./BackendEvent";
-import { Channel } from "../sync/channel";
 import { SyncClient } from "../sync/SyncClient";
-/**
- * Callback type definition for subscribers
- * @param {BackendEvent} e The published event
- */
-type BackendEventListener = (e: BackendEvent) => void;
 
 /**
- * Abstract class to implement the singleton pattern
- * Static methods group functionality
+ * Static registry mapping programming languages to backend worker factories.
+ *
+ * Only configuration lives here: the clients themselves are created per Papyros
+ * instance and owned by its Runner, so instances never share a worker.
  */
 export abstract class BackendManager {
     /**
      * Map programming languages to Backend constructors
      */
-    private static createBackendMap: Map<ProgrammingLanguage, () => SyncClient<Backend>>;
-    /**
-     * Map to cache Backends per ProgrammingLanguage
-     */
-    private static backendMap: Map<ProgrammingLanguage, SyncClient<Backend>>;
+    private static createBackendMap: Map<ProgrammingLanguage, () => SyncClient<Backend>> = new Map();
     /**
      * Map programming languages to overridden Worker script URLs, consulted by the
      * default backendCreators registered in the static initializer
@@ -32,27 +23,12 @@ export abstract class BackendManager {
      * the URL is cross-origin
      */
     private static blobBootstrapUrls: Map<string, string> = new Map();
-    /**
-     * Map an event type to interested subscribers
-     * Uses an Array to maintain order of subscription
-     */
-    private static subscriberMap: Map<BackendEventType, Array<BackendEventListener>>;
-    /**
-     * Whether the BackendManager is publishing events
-     */
-    private static halted: boolean;
-    /**
-     * The channel used to communicate with the SyncClients
-     * Assigned by Papyros once a backend turns out to need one
-     */
-    public static channel: Channel | null = null;
 
     /**
      * @param {ProgrammingLanguage} language The language to support
      * @param {Function} backendCreator The constructor for a SyncClient
      */
     public static registerBackend(language: ProgrammingLanguage, backendCreator: () => SyncClient<Backend>): void {
-        BackendManager.removeBackend(language);
         BackendManager.createBackendMap.set(language, backendCreator);
     }
 
@@ -60,9 +36,8 @@ export abstract class BackendManager {
      * Override where the Worker script for a language's backend is loaded from, e.g. so a
      * page served from a sibling/canonical asset host can point at that host's copy of the
      * worker chunk instead of the page's own origin
-     * Call this before launching the backend for the language: like removeBackend, replacing
-     * the URL after a backend was already created only drops the cached client for that
-     * language, it does not terminate the client's already-running Worker
+     * Call this before launching the backend for the language: a backend that is already
+     * running keeps the Worker it was created with
      * If url is cross-origin relative to the page, papyros bootstraps the Worker through a
      * same-origin blob module that imports the real url: the browser requires the initial
      * Worker construction to be same-origin, and a blob: URL inherits the page's origin so it
@@ -76,7 +51,6 @@ export abstract class BackendManager {
      */
     public static setWorkerUrl(language: ProgrammingLanguage, url: string | URL): void {
         BackendManager.workerUrls.set(language, new URL(url, window.location.href));
-        BackendManager.backendMap.delete(language);
     }
 
     /**
@@ -115,22 +89,16 @@ export abstract class BackendManager {
     }
 
     /**
-     * Start a backend for the given language and cache for reuse
+     * Create a fresh backend client for the given language
      * @param {ProgrammingLanguage} language The programming language supported by the backend
      * @return {SyncClient<Backend>} A SyncClient for the Backend
      */
-    public static getBackend(language: ProgrammingLanguage): SyncClient<Backend> {
-        if (this.backendMap.has(language)) {
-            // Cached
-            return this.backendMap.get(language)!;
-        } else if (this.createBackendMap.has(language)) {
-            // Create and then cache
-            const syncClient = this.createBackendMap.get(language)!();
-            this.backendMap.set(language, syncClient);
-            return syncClient;
-        } else {
+    public static createBackend(language: ProgrammingLanguage): SyncClient<Backend> {
+        const creator = this.createBackendMap.get(language);
+        if (!creator) {
             throw new Error(`${language} is not yet supported.`);
         }
+        return creator();
     }
 
     /**
@@ -139,89 +107,39 @@ export abstract class BackendManager {
      * @return {boolean} Whether the remove operation had any effect
      */
     public static removeBackend(language: ProgrammingLanguage): boolean {
-        this.backendMap.delete(language);
         return this.createBackendMap.delete(language);
     }
 
-    /**
-     * Register a callback for when an event of a certain type is published
-     * @param {BackendEventType} type The type of event to subscribe to
-     * @param {BackendEventListener} subscriber Callback for when an event
-     * of the given type is published
-     */
-    public static subscribe(type: BackendEventType, subscriber: BackendEventListener): void {
-        if (!this.subscriberMap.has(type)) {
-            this.subscriberMap.set(type, []);
-        }
-        const subscribers = this.subscriberMap.get(type)!;
-        if (!subscribers.includes(subscriber)) {
-            subscribers.push(subscriber);
-        }
-    }
-
-    /**
-     * Publish an event, notifying all listeners for its type
-     * @param {BackendEvent} e The event to publish
-     */
-    public static publish(e: BackendEvent): void {
-        if (e.type === BackendEventType.Start) {
-            BackendManager.halted = false;
-        }
-        if (
-            (!BackendManager.halted || e.type === BackendEventType.FrameChange || e.type === BackendEventType.Files) &&
-            this.subscriberMap.has(e.type)
-        ) {
-            this.subscriberMap.get(e.type)!.forEach((cb) => cb(e));
-        }
-    }
-
-    private static halt(): void {
-        BackendManager.halted = true;
-    }
-
-    /**
-     * Initialise the fields and setup the maps
-     */
     static {
-        BackendManager.createBackendMap = new Map();
-        BackendManager.backendMap = new Map();
-        BackendManager.subscriberMap = new Map();
         BackendManager.registerBackend(
             ProgrammingLanguage.Python,
             () =>
-                new SyncClient<Backend>(
-                    () =>
-                        BackendManager.workerFor(
-                            ProgrammingLanguage.Python,
-                            // Bundlers detect this exact `new Worker(new URL(...), ...)` expression to
-                            // emit the worker chunk, so the URL and options must stay inlined, not extracted
-                            () =>
-                                new Worker(new URL("../backend/workers/python/worker", import.meta.url), {
-                                    type: "module",
-                                }),
-                        ),
-                    BackendManager.channel,
+                new SyncClient<Backend>(() =>
+                    BackendManager.workerFor(
+                        ProgrammingLanguage.Python,
+                        // Bundlers detect this exact `new Worker(new URL(...), ...)` expression to
+                        // emit the worker chunk, so the URL and options must stay inlined, not extracted
+                        () =>
+                            new Worker(new URL("../backend/workers/python/worker", import.meta.url), {
+                                type: "module",
+                            }),
+                    ),
                 ),
         );
         BackendManager.registerBackend(
             ProgrammingLanguage.JavaScript,
             () =>
-                new SyncClient<Backend>(
-                    () =>
-                        BackendManager.workerFor(
-                            ProgrammingLanguage.JavaScript,
-                            // Bundlers detect this exact `new Worker(new URL(...), ...)` expression to
-                            // emit the worker chunk, so the URL and options must stay inlined, not extracted
-                            () =>
-                                new Worker(new URL("../backend/workers/javascript/worker", import.meta.url), {
-                                    type: "module",
-                                }),
-                        ),
-                    BackendManager.channel,
+                new SyncClient<Backend>(() =>
+                    BackendManager.workerFor(
+                        ProgrammingLanguage.JavaScript,
+                        // Bundlers detect this exact `new Worker(new URL(...), ...)` expression to
+                        // emit the worker chunk, so the URL and options must stay inlined, not extracted
+                        () =>
+                            new Worker(new URL("../backend/workers/javascript/worker", import.meta.url), {
+                                type: "module",
+                            }),
+                    ),
                 ),
         );
-        BackendManager.halted = false;
-        BackendManager.subscribe(BackendEventType.End, () => BackendManager.halt());
-        BackendManager.subscribe(BackendEventType.Interrupt, () => BackendManager.halt());
     }
 }

--- a/src/communication/EventBus.ts
+++ b/src/communication/EventBus.ts
@@ -1,0 +1,51 @@
+import { BackendEvent, BackendEventType } from "./BackendEvent";
+
+/**
+ * Callback type definition for subscribers
+ * @param {BackendEvent} e The published event
+ */
+export type BackendEventListener = (e: BackendEvent) => void;
+
+/**
+ * Delivers events published by a backend to the state objects of one Papyros
+ * instance. Each instance owns its own bus, so two instances on the same page
+ * never see each other's events.
+ */
+export class EventBus {
+    /**
+     * Map an event type to interested subscribers
+     * Uses an Array to maintain order of subscription
+     */
+    private subscribers: Map<BackendEventType, Array<BackendEventListener>> = new Map();
+
+    /**
+     * Register a callback for when an event of a certain type is published
+     * @param {BackendEventType} type The type of event to subscribe to
+     * @param {BackendEventListener} subscriber Callback for when an event
+     * of the given type is published
+     * @return {Function} Unsubscribes the callback when called
+     */
+    public subscribe(type: BackendEventType, subscriber: BackendEventListener): () => void {
+        if (!this.subscribers.has(type)) {
+            this.subscribers.set(type, []);
+        }
+        const subscribers = this.subscribers.get(type)!;
+        if (!subscribers.includes(subscriber)) {
+            subscribers.push(subscriber);
+        }
+        return () => {
+            const index = subscribers.indexOf(subscriber);
+            if (index !== -1) {
+                subscribers.splice(index, 1);
+            }
+        };
+    }
+
+    /**
+     * Publish an event, notifying all listeners for its type
+     * @param {BackendEvent} e The event to publish
+     */
+    public publish(e: BackendEvent): void {
+        this.subscribers.get(e.type)?.forEach((cb) => cb(e));
+    }
+}

--- a/src/frontend/components/code_mirror/CodeEditor.ts
+++ b/src/frontend/components/code_mirror/CodeEditor.ts
@@ -35,8 +35,8 @@ import {
     testLineExtension,
 } from "./Extensions";
 import readOnlyRangesExtension from "codemirror-readonly-ranges";
-import { BackendManager } from "../../../communication/BackendManager";
 import { BackendEvent, BackendEventType } from "../../../communication/BackendEvent";
+import { Papyros } from "../../state/Papyros";
 import { parseData } from "../../../util/Util";
 
 const tabCompletionKeyMap = [{ key: "Tab", run: acceptCompletion }];
@@ -113,9 +113,35 @@ export class CodeEditor extends CodeMirrorEditor {
         }
     };
 
+    private _papyros: Papyros | undefined;
+    private unsubscribeRelint: (() => void) | undefined;
+
+    /**
+     * The instance whose backend this editor lints against, used to re-lint
+     * when that backend finishes installing a package
+     */
+    set papyros(value: Papyros | undefined) {
+        this.unsubscribeRelint?.();
+        this.unsubscribeRelint = undefined;
+        this._papyros = value;
+        if (this.isConnected) {
+            this.subscribeRelint();
+        }
+    }
+
+    private subscribeRelint(): void {
+        this.unsubscribeRelint ??= this._papyros?.events.subscribe(BackendEventType.Loading, this.reLintOnLoaded);
+    }
+
     public override connectedCallback(): void {
         super.connectedCallback();
-        BackendManager.subscribe(BackendEventType.Loading, this.reLintOnLoaded);
+        this.subscribeRelint();
+    }
+
+    public override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this.unsubscribeRelint?.();
+        this.unsubscribeRelint = undefined;
     }
 
     set debugLine(value: number | undefined) {

--- a/src/frontend/components/code_runner/Code.ts
+++ b/src/frontend/components/code_runner/Code.ts
@@ -17,6 +17,7 @@ export class Code extends PapyrosElement {
     protected override render(): TemplateResult {
         return html`
             <p-code-editor
+                .papyros=${this.papyros}
                 .testLineCount=${this.papyros.test.testLineCount}
                 .programmingLanguage=${this.papyros.runner.programmingLanguage}
                 .debug=${this.papyros.debugger.active}

--- a/src/frontend/state/Debugger.ts
+++ b/src/frontend/state/Debugger.ts
@@ -1,4 +1,3 @@
-import { BackendManager } from "../../communication/BackendManager";
 import { BackendEventType } from "../../communication/BackendEvent";
 import { Frame } from "@dodona/trace-component/dist/trace_types";
 import { State, stateProperty } from "@dodona/lit-state";
@@ -66,16 +65,12 @@ export class Debugger extends State {
         this.papyros = papyros;
         this.reset();
 
-        BackendManager.subscribe(BackendEventType.Start, () => {
-            this.runActive = true;
-            this.reset();
-        });
-        BackendManager.subscribe(BackendEventType.Files, (e) => {
+        this.papyros.events.subscribe(BackendEventType.Files, (e) => {
             if (this._active) {
                 this.fileHistory = [...this.fileHistory, parseFileEntries(e.data, e.contentType)];
             }
         });
-        BackendManager.subscribe(BackendEventType.Frame, (e) => {
+        this.papyros.events.subscribe(BackendEventType.Frame, (e) => {
             this.activeFrame ??= 0;
             const frame = materializeFrame(this.lastMaterializedFrame, JSON.parse(e.data));
             this.lastMaterializedFrame = frame;
@@ -101,11 +96,25 @@ export class Debugger extends State {
             }
         });
         for (const type of [BackendEventType.End, BackendEventType.Error, BackendEventType.Interrupt]) {
-            BackendManager.subscribe(type, () => {
-                this.runActive = false;
-                this.flushFrames();
-            });
+            this.papyros.events.subscribe(type, () => this.onRunEnd());
         }
+    }
+
+    /**
+     * Called by the Runner when a run begins
+     */
+    public onRunStart(): void {
+        this.runActive = true;
+        this.reset();
+    }
+
+    /**
+     * Called when a run stops producing frames: directly by the Runner on stop or
+     * failure, and through the bus when the worker reports the run over
+     */
+    public onRunEnd(): void {
+        this.runActive = false;
+        this.flushFrames();
     }
 
     private flushFrames(): void {

--- a/src/frontend/state/InputOutput.ts
+++ b/src/frontend/state/InputOutput.ts
@@ -1,5 +1,4 @@
 import { State, stateProperty } from "@dodona/lit-state";
-import { BackendManager } from "../../communication/BackendManager";
 import { BackendEventType } from "../../communication/BackendEvent";
 import { isValidFileName, parseData } from "../../util/Util";
 import { Papyros } from "./Papyros";
@@ -122,8 +121,7 @@ export class InputOutput extends State {
         super();
         this.papyros = papyros;
         this.reset();
-        BackendManager.subscribe(BackendEventType.Start, () => this.reset());
-        BackendManager.subscribe(BackendEventType.Output, (e) => {
+        this.papyros.events.subscribe(BackendEventType.Output, (e) => {
             const data = parseData(e.data, e.contentType);
             if (e.contentType && e.contentType.startsWith("image/")) {
                 this.logImage(data, e.contentType);
@@ -131,14 +129,14 @@ export class InputOutput extends State {
                 this.logOutput(data);
             }
         });
-        BackendManager.subscribe(BackendEventType.Turtle, (e) => {
+        this.papyros.events.subscribe(BackendEventType.Turtle, (e) => {
             this.logTurtle(parseData(e.data, e.contentType));
         });
-        BackendManager.subscribe(BackendEventType.Error, (e) => {
+        this.papyros.events.subscribe(BackendEventType.Error, (e) => {
             const data = parseData(e.data, e.contentType);
             this.logError(data);
         });
-        BackendManager.subscribe(BackendEventType.Input, (e) => {
+        this.papyros.events.subscribe(BackendEventType.Input, (e) => {
             if (this.nextBufferedLine !== undefined && this.inputMode === InputMode.batch) {
                 this.provideInput(this.nextBufferedLine);
                 return;
@@ -147,17 +145,23 @@ export class InputOutput extends State {
             this.prompt = e.data || "";
             this.awaitingInput = true;
         });
-        BackendManager.subscribe(BackendEventType.End, () => {
-            this.awaitingInput = false;
-            // If the finished run produced no turtle output, drop the (stale) Turtle tab
-            // selection so the tab bar hides. A manual selection is preserved.
-            if (this.activeOutputTab === TURTLE_TAB && !this.hasTurtleOutput && !this.outputTabManuallySet) {
-                this.activeOutputTab = OUTPUT_TAB;
-            }
-        });
-        BackendManager.subscribe(BackendEventType.Files, (e) => {
+        this.papyros.events.subscribe(BackendEventType.End, () => this.onRunEnd());
+        this.papyros.events.subscribe(BackendEventType.Files, (e) => {
             this.files = parseFileEntries(e.data, e.contentType);
         });
+    }
+
+    /**
+     * Close the input prompt when a run stops producing events, whether it finished,
+     * failed or was interrupted
+     */
+    public onRunEnd(): void {
+        this.awaitingInput = false;
+        // If the finished run produced no turtle output, drop the (stale) Turtle tab
+        // selection so the tab bar hides. A manual selection is preserved.
+        if (this.activeOutputTab === TURTLE_TAB && !this.hasTurtleOutput && !this.outputTabManuallySet) {
+            this.activeOutputTab = OUTPUT_TAB;
+        }
     }
 
     public logError(error: FriendlyError | string): void {

--- a/src/frontend/state/Papyros.ts
+++ b/src/frontend/state/Papyros.ts
@@ -5,13 +5,23 @@ import { InputOutput } from "./InputOutput";
 import { Constants } from "./Constants";
 import { Examples } from "./Examples";
 import { BackendManager } from "../../communication/BackendManager";
+import { EventBus } from "../../communication/EventBus";
 import { Channel, makeChannel } from "../../sync/channel";
 import { ProgrammingLanguage } from "../../ProgrammingLanguage";
 import { I18n } from "./I18n";
 import { Test } from "./Test";
 import { PapyrosLaunchError, ServiceWorkerRegistrationError } from "./PapyrosErrors";
 
+/**
+ * In flight service worker registrations, shared between instances: a page can only
+ * have one registration per scope anyway, so instances wait on the same promise
+ * instead of racing the browser. Failed registrations are removed so they can retry.
+ */
+const serviceWorkerRegistrations: Map<string, Promise<ServiceWorkerRegistration>> = new Map();
+
 export class Papyros extends State {
+    // The bus is declared first so the states below can subscribe to it while constructing
+    readonly events: EventBus = new EventBus();
     readonly debugger: Debugger = new Debugger(this);
     readonly runner: Runner = new Runner(this);
     readonly io: InputOutput = new InputOutput(this);
@@ -25,7 +35,12 @@ export class Papyros extends State {
     serviceWorkerName: string = "InputServiceWorker.js";
 
     /**
-     * In flight channel setup, so concurrent callers register the service worker once
+     * The channel this instance's backends read their input from, when they need one
+     */
+    public channel: Channel | null = null;
+
+    /**
+     * In flight channel setup, so concurrent callers build the channel once
      */
     private channelPromise?: Promise<Channel | null>;
 
@@ -49,6 +64,16 @@ export class Papyros extends State {
             }
         }
         return this;
+    }
+
+    /**
+     * Release the resources held by this instance: its workers are terminated and
+     * in flight launches are abandoned. The instance cannot run code afterwards.
+     */
+    public dispose(): void {
+        this.runner.dispose();
+        // Drops any pending frame flush timer
+        this.debugger.reset();
     }
 
     /**
@@ -89,7 +114,7 @@ export class Papyros extends State {
      * @return {Promise<boolean>} Whether a channel is available
      */
     public async ensureChannel(): Promise<boolean> {
-        if (BackendManager.channel) {
+        if (this.channel) {
             return true;
         }
         this.channelPromise ??= this.createChannel();
@@ -98,8 +123,8 @@ export class Papyros extends State {
 
     private async createChannel(): Promise<Channel | null> {
         if (typeof SharedArrayBuffer !== "undefined") {
-            BackendManager.channel = makeChannel({ atomics: {} })!;
-            return BackendManager.channel;
+            this.channel = makeChannel({ atomics: {} })!;
+            return this.channel;
         }
         if (!this.serviceWorkerName || !("serviceWorker" in navigator)) {
             this.errorHandler(
@@ -110,20 +135,32 @@ export class Papyros extends State {
             return null;
         }
         try {
-            const registration = await navigator.serviceWorker.register(this.serviceWorkerName, { scope: "/" });
-            await this.waitForActiveRegistration();
+            const registration = await this.registerServiceWorker();
             // The channel's scope becomes the base of a synchronous XHR inside the worker;
             // a relative scope resolves against the worker's own base URL, which is opaque
             // in a worker bootstrapped from a blob (see BackendManager.setWorkerUrl), so
             // registration.scope (an absolute URL) is used instead
-            BackendManager.channel = makeChannel({ serviceWorker: { scope: registration.scope } })!;
-            return BackendManager.channel;
+            this.channel = makeChannel({ serviceWorker: { scope: registration.scope } })!;
+            return this.channel;
         } catch (e) {
             this.errorHandler(new ServiceWorkerRegistrationError("Error registering service worker", { cause: e }));
             // Allow a later backend to try again rather than caching the failure forever
             this.channelPromise = undefined;
             return null;
         }
+    }
+
+    private registerServiceWorker(): Promise<ServiceWorkerRegistration> {
+        let registration = serviceWorkerRegistrations.get(this.serviceWorkerName);
+        if (!registration) {
+            registration = navigator.serviceWorker.register(this.serviceWorkerName, { scope: "/" }).then(async (r) => {
+                await this.waitForActiveRegistration();
+                return r;
+            });
+            registration.catch(() => serviceWorkerRegistrations.delete(this.serviceWorkerName));
+            serviceWorkerRegistrations.set(this.serviceWorkerName, registration);
+        }
+        return registration;
     }
 
     private async waitForActiveRegistration(timeout: number = 5000): Promise<void> {

--- a/src/frontend/state/Runner.ts
+++ b/src/frontend/state/Runner.ts
@@ -169,17 +169,68 @@ export class Runner extends State {
      */
     private papyros: Papyros;
 
+    /**
+     * The live backend client per language, owned by this instance
+     */
+    private clients: Map<ProgrammingLanguage, SyncClient<Backend>> = new Map();
+    /**
+     * Per-instance factory overrides, so tests can inject a backend without
+     * touching the static registry shared by every instance
+     */
+    private backendCreators: Map<ProgrammingLanguage, () => SyncClient<Backend>> = new Map();
+    /**
+     * Tracks which workers have completed their launch call, so relaunching a live
+     * client is free. Keyed by the Worker itself: an interrupt that replaces the
+     * worker automatically invalidates the entry.
+     */
+    private launched: WeakMap<object, Promise<void>> = new WeakMap();
+
     constructor(papyros: Papyros) {
         super();
         this.papyros = papyros;
         this.backend = Promise.resolve({} as SyncClient<Backend>);
 
-        BackendManager.subscribe(BackendEventType.Input, () => this.setState(RunState.AwaitingInput));
-        BackendManager.subscribe(BackendEventType.Loading, (e) => this.onLoad(e));
-        BackendManager.subscribe(BackendEventType.Start, (e) => this.onStart(e));
-        BackendManager.subscribe(BackendEventType.End, (e) => this.onEnd(e));
-        BackendManager.subscribe(BackendEventType.Error, () => this.onError());
-        BackendManager.subscribe(BackendEventType.Stop, () => this.stop());
+        this.papyros.events.subscribe(BackendEventType.Input, () => this.setState(RunState.AwaitingInput));
+        this.papyros.events.subscribe(BackendEventType.Loading, (e) => this.onLoad(e));
+        this.papyros.events.subscribe(BackendEventType.Start, (e) => this.onStart(e));
+        this.papyros.events.subscribe(BackendEventType.End, (e) => this.onEnd(e));
+        this.papyros.events.subscribe(BackendEventType.Error, () => this.onError());
+    }
+
+    /**
+     * Use a custom backend for the given language on this instance only
+     * @param {ProgrammingLanguage} language The language to override
+     * @param {Function} backendCreator The constructor for a SyncClient
+     */
+    public registerBackend(language: ProgrammingLanguage, backendCreator: () => SyncClient<Backend>): void {
+        this.backendCreators.set(language, backendCreator);
+        this.clients.delete(language);
+    }
+
+    private getClient(language: ProgrammingLanguage): SyncClient<Backend> {
+        let client = this.clients.get(language);
+        if (!client) {
+            const create = this.backendCreators.get(language);
+            client = create ? create() : BackendManager.createBackend(language);
+            this.clients.set(language, client);
+        }
+        return client;
+    }
+
+    /**
+     * Terminate every worker this instance started and abandon in flight launches
+     */
+    public dispose(): void {
+        this.launchId++;
+        this.backendReady = false;
+        for (const client of this.clients.values()) {
+            try {
+                client.terminate();
+            } catch {
+                // An injected or never-started client has no worker to terminate
+            }
+        }
+        this.clients.clear();
     }
 
     /**
@@ -202,7 +253,7 @@ export class Runner extends State {
         this.setState(RunState.Loading);
         this.backendReady = false;
         const launchId = ++this.launchId;
-        const backend = BackendManager.getBackend(this.programmingLanguage);
+        const backend = this.getClient(this.programmingLanguage);
         // Expose the promise before it settles so runs can already be queued while downloading
         const backendLaunched = this.launchBackend(backend, launchId);
         this.backend = backendLaunched;
@@ -218,13 +269,29 @@ export class Runner extends State {
     }
 
     private async launchBackend(backend: SyncClient<Backend>, launchId: number): Promise<SyncClient<Backend>> {
-        // Allow passing messages between worker and main thread
-        await backend.workerProxy.launch(
-            proxy((e: BackendEvent) => BackendManager.publish(e)),
-            this.pyodideAssetURL,
-            this.allowJspi,
-        );
-        backend.usesPromiseTransport = await backend.workerProxy.usesJspi();
+        // An injected test double has no worker, so fall back to keying on the client
+        const worker: object = backend.worker ?? backend;
+        let launched = this.launched.get(worker);
+        if (!launched) {
+            // Allow passing messages between worker and main thread
+            launched = backend.workerProxy
+                .launch(
+                    proxy((e: BackendEvent) => this.papyros.events.publish(e)),
+                    this.pyodideAssetURL,
+                    this.allowJspi,
+                )
+                .then(async () => {
+                    backend.usesPromiseTransport = await backend.workerProxy.usesJspi();
+                });
+            this.launched.set(worker, launched);
+        }
+        try {
+            await launched;
+        } catch (error) {
+            // Let a retry attempt the launch again instead of replaying this failure
+            this.launched.delete(worker);
+            throw error;
+        }
         if (!backend.usesPromiseTransport) {
             // This backend blocks on the channel, so it needs one to exist before it runs.
             // Registration may not have happened yet: Papyros defers it when the browser
@@ -234,7 +301,7 @@ export class Runner extends State {
             await this.papyros.ensureChannel();
         }
         // Assign either way, so a client that switched to JSPI drops a channel it no longer uses
-        backend.channel = BackendManager.channel;
+        backend.channel = this.papyros.channel;
         if (launchId === this.launchId) {
             this.updateRunModes();
             this.backendReady = true;
@@ -254,11 +321,8 @@ export class Runner extends State {
         this.setState(RunState.Loading);
         // Ensure we go back to Loading after finishing any remaining installs
         this.previousState = RunState.Loading;
-        BackendManager.publish({
-            type: BackendEventType.Start,
-            data: "StartClicked",
-            contentType: "text/plain",
-        });
+        this.papyros.io.reset();
+        this.papyros.debugger.onRunStart();
         let interrupted = false;
         let terminated = false;
         const backend = await this.backend;
@@ -277,15 +341,12 @@ export class Runner extends State {
                 terminated = true;
             } else {
                 this.papyros.io.logError(error);
-                BackendManager.publish({
-                    type: BackendEventType.End,
-                    data: "RunError",
-                    contentType: "text/plain",
-                });
+                this.papyros.io.onRunEnd();
+                this.papyros.debugger.onRunEnd();
             }
         } finally {
             if (this.state === RunState.Stopping) {
-                // Was interrupted, End message already published
+                // stop() already closed the input prompt and flushed the debugger
                 interrupted = true;
             }
             if (terminated) {
@@ -308,11 +369,8 @@ export class Runner extends State {
      */
     public async stop(): Promise<void> {
         this.setState(RunState.Stopping);
-        BackendManager.publish({
-            type: BackendEventType.End,
-            data: "User cancelled run",
-            contentType: "text/plain",
-        });
+        this.papyros.io.onRunEnd();
+        this.papyros.debugger.onRunEnd();
         const backend = await this.backend;
         await backend.interrupt();
 
@@ -394,7 +452,7 @@ export class Runner extends State {
         if (fileNames.length === 0) {
             return;
         }
-        BackendManager.publish({
+        this.onLoad({
             type: BackendEventType.Loading,
             data: JSON.stringify({
                 modules: fileNames,

--- a/src/frontend/state/Runner.ts
+++ b/src/frontend/state/Runner.ts
@@ -184,6 +184,11 @@ export class Runner extends State {
      * worker automatically invalidates the entry.
      */
     private launched: WeakMap<object, Promise<void>> = new WeakMap();
+    /**
+     * Whether dispose() ran. Disposing during an active run makes that run fail as
+     * interrupted, which normally relaunches the worker; this suppresses it.
+     */
+    private disposed: boolean = false;
 
     constructor(papyros: Papyros) {
         super();
@@ -218,9 +223,11 @@ export class Runner extends State {
     }
 
     /**
-     * Terminate every worker this instance started and abandon in flight launches
+     * Terminate every worker this instance started and abandon in flight launches.
+     * The runner cannot launch again afterwards.
      */
     public dispose(): void {
+        this.disposed = true;
         this.launchId++;
         this.backendReady = false;
         for (const client of this.clients.values()) {
@@ -250,6 +257,11 @@ export class Runner extends State {
      * Start the backend to enable running code
      */
     public async launch(): Promise<void> {
+        if (this.disposed) {
+            // Terminating a worker mid-run fails that run as interrupted, which
+            // would relaunch the worker here and leak what dispose() just released
+            return;
+        }
         this.setState(RunState.Loading);
         this.backendReady = false;
         const launchId = ++this.launchId;

--- a/src/frontend/state/Runner.ts
+++ b/src/frontend/state/Runner.ts
@@ -464,12 +464,14 @@ export class Runner extends State {
         if (fileNames.length === 0) {
             return;
         }
+        // parseData hands application/json data over as-is, so it must be the object
         this.onLoad({
             type: BackendEventType.Loading,
-            data: JSON.stringify({
+            data: {
                 modules: fileNames,
                 status: "loading",
-            }),
+            },
+            contentType: "application/json",
         });
 
         const backend = await this.backend;

--- a/test/__tests__/BackendManager.test.ts
+++ b/test/__tests__/BackendManager.test.ts
@@ -2,39 +2,31 @@ import { ProgrammingLanguage } from "../../src/ProgrammingLanguage";
 import { BackendManager } from "../../src/communication/BackendManager";
 // eslint-disable-next-line jest/no-mocks-import
 import { MockBackend } from "../__mocks__/MockBackend";
-import { BackendEvent, BackendEventType } from "../../src/communication/BackendEvent";
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 
-function registerMock(language: ProgrammingLanguage): void {
-    BackendManager.registerBackend(language, () => {
-        return { workerProxy: new MockBackend() } as any;
-    });
-}
-
 describe("BackendManager", () => {
-    beforeEach(() => {
-        registerMock(ProgrammingLanguage.JavaScript);
-    });
-
     it("can register a backend", () => {
-        expect(BackendManager.getBackend(ProgrammingLanguage.JavaScript)).toBeTruthy();
+        BackendManager.registerBackend(ProgrammingLanguage.JavaScript, () => {
+            return { workerProxy: new MockBackend() } as any;
+        });
+        expect(BackendManager.createBackend(ProgrammingLanguage.JavaScript)).toBeTruthy();
     });
 
-    it("properly implements PubSub", async () => {
-        const events: Array<BackendEvent> = [];
-        const backend = BackendManager.getBackend(ProgrammingLanguage.JavaScript);
-        const eventHandler = vi.fn((e: BackendEvent) => BackendManager.publish(e));
-        const eventProcessor = vi.fn((e: BackendEvent) => events.push(e));
-        BackendManager.subscribe(BackendEventType.Output, eventProcessor);
-        await backend.workerProxy.launch(eventHandler);
-        await backend.workerProxy.lintCode("");
-        expect(eventHandler).toBeCalled();
-        expect(eventProcessor).toBeCalled();
-        expect(events.length).toEqual(1);
+    it("creates a fresh client per call", () => {
+        BackendManager.registerBackend(ProgrammingLanguage.JavaScript, () => {
+            return { workerProxy: new MockBackend() } as any;
+        });
+        const first = BackendManager.createBackend(ProgrammingLanguage.JavaScript);
+        const second = BackendManager.createBackend(ProgrammingLanguage.JavaScript);
+        expect(first).not.toBe(second);
     });
 
     it("can remove a backend", () => {
+        BackendManager.registerBackend(ProgrammingLanguage.JavaScript, () => {
+            return { workerProxy: new MockBackend() } as any;
+        });
         expect(BackendManager.removeBackend(ProgrammingLanguage.JavaScript)).toEqual(true);
+        expect(() => BackendManager.createBackend(ProgrammingLanguage.JavaScript)).toThrow("not yet supported");
     });
 });
 
@@ -55,7 +47,7 @@ describe("BackendManager.setWorkerUrl", () => {
     });
 
     it("falls back to the default Worker when no URL is set for the language", () => {
-        BackendManager.getBackend(ProgrammingLanguage.Python);
+        BackendManager.createBackend(ProgrammingLanguage.Python);
         expect(workerSpy).toBeCalled();
 
         const [bundledUrl] = workerSpy.mock.calls[0];
@@ -66,14 +58,14 @@ describe("BackendManager.setWorkerUrl", () => {
     it("constructs the real Worker directly for a same-origin URL", () => {
         const sameOriginUrl = new URL("/same-origin-worker.js", window.location.href);
         BackendManager.setWorkerUrl(ProgrammingLanguage.Python, sameOriginUrl);
-        BackendManager.getBackend(ProgrammingLanguage.Python);
+        BackendManager.createBackend(ProgrammingLanguage.Python);
         expect(workerSpy).toBeCalledWith(sameOriginUrl, { type: "module" });
     });
 
     it("bootstraps a cross-origin URL through a same-origin blob module", async () => {
         const crossOriginUrl = "https://cross-origin.example.com/worker.js";
         BackendManager.setWorkerUrl(ProgrammingLanguage.Python, crossOriginUrl);
-        BackendManager.getBackend(ProgrammingLanguage.Python);
+        BackendManager.createBackend(ProgrammingLanguage.Python);
         expect(workerSpy).toBeCalledTimes(1);
 
         const [blobUrl, options] = workerSpy.mock.calls[0];
@@ -82,16 +74,5 @@ describe("BackendManager.setWorkerUrl", () => {
 
         const blobContent = await (await fetch(blobUrl as string)).text();
         expect(blobContent).toBe(`import ${JSON.stringify(crossOriginUrl)};`);
-    });
-
-    it("drops the cached client for the language so the next getBackend picks up the new URL", () => {
-        const creator = vi.fn(() => ({ workerProxy: new MockBackend() }) as any);
-        BackendManager.registerBackend(ProgrammingLanguage.JavaScript, creator);
-        BackendManager.getBackend(ProgrammingLanguage.JavaScript);
-        expect(creator).toBeCalledTimes(1);
-
-        BackendManager.setWorkerUrl(ProgrammingLanguage.JavaScript, "https://cross-origin.example.com/worker.js");
-        BackendManager.getBackend(ProgrammingLanguage.JavaScript);
-        expect(creator).toBeCalledTimes(2);
     });
 });

--- a/test/__tests__/EventBus.test.ts
+++ b/test/__tests__/EventBus.test.ts
@@ -1,0 +1,54 @@
+import { EventBus } from "../../src/communication/EventBus";
+import { BackendEvent, BackendEventType } from "../../src/communication/BackendEvent";
+import { describe, expect, it, vi } from "vitest";
+
+const output = (data: string): BackendEvent => ({ type: BackendEventType.Output, data, contentType: "text/plain" });
+
+describe("EventBus", () => {
+    it("delivers events to subscribers of their type", () => {
+        const bus = new EventBus();
+        const onOutput = vi.fn();
+        const onError = vi.fn();
+        bus.subscribe(BackendEventType.Output, onOutput);
+        bus.subscribe(BackendEventType.Error, onError);
+
+        bus.publish(output("hello"));
+
+        expect(onOutput).toHaveBeenCalledWith(output("hello"));
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    it("subscribes a listener only once", () => {
+        const bus = new EventBus();
+        const listener = vi.fn();
+        bus.subscribe(BackendEventType.Output, listener);
+        bus.subscribe(BackendEventType.Output, listener);
+
+        bus.publish(output("once"));
+
+        expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops delivering after unsubscribing", () => {
+        const bus = new EventBus();
+        const listener = vi.fn();
+        const unsubscribe = bus.subscribe(BackendEventType.Output, listener);
+
+        bus.publish(output("first"));
+        unsubscribe();
+        bus.publish(output("second"));
+
+        expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps instances isolated from each other", () => {
+        const first = new EventBus();
+        const second = new EventBus();
+        const listener = vi.fn();
+        first.subscribe(BackendEventType.Output, listener);
+
+        second.publish(output("elsewhere"));
+
+        expect(listener).not.toHaveBeenCalled();
+    });
+});

--- a/test/__tests__/state/Channel.test.ts
+++ b/test/__tests__/state/Channel.test.ts
@@ -1,20 +1,13 @@
-import { describe, expect, it, beforeEach } from "vitest";
+import { describe, expect, it } from "vitest";
 import { Papyros } from "../../../src/frontend/state/Papyros";
 import { ProgrammingLanguage } from "../../../src/ProgrammingLanguage";
-import { BackendManager } from "../../../src/communication/BackendManager";
 import { waitForInputReady, waitForOutput, waitForPapyrosReady } from "../../helpers";
 
 /**
- * BackendManager.channel is static and shared, and BackendManager caches one client per
- * language, so clear the channel to observe what a launch actually needed rather than what an
- * earlier test left behind. Runner.launch assigns backend.channel on every launch, including
- * setting it back to null, so the cached client cannot carry a stale channel into these tests.
+ * The channel and the backend clients are owned by the instance, so a fresh Papyros
+ * per test observes what its own launch actually needed.
  */
 describe.sequential("lazy channel setup", () => {
-    beforeEach(() => {
-        BackendManager.channel = null;
-    });
-
     it("does not build a channel for python when the stack can be suspended", async () => {
         const papyros = new Papyros();
         await papyros.launch();
@@ -22,7 +15,7 @@ describe.sequential("lazy channel setup", () => {
         const backend = await papyros.runner.backend;
 
         expect(backend.usesPromiseTransport).toBe(true);
-        expect(BackendManager.channel).toBeNull();
+        expect(papyros.channel).toBeNull();
         expect(backend.channel).toBeNull();
     }, 180000);
 
@@ -34,8 +27,8 @@ describe.sequential("lazy channel setup", () => {
         const backend = await papyros.runner.backend;
 
         expect(backend.usesPromiseTransport).toBe(false);
-        expect(BackendManager.channel).not.toBeNull();
-        expect(backend.channel).toBe(BackendManager.channel);
+        expect(papyros.channel).not.toBeNull();
+        expect(backend.channel).toBe(papyros.channel);
     }, 180000);
 
     it("builds a channel when javascript is selected, and input still works", async () => {
@@ -45,7 +38,7 @@ describe.sequential("lazy channel setup", () => {
         const backend = await papyros.runner.backend;
 
         expect(backend.usesPromiseTransport).toBe(false);
-        expect(BackendManager.channel).not.toBeNull();
+        expect(papyros.channel).not.toBeNull();
 
         papyros.runner.code = 'console.log("hello", prompt("name?"));';
         await waitForInputReady();

--- a/test/__tests__/state/Jspi.test.ts
+++ b/test/__tests__/state/Jspi.test.ts
@@ -18,8 +18,7 @@ async function pythonPapyros(allowJspi: boolean = true): Promise<Papyros> {
     papyros.runner.allowJspi = allowJspi;
     await papyros.launch();
     papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
-    // BackendManager caches one client per language, so let this launch settle before
-    // the test uses it rather than racing whatever a previous test left in flight
+    // Let the launch settle before the test uses the client
     await papyros.runner.backend;
     return papyros;
 }
@@ -148,7 +147,7 @@ describe.sequential("JSPI input transport", () => {
             // Pyodide startup dominates on CI, so wait for the loop rather than guessing a delay
             await waitForRunning(papyros);
         } finally {
-            // Never leave the shared backend spinning, it would hang every later test
+            // Never leave a worker spinning, it would slow down every later test
             await papyros.runner.stop();
             await runPromise;
         }
@@ -156,7 +155,7 @@ describe.sequential("JSPI input transport", () => {
         expect(papyros.runner.stateMessage).toMatch(/^Code interrupted after/);
         expect(papyros.runner.backend).not.toBe(backendBefore);
         // Interrupting terminated the worker, and the relaunch is not awaited by start().
-        // Drain it, or it races the next test's launch on the same cached client.
+        // Drain it, so the test does not finish with a launch still in flight.
         await papyros.runner.backend;
     }, 180000);
 });

--- a/test/__tests__/state/LaunchFailure.test.ts
+++ b/test/__tests__/state/LaunchFailure.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { Papyros } from "../../../src/frontend/state/Papyros";
 import { ProgrammingLanguage } from "../../../src/ProgrammingLanguage";
-import { BackendManager } from "../../../src/communication/BackendManager";
 import { RunState } from "../../../src/frontend/state/Runner";
 import { PapyrosLaunchError } from "../../../src/frontend/state/PapyrosErrors";
 
@@ -16,7 +15,10 @@ function withTimeout<T>(promise: Promise<T>, ms: number, what: string): Promise<
 
 describe("Papyros launch failure", () => {
     it("surfaces a failed backend launch instead of hanging", async () => {
-        BackendManager.registerBackend(
+        vi.spyOn(window, "confirm").mockReturnValue(false);
+
+        const papyros = new Papyros();
+        papyros.runner.registerBackend(
             ProgrammingLanguage.Python,
             () =>
                 ({
@@ -25,9 +27,6 @@ describe("Papyros launch failure", () => {
                     },
                 }) as any,
         );
-        vi.spyOn(window, "confirm").mockReturnValue(false);
-
-        const papyros = new Papyros();
         const errorHandler = vi.fn();
         papyros.setErrorHandler(errorHandler);
 

--- a/test/__tests__/state/MultiInstance.test.ts
+++ b/test/__tests__/state/MultiInstance.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { Papyros } from "../../../src/frontend/state/Papyros";
 import { ProgrammingLanguage } from "../../../src/ProgrammingLanguage";
 import { BackendEventType } from "../../../src/communication/BackendEvent";
-import { waitForInputReady, waitForOutput, waitForPapyrosReady } from "../../helpers";
+import { waitForInputReady, waitForOutput, waitForPapyrosReady, waitForRunning } from "../../helpers";
 
 async function javascriptPapyros(): Promise<Papyros> {
     const papyros = new Papyros();
@@ -73,6 +73,20 @@ describe.sequential("multiple Papyros instances", () => {
         expect(second.io.output).toEqual([]);
         first.dispose();
         second.dispose();
+    }, 180000);
+
+    it("do not relaunch a worker that is disposed during an active run", async () => {
+        const papyros = await javascriptPapyros();
+        papyros.runner.code = "while (true) {}";
+        const runPromise = papyros.runner.start();
+        await waitForRunning(papyros);
+
+        // Terminating the busy worker fails the run as interrupted, which used to
+        // make start() boot a replacement worker for the freshly disposed instance
+        papyros.dispose();
+        await runPromise;
+
+        expect(papyros.runner.backendReady).toBe(false);
     }, 180000);
 
     it("keep working after another instance is disposed", async () => {

--- a/test/__tests__/state/MultiInstance.test.ts
+++ b/test/__tests__/state/MultiInstance.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { Papyros } from "../../../src/frontend/state/Papyros";
+import { ProgrammingLanguage } from "../../../src/ProgrammingLanguage";
+import { BackendEventType } from "../../../src/communication/BackendEvent";
+import { waitForInputReady, waitForOutput, waitForPapyrosReady } from "../../helpers";
+
+async function javascriptPapyros(): Promise<Papyros> {
+    const papyros = new Papyros();
+    // Selecting the language before launching keeps the default Python backend
+    // from booting at all: only the JavaScript worker is ever started
+    papyros.runner.programmingLanguage = ProgrammingLanguage.JavaScript;
+    await papyros.launch();
+    await papyros.runner.backend;
+    return papyros;
+}
+
+describe.sequential("multiple Papyros instances", () => {
+    it("run the same language concurrently with isolated output", async () => {
+        const first = await javascriptPapyros();
+        const second = await javascriptPapyros();
+
+        first.runner.code = 'console.log("from first");';
+        second.runner.code = 'console.log("from second");';
+        await Promise.all([first.runner.start(), second.runner.start()]);
+        await waitForOutput(first);
+        await waitForOutput(second);
+
+        expect(first.io.output[0].content).toBe("from first\n");
+        expect(second.io.output[0].content).toBe("from second\n");
+        first.dispose();
+        second.dispose();
+    }, 180000);
+
+    it("read input through their own channels", async () => {
+        const first = await javascriptPapyros();
+        const second = await javascriptPapyros();
+        expect(first.channel).not.toBeNull();
+        expect(second.channel).not.toBeNull();
+        expect(first.channel).not.toBe(second.channel);
+
+        first.runner.code = 'console.log("first", prompt("name?"));';
+        second.runner.code = 'console.log("second", prompt("name?"));';
+        await waitForInputReady();
+        const unsubFirst = first.io.subscribe(
+            () => (first.io.awaitingInput ? first.io.provideInput("one") : ""),
+            "awaitingInput",
+        );
+        const unsubSecond = second.io.subscribe(
+            () => (second.io.awaitingInput ? second.io.provideInput("two") : ""),
+            "awaitingInput",
+        );
+        await Promise.all([first.runner.start(), second.runner.start()]);
+        await waitForOutput(first);
+        await waitForOutput(second);
+        unsubFirst();
+        unsubSecond();
+
+        expect(first.io.output[0].content).toBe("first one\n");
+        expect(second.io.output[0].content).toBe("second two\n");
+        first.dispose();
+        second.dispose();
+    }, 180000);
+
+    it("do not deliver events across instances", async () => {
+        const first = await javascriptPapyros();
+        const second = await javascriptPapyros();
+
+        first.runner.code = 'console.log("only first");';
+        await first.runner.start();
+        await waitForOutput(first);
+        await waitForPapyrosReady(first);
+
+        expect(second.io.output).toEqual([]);
+        first.dispose();
+        second.dispose();
+    }, 180000);
+
+    it("keep working after another instance is disposed", async () => {
+        const disposed = await javascriptPapyros();
+        const survivor = await javascriptPapyros();
+        disposed.dispose();
+
+        // A disposed bus can still receive stragglers without breaking anything
+        disposed.events.publish({ type: BackendEventType.Output, data: "late", contentType: "text/plain" });
+
+        survivor.runner.code = 'console.log("still alive");';
+        await survivor.runner.start();
+        await waitForOutput(survivor);
+
+        expect(survivor.io.output[0].content).toBe("still alive\n");
+        survivor.dispose();
+    }, 180000);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,8 @@ export default defineConfig({
         },
         testTimeout: 100000, // loading pyodide can take a while
         sequence: {
-            // tests within a file share the static BackendManager, so they cannot overlap
+            // Papyros instances are isolated now, but tests within a file still share
+            // the page, its window mocks and the CPU that boots Pyodide
             concurrent: false,
         },
         maxWorkers: 4, // launching pyodide is CPU-bound, more workers do not help


### PR DESCRIPTION
This pull request makes every `new Papyros()` self-contained. `BackendManager` was the last global after #878: one subscriber map, one client cache, one channel and one `halted` flag for the whole page. Each instance now owns its event bus (`papyros.events`), its backend clients and its channel, which is what dodona-edu/dodona#8755 (multiple executable code blocks per description) needs, and what lets tests inject or reuse backends safely. Rebased onto main now that #1085 and #1086 are in.

**What moved where**

- `EventBus` is a new instance-scoped pub/sub whose `subscribe` returns an unsubscribe function. Nothing accumulates across instances anymore, and components (`p-code-editor`) unsubscribe on disconnect.
- `BackendManager` keeps only the static registration config (language to worker factory). Clients are created per instance by `Runner`, and `runner.registerBackend` overrides the factory per instance, so `LaunchFailure.test.ts` no longer mutates global state to inject its fake.
- The channel is `papyros.channel`. The one service worker registration a page can have is shared between instances through a module-level promise; each instance builds its own channel on top of it.
- Frontend-originated events no longer ride the bus. `start()` and `stop()` call `io.reset()`, `io.onRunEnd()`, `debugger.onRunStart()` and `debugger.onRunEnd()` directly, so the `halted` gate and its FrameChange/Files exemptions are deleted. The `Stop` and `FrameChange` event types had no publisher anywhere (and `BackendManager` was never part of the public API, so Dodona cannot be publishing them) and are removed.
- `launch()` is idempotent per worker: relaunching a live client is a cache hit, and language switches reuse live clients. The launch cache is keyed on the `Worker` itself, so an interrupt that replaces the worker invalidates it by construction.
- `dispose()` terminates an instance's workers, for Turbo-navigated pages that tear blocks down and recreate them.

**Deliberate behavior change**

Output the worker had already buffered when the user pressed stop is now delivered instead of dropped, since the `halted` gate that suppressed it is gone. The interrupt itself still surfaces as the usual "Code interrupted" state, not as an error.

**Manual testing instructions**

- `yarn setup && yarn build:sw && yarn start`
- Run a Python program with `input()`, answer it, stop a `while True: pass` loop, and switch to JavaScript and back: everything behaves as before.
- The `papyros` singleton export is unchanged, it is simply a default instance now.

**Verification**

| Check | Result |
|---|---|
| `yarn vitest --run` | 20 files / 161 tests, green |
| `yarn typecheck` | clean |
| `yarn lint` | clean |

**Checklist**
- Tests: new `EventBus.test.ts` (delivery, dedupe, unsubscribe, instance isolation) and `MultiInstance.test.ts` (two instances run the same language concurrently with isolated output, per-instance channels over the shared service worker registration, cross-instance event isolation, dispose). Channel/LaunchFailure/Jspi/BackendManager tests updated for instance scoping.
- Docs: README gains a "Multiple instances" section and documents `papyros.events`.
- Announcement: n/a
- AI: Claude Code wrote the implementation and the tests

Closes #1105

