### PR TITLE
Spawn a fresh worker after a failed backend launch

### DIFF
--- a/src/frontend/state/Runner.ts
+++ b/src/frontend/state/Runner.ts
@@ -307,10 +307,12 @@ export class Runner extends State {
         } catch (error) {
             // Let a retry attempt the launch again instead of replaying this failure
             this.launched.delete(worker);
-            if (launchId === this.launchId) {
+            if (this.clients.get(language) === backend) {
                 // The module map of the failed worker keeps the failed import, so retrying in
                 // it fails the same way: drop the client so the next launch spawns a fresh
-                // worker. A superseded launch must leave the newer client alone.
+                // worker. Keyed on the client rather than on launchId, so a launch a language
+                // switch superseded is cleaned up too, while a client already replaced for this
+                // language is left alone.
                 this.clients.delete(language);
                 try {
                     backend.terminate();

--- a/src/frontend/state/Runner.ts
+++ b/src/frontend/state/Runner.ts
@@ -265,9 +265,10 @@ export class Runner extends State {
         this.setState(RunState.Loading);
         this.backendReady = false;
         const launchId = ++this.launchId;
-        const backend = this.getClient(this.programmingLanguage);
+        const language = this.programmingLanguage;
+        const backend = this.getClient(language);
         // Expose the promise before it settles so runs can already be queued while downloading
-        const backendLaunched = this.launchBackend(backend, launchId);
+        const backendLaunched = this.launchBackend(language, backend, launchId);
         this.backend = backendLaunched;
         this.setState(RunState.Ready);
         try {
@@ -280,7 +281,11 @@ export class Runner extends State {
         }
     }
 
-    private async launchBackend(backend: SyncClient<Backend>, launchId: number): Promise<SyncClient<Backend>> {
+    private async launchBackend(
+        language: ProgrammingLanguage,
+        backend: SyncClient<Backend>,
+        launchId: number,
+    ): Promise<SyncClient<Backend>> {
         // An injected test double has no worker, so fall back to keying on the client
         const worker: object = backend.worker ?? backend;
         let launched = this.launched.get(worker);
@@ -302,6 +307,17 @@ export class Runner extends State {
         } catch (error) {
             // Let a retry attempt the launch again instead of replaying this failure
             this.launched.delete(worker);
+            if (launchId === this.launchId) {
+                // The module map of the failed worker keeps the failed import, so retrying in
+                // it fails the same way: drop the client so the next launch spawns a fresh
+                // worker. A superseded launch must leave the newer client alone.
+                this.clients.delete(language);
+                try {
+                    backend.terminate();
+                } catch {
+                    // An injected or never-started client has no worker to terminate
+                }
+            }
             throw error;
         }
         if (!backend.usesPromiseTransport) {

--- a/test/__tests__/state/LaunchFailure.test.ts
+++ b/test/__tests__/state/LaunchFailure.test.ts
@@ -3,6 +3,8 @@ import { Papyros } from "../../../src/frontend/state/Papyros";
 import { ProgrammingLanguage } from "../../../src/ProgrammingLanguage";
 import { RunState } from "../../../src/frontend/state/Runner";
 import { PapyrosLaunchError } from "../../../src/frontend/state/PapyrosErrors";
+// eslint-disable-next-line jest/no-mocks-import
+import { MockBackend } from "../../__mocks__/MockBackend";
 
 // Fails fast instead of letting a regression hit the suite timeout
 function withTimeout<T>(promise: Promise<T>, ms: number, what: string): Promise<T> {
@@ -43,5 +45,44 @@ describe("Papyros launch failure", () => {
         await expect(withTimeout(papyros.runner.backend, 2000, "runner.backend")).rejects.toThrow(
             "worker failed to start",
         );
+    });
+
+    it("launches a fresh backend after a failed one", async () => {
+        vi.spyOn(window, "confirm").mockReturnValue(false);
+
+        const terminate = vi.fn();
+        const creator = vi
+            .fn()
+            .mockImplementationOnce(
+                () =>
+                    ({
+                        workerProxy: {
+                            launch: () => Promise.reject(new Error("worker failed to start")),
+                        },
+                        terminate,
+                    }) as any,
+            )
+            .mockImplementationOnce(() => ({ workerProxy: new MockBackend() }) as any);
+
+        const papyros = new Papyros();
+        papyros.runner.registerBackend(ProgrammingLanguage.Python, creator);
+        papyros.setErrorHandler(vi.fn());
+
+        await withTimeout(papyros.launch(), 2000, "Papyros.launch()");
+
+        expect(creator).toHaveBeenCalledOnce();
+        expect(terminate).toHaveBeenCalledOnce();
+        expect(papyros.runner.state).toBe(RunState.Error);
+        expect(papyros.runner.backendReady).toBe(false);
+
+        // A longer budget than the failed launch: this one reaches ensureChannel, which may
+        // register the input service worker
+        await withTimeout(papyros.runner.launch(), 10000, "runner.launch() retry");
+
+        expect(creator).toHaveBeenCalledTimes(2);
+        expect(papyros.runner.state).toBe(RunState.Ready);
+        expect(papyros.runner.backendReady).toBe(true);
+
+        papyros.dispose();
     });
 });

--- a/test/__tests__/state/LaunchFailure.test.ts
+++ b/test/__tests__/state/LaunchFailure.test.ts
@@ -85,4 +85,53 @@ describe("Papyros launch failure", () => {
 
         papyros.dispose();
     });
+    it("cleans up a failed launch that a language switch superseded", async () => {
+        vi.spyOn(window, "confirm").mockReturnValue(false);
+
+        const terminate = vi.fn();
+        let failLaunch: (error: Error) => void;
+        const working = (): any =>
+            ({
+                workerProxy: {
+                    launch: () => Promise.resolve(),
+                    usesJspi: () => Promise.resolve(true),
+                    runModes: () => Promise.resolve([]),
+                },
+            }) as any;
+        const pythonCreator = vi
+            .fn()
+            .mockImplementationOnce(
+                () =>
+                    ({
+                        workerProxy: {
+                            launch: () =>
+                                new Promise((_, reject) => {
+                                    failLaunch = reject;
+                                }),
+                        },
+                        terminate,
+                    }) as any,
+            )
+            .mockImplementationOnce(working);
+
+        const papyros = new Papyros();
+        papyros.setErrorHandler(vi.fn());
+        papyros.runner.registerBackend(ProgrammingLanguage.Python, pythonCreator);
+        papyros.runner.registerBackend(ProgrammingLanguage.JavaScript, working);
+
+        // A Python launch still in flight, superseded by a switch to JavaScript
+        const first = papyros.runner.launch().catch(() => undefined);
+        papyros.runner.programmingLanguage = ProgrammingLanguage.JavaScript;
+        failLaunch!(new Error("worker failed to start"));
+        await withTimeout(first, 2000, "superseded runner.launch()");
+
+        expect(terminate).toHaveBeenCalledOnce();
+
+        // Switching back must not hand out the worker whose module map cached the failure
+        papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+
+        expect(pythonCreator).toHaveBeenCalledTimes(2);
+
+        papyros.dispose();
+    });
 });


### PR DESCRIPTION
Followup from https://github.com/dodona-edu/dodona/pull/8648: a worker that failed to load never would load, until the page got refreshed. This PR now terminates the worker on a failed run, so it gets a fresh worker when trying to restart, to recover from a failed load without having to refresh the page.

<details>

When the backend fails to launch (for example because the Pyodide assets could not be downloaded), `Runner.launchBackend()` evicts its launch memo so a retry runs `workerProxy.launch()` again, but it keeps the same `SyncClient` and `Worker`. The worker's module map already holds the failed `import()` of `pyodide.asm.mjs`, so every retry fails inside that worker until the page is reloaded. This is visible in Dodona's code playground (dodona-edu/dodona#8648): after a failed download the assets re-download fine on the next Run, `pyodide.asm.mjs` is never requested again, and the block keeps reporting "failed to load". `Papyros.launch()`'s confirm-and-relaunch loops the same way.

The runner now drops the failed client from `clients` and terminates its worker (guarded the same way `dispose()` is, since injected clients may have no worker), but only when that launch is still the current one. The next `launch()` therefore goes through `getClient()` and starts a fresh worker, which also covers `start()`'s relaunch after a terminate.

</details>

**Manual testing instructions**
- Open a page that launches papyros (the demo app is fine), block `*/pyodide/*` in devtools' request blocking before the first run, run: the launch fails.
- Remove the blocking rule and run again: on `main` this fails again until a reload; with this change the second run boots Pyodide and runs.

**Checklist**
- Tests: yes, a launch-failure test that asserts the second launch gets a fresh backend and the failed one was terminated
- Docs: n/a
- AI: implemented and verified with Claude
