### PR TITLE
End every run with an end event instead of treating errors as the end

### DIFF
--- a/src/backend/workers/python/papyros/papyros.py
+++ b/src/backend/workers/python/papyros/papyros.py
@@ -243,6 +243,8 @@ class Papyros(python_runner.PyodideRunner):
                 self._flush_open_files()
                 self._emit_created_files()
                 self._emit_turtle_snapshot()
+                # every run that is not interrupted ends with this event
+                self.callback("end", data="CodeFinished", contentType="text/plain")
             finally:
                 self._tracking_files = False
         self.post_run()

--- a/src/frontend/state/Debugger.ts
+++ b/src/frontend/state/Debugger.ts
@@ -113,7 +113,7 @@ export class Debugger extends State {
                 this.flushTimer ??= setTimeout(() => this.flushFrames(), Debugger.FLUSH_INTERVAL_MS);
             }
         });
-        for (const type of [BackendEventType.End, BackendEventType.Error, BackendEventType.Interrupt]) {
+        for (const type of [BackendEventType.End, BackendEventType.Interrupt]) {
             this.papyros.events.subscribe(type, () => this.onRunEnd());
         }
     }

--- a/src/frontend/state/Runner.ts
+++ b/src/frontend/state/Runner.ts
@@ -199,7 +199,6 @@ export class Runner extends State {
         this.papyros.events.subscribe(BackendEventType.Loading, (e) => this.onLoad(e));
         this.papyros.events.subscribe(BackendEventType.Start, (e) => this.onStart(e));
         this.papyros.events.subscribe(BackendEventType.End, (e) => this.onEnd(e));
-        this.papyros.events.subscribe(BackendEventType.Error, () => this.onError());
     }
 
     /**
@@ -373,6 +372,7 @@ export class Runner extends State {
                 this.papyros.io.logError(error);
                 this.papyros.io.onRunEnd();
                 this.papyros.debugger.onRunEnd();
+                this.onFinished();
             }
         } finally {
             if (this.state === RunState.Stopping) {
@@ -557,14 +557,15 @@ export class Runner extends State {
     private onEnd(e: BackendEvent): void {
         const endData = parseData(e.data, e.contentType) as string;
         if (endData.includes("CodeFinished")) {
-            this.setState(
-                RunState.Ready,
-                this.papyros.i18n.t("Papyros.finished", { time: (new Date().getTime() - this.runStartTime) / 1000 }),
-            );
+            this.onFinished();
         }
     }
 
-    private onError(): void {
+    /**
+     * The run is over, whether the program completed or raised: the worker
+     * sends an end event either way, error events only carry output
+     */
+    private onFinished(): void {
         this.setState(
             RunState.Ready,
             this.papyros.i18n.t("Papyros.finished", { time: (new Date().getTime() - this.runStartTime) / 1000 }),

--- a/test/__tests__/state/Runner.test.ts
+++ b/test/__tests__/state/Runner.test.ts
@@ -4,7 +4,7 @@ import {ProgrammingLanguage} from "../../../src/ProgrammingLanguage";
 import {RunState} from "../../../src/frontend/state/Runner";
 import {RunMode} from "../../../src/backend/Backend";
 import {launchPapyros, settlePapyros, waitForOutput, waitForPapyrosReady} from "../../helpers";
-import {FriendlyError} from "../../../src/frontend/state/InputOutput";
+import {FriendlyError, OutputType} from "../../../src/frontend/state/InputOutput";
 
 // One Pyodide boot for the whole file: instances are isolated now, so the suite
 // shares a single Python instance and settles it between tests.
@@ -75,6 +75,34 @@ const c = a + b;`;
         await waitForOutput(papyros);
         expect(papyros.runner.stateMessage).toMatch(/^Code executed in/);
         expect((papyros.io.output[0].content as FriendlyError).traceback).toMatch(/ValueError: test/);
+    });
+
+    it("should finish a run that fails to compile", async () => {
+        papyros.runner.code = "print 'hello'\n";
+        await papyros.runner.start();
+        await waitForPapyrosReady(papyros);
+        await waitForOutput(papyros);
+        expect(papyros.runner.stateMessage).toMatch(/^Code executed in/);
+        expect((papyros.io.output[0].content as FriendlyError).traceback).toMatch(/SyntaxError/);
+    });
+
+    it("should keep running while the program writes to stderr", async () => {
+        const jsPapyros = await launchPapyros(ProgrammingLanguage.JavaScript);
+        jsPapyros.runner.code = `console.error("warning");
+console.log("started");
+const deadline = Date.now() + 500;
+while (Date.now() < deadline) {}
+console.log("done");`;
+        const runPromise = jsPapyros.runner.start();
+        await waitForOutput(jsPapyros, 2);
+        // the stderr output is in, the program is still busy
+        expect(jsPapyros.runner.state).toBe(RunState.Running);
+        await runPromise;
+        await waitForPapyrosReady(jsPapyros);
+        expect(jsPapyros.io.output[0].type).toBe(OutputType.stderr);
+        expect(jsPapyros.io.output.slice(1).every(o => o.type === OutputType.stdout)).toBe(true);
+        expect(jsPapyros.io.output.map(o => o.content).join("")).toMatch(/started[\s\S]*done/);
+        jsPapyros.dispose();
     });
 
     it("should be able to interrupt code", async () => {


### PR DESCRIPTION
This pull request makes the worker's `end` event the only signal that a run is over. Stacked on #1119, the last piece of #1118.

The Runner set `Ready` on every `Error` event, because a Python run that raised sent a traceback and no `end`. That also made any error output mid-run re-enable Run while the program was still going: the JavaScript worker's `console.error` did exactly that. The Python worker now sends `end` after the traceback too, so every run that is not interrupted ends with it, and the `Error` subscription in the Runner is gone. The debugger likewise stops treating an error event as the end of a run, which kept its frame batching from being switched off mid-run. A run whose worker call rejects (a failure outside the program itself) also reports `Ready` now; before, nothing set the state on that path.

One thing this does not change, found while writing the test: Python's `sys.stderr` writes are typed `"error"` by the redirected stream, and `runner_callback` only maps `"stderr"`, `"traceback"` and `"syntax_error"` to an error event, so Python stderr output has always shown up as plain stdout and never flipped the state. The mid-run `Ready` the issue describes was reachable through the JavaScript worker, not through Python stderr. #1121, stacked on this one, makes stderr render as error output.

**Manual testing instructions**
- Run a Python program that raises: the state still reports "Code executed in" and the traceback shows.
- Run a Python program with a syntax error: same.
- In JavaScript, run `console.error("x"); const t = Date.now() + 2000; while (Date.now() < t) {}`: the Run button stays disabled until the loop ends. On `main` it re-enables as soon as the error prints.

**Verification**

| Check | Result |
|---|---|
| `yarn typecheck` | clean |
| `yarn lint` | clean |
| `yarn setup && yarn vitest --run` | 21 files / 169 tests, green |
| New stderr test on the base branch | fails with `expected 'ready' to be 'running'` |

**Checklist**
- Tests: `Runner.test.ts` gains a syntax-error run that must reach `Ready`, and a JavaScript run that must stay `Running` after error output
- Docs: n/a
- Announcement: 🐛 The Run button no longer re-enables while a program that printed an error is still running
- AI: Claude Code implemented the change and the tests

Part of #1118


