### PR TITLE
Describe the Escape-then-Tab exit on the code editor

### DIFF
--- a/src/frontend/components/code_mirror/CodeEditor.ts
+++ b/src/frontend/components/code_mirror/CodeEditor.ts
@@ -103,7 +103,7 @@ export class CodeEditor extends CodeMirrorEditor {
                 padding: 0;
                 margin: -1px;
                 overflow: hidden;
-                clip: rect(0, 0, 0, 0);
+                clip-path: inset(50%);
                 white-space: nowrap;
                 border: 0;
             }

--- a/src/frontend/components/code_mirror/CodeEditor.ts
+++ b/src/frontend/components/code_mirror/CodeEditor.ts
@@ -37,7 +37,6 @@ import {
 import readOnlyRangesExtension from "codemirror-readonly-ranges";
 import { BackendEvent, BackendEventType } from "../../../communication/BackendEvent";
 import { Papyros } from "../../state/Papyros";
-import { ESCAPE_HINT } from "../../state/Translations";
 import { parseData } from "../../../util/Util";
 
 const tabCompletionKeyMap = [{ key: "Tab", run: acceptCompletion }];
@@ -142,7 +141,9 @@ export class CodeEditor extends CodeMirrorEditor {
 
     private updateEscapeHint(): void {
         if (this.escapeHintElement && this.view) {
-            this.escapeHintElement.textContent = this.view.state.phrase(ESCAPE_HINT);
+            this.escapeHintElement.textContent = this.view.state.phrase(
+                "Press Escape followed by Tab to leave the code editor.",
+            );
         }
     }
 

--- a/src/frontend/components/code_mirror/CodeEditor.ts
+++ b/src/frontend/components/code_mirror/CodeEditor.ts
@@ -37,9 +37,15 @@ import {
 import readOnlyRangesExtension from "codemirror-readonly-ranges";
 import { BackendEvent, BackendEventType } from "../../../communication/BackendEvent";
 import { Papyros } from "../../state/Papyros";
+import { ESCAPE_HINT } from "../../state/Translations";
 import { parseData } from "../../../util/Util";
 
 const tabCompletionKeyMap = [{ key: "Tab", run: acceptCompletion }];
+// This editor binds Tab to indentation, so Tab no longer moves focus out of it and the way
+// out is CodeMirror's Escape-then-Tab. WCAG 2.1.2 asks that people are advised of such an
+// exit, and aria-describedby only resolves ids in the described element's own tree, so the
+// hint has to sit in this shadow root next to .cm-content.
+const ESCAPE_HINT_ID = "escape-hint";
 // Dispatched to ask the linter to re-run without a document change (see needsRefresh).
 const forceLintEffect = StateEffect.define<null>();
 const languageExtensions: Record<ProgrammingLanguage, LanguageSupport> = {
@@ -89,6 +95,18 @@ export class CodeEditor extends CodeMirrorEditor {
             .papyros-icon-link:hover {
                 color: var(--md-sys-color-primary);
             }
+
+            #escape-hint {
+                position: absolute;
+                width: 1px;
+                height: 1px;
+                padding: 0;
+                margin: -1px;
+                overflow: hidden;
+                clip: rect(0, 0, 0, 0);
+                white-space: nowrap;
+                border: 0;
+            }
         `;
     }
 
@@ -115,6 +133,18 @@ export class CodeEditor extends CodeMirrorEditor {
 
     private _papyros: Papyros | undefined;
     private unsubscribeRelint: (() => void) | undefined;
+    private escapeHintElement: HTMLElement | undefined;
+
+    override set translations(translations: Record<string, string>) {
+        super.translations = translations;
+        this.updateEscapeHint();
+    }
+
+    private updateEscapeHint(): void {
+        if (this.escapeHintElement && this.view) {
+            this.escapeHintElement.textContent = this.view.state.phrase(ESCAPE_HINT);
+        }
+    }
 
     /**
      * The instance whose backend this editor lints against, used to re-lint
@@ -136,12 +166,19 @@ export class CodeEditor extends CodeMirrorEditor {
     public override connectedCallback(): void {
         super.connectedCallback();
         this.subscribeRelint();
+
+        this.escapeHintElement = document.createElement("span");
+        this.escapeHintElement.id = ESCAPE_HINT_ID;
+        this.shadowRoot!.appendChild(this.escapeHintElement);
+        this.updateEscapeHint();
     }
 
     public override disconnectedCallback(): void {
         super.disconnectedCallback();
         this.unsubscribeRelint?.();
         this.unsubscribeRelint = undefined;
+        this.escapeHintElement?.remove();
+        this.escapeHintElement = undefined;
     }
 
     set debugLine(value: number | undefined) {
@@ -282,6 +319,7 @@ export class CodeEditor extends CodeMirrorEditor {
                     ...lintKeymap,
                     indentWithTab,
                 ]),
+                EditorView.contentAttributes.of({ "aria-describedby": ESCAPE_HINT_ID }),
             ],
             debugging: [highlightActiveLineGutter(), lintGutter(), highlightActiveLine()],
         });

--- a/src/frontend/state/Translations.ts
+++ b/src/frontend/state/Translations.ts
@@ -4,10 +4,6 @@
  * enforces both.
  */
 
-// Both the phrase key CodeEditor looks up and its own English value, so the sentence
-// is written once.
-export const ESCAPE_HINT = "Press Escape followed by Tab to leave the code editor.";
-
 export const ENGLISH_TRANSLATION = {
     Papyros: {
         Papyros: "Papyros",
@@ -92,7 +88,8 @@ export const ENGLISH_TRANSLATION = {
     },
     CodeMirror: {
         // Papyros
-        [ESCAPE_HINT]: ESCAPE_HINT,
+        "Press Escape followed by Tab to leave the code editor.":
+            "Press Escape followed by Tab to leave the code editor.",
         // @codemirror/search
         "Go to line": "Go to line",
         go: "OK",
@@ -193,7 +190,8 @@ export const DUTCH_TRANSLATION = {
     },
     CodeMirror: {
         // Papyros
-        [ESCAPE_HINT]: "Druk op Escape en daarna Tab om de code-editor te verlaten.",
+        "Press Escape followed by Tab to leave the code editor.":
+            "Druk op Escape en daarna Tab om de code-editor te verlaten.",
         // @codemirror/view
         "Control character": "Controlekarakter",
         // @codemirror/fold

--- a/src/frontend/state/Translations.ts
+++ b/src/frontend/state/Translations.ts
@@ -3,6 +3,11 @@
  * CodeMirror block, whose English phrases CodeMirror already ships. Translations.test.ts
  * enforces both.
  */
+
+// Both the phrase key CodeEditor looks up and its own English value, so the sentence
+// is written once.
+export const ESCAPE_HINT = "Press Escape followed by Tab to leave the code editor.";
+
 export const ENGLISH_TRANSLATION = {
     Papyros: {
         Papyros: "Papyros",
@@ -86,6 +91,8 @@ export const ENGLISH_TRANSLATION = {
         output_tab_turtle: "Turtle",
     },
     CodeMirror: {
+        // Papyros
+        [ESCAPE_HINT]: ESCAPE_HINT,
         // @codemirror/search
         "Go to line": "Go to line",
         go: "OK",
@@ -185,6 +192,8 @@ export const DUTCH_TRANSLATION = {
         output_tab_turtle: "Turtle",
     },
     CodeMirror: {
+        // Papyros
+        [ESCAPE_HINT]: "Druk op Escape en daarna Tab om de code-editor te verlaten.",
         // @codemirror/view
         "Control character": "Controlekarakter",
         // @codemirror/fold

--- a/test/__tests__/components/CodeEditor.test.ts
+++ b/test/__tests__/components/CodeEditor.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { DUTCH_TRANSLATION, ENGLISH_TRANSLATION } from "../../../src/frontend/state/Translations";
+import type { CodeEditor } from "../../../src/frontend/components/code_mirror/CodeEditor";
+import "../../../src/frontend/components/code_mirror/CodeEditor";
+
+describe("CodeEditor", () => {
+    it("describes how to leave the editor on the editable content", async () => {
+        const element = document.createElement("p-code-editor") as CodeEditor;
+        element.translations = ENGLISH_TRANSLATION.CodeMirror;
+        document.body.append(element);
+        await element.updateComplete;
+
+        const shadowRoot = element.shadowRoot!;
+        const content = shadowRoot.querySelector(".cm-content")!;
+        const hintId = content.getAttribute("aria-describedby")!;
+        expect(hintId).toBeTruthy();
+
+        const hint = shadowRoot.getElementById(hintId);
+        expect(hint?.textContent).toBe("Press Escape followed by Tab to leave the code editor.");
+
+        element.translations = DUTCH_TRANSLATION.CodeMirror;
+        await element.updateComplete;
+        expect(hint?.textContent).toBe("Druk op Escape en daarna Tab om de code-editor te verlaten.");
+
+        element.remove();
+    });
+});


### PR DESCRIPTION
The code editor binds `Tab` to indentation, so `Tab` no longer moves focus out of it. CodeMirror's way out is `Escape` followed by `Tab`, and WCAG 2.1.2 asks that people are advised of such a non-standard exit.

<details>

The editor now renders a visually hidden hint in its own shadow root and points `.cm-content` at it with `EditorView.contentAttributes.of({ "aria-describedby": ... })`, so a screen reader reads it when focus enters the editor. The hint has to live in that shadow root: `aria-describedby` only resolves ids within the tree the described element lives in, so a hint the host page renders next to the editor cannot be associated with the focused element. That is what came out of the accessibility review of dodona-edu/dodona#8648.

It all lives in `CodeEditor`, which is the only editor that binds `Tab`, so it owns the reason, the keymap, the visually hidden rule in its own `static styles` and the `contentAttributes` extension. `CodeMirrorEditor` needed no changes: a subclass can already add extensions through `configure()` and append to the shadow root after `super.connectedCallback()`. `Tab` still moves focus out of the batch input and file editors, where the advice would just be noise, and `indentWithTab` and the keymaps are unchanged.

The phrase goes through the existing `CodeMirror` translations (en and nl), so hosts that already pass `getTranslations("CodeMirror")`, Dodona included, pick it up without changes. It is keyed on its English sentence like the other phrases in that block, so a locale that does not define it falls back to readable English instead of a key.

</details>

**Manual testing instructions**

1. `yarn setup && yarn build:sw && yarn start` and open the demo.
2. Turn on a screen reader (VoiceOver: cmd+F5), tab into the code editor and check that the hint is announced when focus enters it.
3. Without a screen reader: inspect the `p-code-editor` shadow root in devtools, check that `.cm-content` carries `aria-describedby="escape-hint"`, and that `#escape-hint` in the same shadow root holds the hint text and is not visible on screen.
4. Switch the interface language to Dutch and check that the text of that span follows.
5. Check that `Tab` still indents inside the editor, and that `Escape` followed by `Tab` still moves focus out.

**Verification**

| Check | Result |
|---|---|
| `yarn typecheck` | clean |
| `yarn lint` | clean |
| `yarn vitest --run test/__tests__/components test/__tests__/state/Translations.test.ts` | 3 files / 6 tests, green |
| Checked live on the dev server | `.cm-content` resolves `aria-describedby="escape-hint"` in the same shadow root, computed style is 1x1 clipped, and the text follows the locale to Dutch |

**Checklist**
- Tests: new `test/__tests__/components/CodeEditor.test.ts`, which asserts that `.cm-content` is described by an element in the same shadow root and that the text follows the translations
- Docs: n/a
- Announcement: n/a
- AI: implemented with Claude
