### PR TITLE
Drop debug frames that do not belong to the current run

### DIFF
--- a/src/frontend/state/Debugger.ts
+++ b/src/frontend/state/Debugger.ts
@@ -4,6 +4,7 @@ import { State, stateProperty } from "@dodona/lit-state";
 import { Papyros } from "./Papyros";
 import { CODE_TAB, FileEntry, parseFileEntries } from "./InputOutput";
 import { materializeFrame } from "./DebuggerFrames";
+import { parseData } from "../../util/Util";
 export type FrameState = {
     line: number;
     outputs: number;
@@ -28,6 +29,13 @@ export class Debugger extends State {
     private lastMaterializedFrame: Frame | undefined = undefined;
     private flushTimer: ReturnType<typeof setTimeout> | undefined = undefined;
     private runActive: boolean = false;
+    /**
+     * Set from the moment the Runner starts a run until the worker reports that
+     * it began. Frames of the previous run can still be in flight then, and the
+     * worker only sends its start event once it has sent everything before it,
+     * so frames received while this is set never belong to the current run.
+     */
+    private awaitingWorkerStart: boolean = false;
     @stateProperty
     private frameStates: FrameState[] = [];
     @stateProperty
@@ -65,12 +73,22 @@ export class Debugger extends State {
         this.papyros = papyros;
         this.reset();
 
+        this.papyros.events.subscribe(BackendEventType.Start, (e) => {
+            if ((parseData(e.data, e.contentType) as string).includes("RunCode")) {
+                this.awaitingWorkerStart = false;
+                // an end event of the previous run may have arrived in the meantime
+                this.runActive = true;
+            }
+        });
         this.papyros.events.subscribe(BackendEventType.Files, (e) => {
-            if (this._active) {
+            if (this._active && !this.awaitingWorkerStart) {
                 this.fileHistory = [...this.fileHistory, parseFileEntries(e.data, e.contentType)];
             }
         });
         this.papyros.events.subscribe(BackendEventType.Frame, (e) => {
+            if (!this.acceptsFrames()) {
+                return;
+            }
             this.activeFrame ??= 0;
             const frame = materializeFrame(this.lastMaterializedFrame, JSON.parse(e.data));
             this.lastMaterializedFrame = frame;
@@ -106,6 +124,16 @@ export class Debugger extends State {
     public onRunStart(): void {
         this.runActive = true;
         this.reset();
+        this.awaitingWorkerStart = true;
+    }
+
+    /**
+     * Whether a frame received now belongs to the current run: not while the
+     * previous run's frames may still be arriving, and not after the tracer's
+     * uncaught_exception frame, which is always the last one it sends
+     */
+    private acceptsFrames(): boolean {
+        return !this.awaitingWorkerStart && this.lastMaterializedFrame?.event !== "uncaught_exception";
     }
 
     /**

--- a/test/__tests__/state/Debugger.test.ts
+++ b/test/__tests__/state/Debugger.test.ts
@@ -5,6 +5,7 @@ import {RunMode} from "../../../src/backend/Backend";
 import {RunState} from "../../../src/frontend/state/Runner";
 import {NonExceptionFrame} from "@dodona/trace-component/dist/trace_types";
 import {launchPapyros, settlePapyros, waitForInputReady, waitForOutput, waitForPapyrosReady, wipeWorkspace} from "../../helpers";
+import {BackendEvent, BackendEventType} from "../../../src/communication/BackendEvent";
 
 // One Pyodide boot for the whole file: the tests share a Python instance. The frame
 // history records a file snapshot per run, so the workspace is wiped between tests.
@@ -146,4 +147,79 @@ print(z)`;
         expect(papyros.debugger.trace.length).toBe(0);
     });
 
+});
+
+// The events a worker sends during a debug run, replayed by hand on an instance
+// without a worker: the ordering between two runs is what these tests are about,
+// and it cannot be reproduced reliably against a live worker.
+describe("Debugger run boundaries", () => {
+    const start: BackendEvent = { type: BackendEventType.Start, data: "RunCode", contentType: "text/plain" };
+    const end: BackendEvent = { type: BackendEventType.End, data: "CodeFinished", contentType: "text/plain" };
+    const frame = (line: number): BackendEvent => ({
+        type: BackendEventType.Frame,
+        contentType: "application/json",
+        data: JSON.stringify({
+            line,
+            event: "step_line",
+            func_name: "<module>",
+            globals: {},
+            ordered_globals: [],
+            stack_to_render: [],
+            heap: {},
+        }),
+    });
+    const exception: BackendEvent = {
+        type: BackendEventType.Frame,
+        contentType: "application/json",
+        data: JSON.stringify({ line: 2, event: "uncaught_exception", exception_msg: "boom" }),
+    };
+
+    let papyros: Papyros;
+
+    beforeEach(() => {
+        papyros = new Papyros();
+        papyros.debugger.active = true;
+    });
+
+    afterAll(() => papyros.dispose());
+
+    it("drops frames of the previous run that arrive before the worker starts the next one", () => {
+        papyros.debugger.onRunStart();
+        papyros.events.publish(start);
+        papyros.events.publish(frame(1));
+        papyros.events.publish(exception);
+        papyros.events.publish(end);
+        expect(papyros.debugger.trace.map(f => f.event)).toEqual(["step_line", "uncaught_exception"]);
+
+        // the next run starts while the previous one is still delivering its last frame
+        papyros.debugger.onRunStart();
+        papyros.events.publish(exception);
+        expect(papyros.debugger.trace).toEqual([]);
+
+        papyros.events.publish(start);
+        papyros.events.publish(frame(1));
+        papyros.events.publish(end);
+        expect(papyros.debugger.trace.map(f => f.event)).toEqual(["step_line"]);
+    });
+
+    it("ignores anything sent after the uncaught_exception frame of a run", () => {
+        papyros.debugger.onRunStart();
+        papyros.events.publish(start);
+        papyros.events.publish(frame(1));
+        papyros.events.publish(exception);
+        papyros.events.publish(frame(3));
+        papyros.events.publish(end);
+        expect(papyros.debugger.trace.map(f => f.event)).toEqual(["step_line", "uncaught_exception"]);
+    });
+
+    it("keeps batching frames when the previous run ends after the next one started", () => {
+        papyros.debugger.onRunStart();
+        // the end event of the previous run lands after the reset
+        papyros.events.publish(end);
+        papyros.events.publish(start);
+        papyros.events.publish(frame(1));
+        expect(papyros.debugger.trace).toEqual([]);
+        papyros.events.publish(end);
+        expect(papyros.debugger.trace.map(f => f.line)).toEqual([1]);
+    });
 });


### PR DESCRIPTION
This pull request stops the debugger from appending frames of a previous run to the trace of the next one, which is what crashed the trace component in #1118.

The Runner resets the debugger at click time, but frames of the previous run can still be in flight then, so the trace ended up as `[..., uncaught_exception (run A), step_line (run B)]` and `HeapLayout` threw on the frame after the exception. The debugger now subscribes to the worker's `Start` event again and ignores `Frame` and `Files` events between `onRunStart()` and that event: the worker only sends it after everything it sent for the previous run, so those events never belong to the current one. As an independent guard it also drops anything received after the tracer's `uncaught_exception` frame, which the tracer always sends last. The start event re-arms frame batching too, so an end event of the previous run landing after the reset no longer makes the next run flush a reactive update per frame.

Dropping stale frames before materializing them also avoids a second failure of the same race: a stale delta frame arriving after the reset had no full frame to apply to, so `materializeFrame` threw.

Not in this PR: `Runner.onError` still sets `Ready` on every error event, which re-enables Run while a program that printed an error is still going. #1120, stacked on this one, makes the worker's end event the only run-end signal. dodona-edu/trace-component#152 makes the component itself survive a frame after an exception frame.

**Manual testing instructions**
- The race is hard to hit by hand, so the tests replay the worker's event order instead. To try it live: debug a program that writes to stderr and then raises, click Run again as soon as the button re-enables, and check that the trace shows only the second run.

**Verification**

| Check | Result |
|---|---|
| `yarn typecheck` | clean |
| `yarn lint` | clean |
| `yarn vitest --run` | 21 files / 167 tests, green |
| New tests on `main` | all 3 fail, the first with the `['uncaught_exception', 'step_line']` trace from the issue |

**Checklist**
- Tests: `Debugger.test.ts` gains a `Debugger run boundaries` block that replays the event order on an instance without a worker: frames before the start event are dropped, nothing after an `uncaught_exception` frame is kept, and batching survives a late end event
- Docs: n/a
- Announcement: 🐛 The debugger no longer breaks when a run is started while the previous one is still finishing
- AI: Claude Code implemented the fix and the tests, following the analysis in the issue

Closes #1118

