### PR TITLE
Show what a Python program writes to stderr as error output

### DIFF
--- a/src/backend/Backend.ts
+++ b/src/backend/Backend.ts
@@ -52,7 +52,7 @@ export abstract class Backend {
      * Settles the promise this backend is suspended on while it waits for the main
      * thread to answer, if it is waiting at all
      */
-    private pending?: { resolve: (value: any) => void; reject: (reason: unknown) => void };
+    private pending?: { resolve: (value: any) => void };
     /**
      * Callback to handle events published by this Backend
      */
@@ -132,8 +132,10 @@ export abstract class Backend {
     }
 
     /**
-     * Abort the main thread question this backend is suspended on.
-     * python_runner maps the rejection onto a KeyboardInterrupt, so the worker survives.
+     * Abort the main thread question this backend is suspended on. The answer is an
+     * InterruptError value, which the Python side raises as KeyboardInterrupt so the
+     * worker survives. Pyodide prints a rejected promise's error to the program's
+     * stderr, so the promise must not reject.
      * @return {boolean} Whether the backend was waiting
      */
     public interruptMessage(): boolean {
@@ -142,7 +144,7 @@ export abstract class Backend {
             return false;
         }
         this.pending = undefined;
-        pending.reject(new InterruptError());
+        pending.resolve(new InterruptError());
         return true;
     }
 
@@ -150,10 +152,10 @@ export abstract class Backend {
      * Suspend until the main thread provides input
      * @return {Promise<string>} The value the user entered
      */
-    private suspendForInput(): Promise<string> {
+    private suspendForInput(): Promise<string | InterruptError> {
         this.extras.reportStatus("reading");
-        return new Promise<string>((resolve, reject) => {
-            this.pending = { resolve, reject };
+        return new Promise<string | InterruptError>((resolve) => {
+            this.pending = { resolve };
         });
     }
 
@@ -162,22 +164,20 @@ export abstract class Backend {
      * @param {number} ms How long to sleep
      * @return {Promise<void>} Resolves once the time has passed
      */
-    private suspendForSleep(ms: number): Promise<void> {
+    private suspendForSleep(ms: number): Promise<void | InterruptError> {
         this.extras.reportStatus("sleeping");
-        return new Promise<void>((resolve, reject) => {
+        return new Promise<void | InterruptError>((resolve) => {
             const timer = setTimeout(() => {
                 this.pending = undefined;
                 this.extras.reportStatus("slept");
                 resolve();
             }, ms);
-            const settle = (finish: () => void): void => {
-                clearTimeout(timer);
-                this.extras.reportStatus("slept");
-                finish();
-            };
             this.pending = {
-                resolve: () => settle(resolve),
-                reject: (reason: unknown) => settle(() => reject(reason)),
+                resolve: (value: void | InterruptError) => {
+                    clearTimeout(timer);
+                    this.extras.reportStatus("slept");
+                    resolve(value);
+                },
             };
         });
     }

--- a/src/backend/Backend.ts
+++ b/src/backend/Backend.ts
@@ -150,7 +150,8 @@ export abstract class Backend {
 
     /**
      * Suspend until the main thread provides input
-     * @return {Promise<string>} The value the user entered
+     * @return {Promise<string | InterruptError>} The value the user entered, or an
+     * InterruptError when the run was interrupted while waiting
      */
     private suspendForInput(): Promise<string | InterruptError> {
         this.extras.reportStatus("reading");
@@ -162,7 +163,8 @@ export abstract class Backend {
     /**
      * Suspend for the requested duration, remaining interruptible throughout
      * @param {number} ms How long to sleep
-     * @return {Promise<void>} Resolves once the time has passed
+     * @return {Promise<void | InterruptError>} Resolves once the time has passed, or
+     * with an InterruptError when the run was interrupted while waiting
      */
     private suspendForSleep(ms: number): Promise<void | InterruptError> {
         this.extras.reportStatus("sleeping");

--- a/src/backend/workers/python/papyros/papyros.py
+++ b/src/backend/workers/python/papyros/papyros.py
@@ -58,11 +58,14 @@ class Papyros(python_runner.PyodideRunner):
     def set_event_callback(self, event_callback):
         def unwrap(result):
             # With the JSPI transport the callback answers with a promise instead of a
-            # value, so suspend the wasm stack until it settles. run_sync re-raises a
-            # rejection, which python_runner maps onto KeyboardInterrupt.
+            # value, so suspend the wasm stack until it settles. An interrupt arrives
+            # as an InterruptError value: Pyodide prints a rejected promise's error to
+            # the program's stderr.
             if hasattr(result, "then"):
                 from pyodide.ffi import run_sync
-                return run_sync(result)
+                result = run_sync(result)
+            if getattr(result, "type", None) == "InterruptError":
+                raise KeyboardInterrupt
             return result
 
         def runner_callback(event_type, data):

--- a/src/backend/workers/python/papyros/papyros.py
+++ b/src/backend/workers/python/papyros/papyros.py
@@ -237,7 +237,7 @@ class Papyros(python_runner.PyodideRunner):
         self._last_emitted_snapshot = None
         with (
             redirect_stdout(python_runner.output.SysStream("output", self.output_buffer)),
-            redirect_stderr(python_runner.output.SysStream("error", self.output_buffer)),
+            redirect_stderr(python_runner.output.SysStream("stderr", self.output_buffer)),
         ):
             try:
                 yield

--- a/test/__tests__/state/Runner.test.ts
+++ b/test/__tests__/state/Runner.test.ts
@@ -105,6 +105,20 @@ console.log("done");`;
         jsPapyros.dispose();
     });
 
+    it("should show what a program writes to stderr as error output", async () => {
+        papyros.runner.code = `import sys
+print("to stdout")
+print("to stderr", file=sys.stderr)`;
+        await papyros.runner.start();
+        await waitForPapyrosReady(papyros);
+        await waitForOutput(papyros, 2);
+        expect(papyros.runner.stateMessage).toMatch(/^Code executed in/);
+        // output streams in chunks, so compare the text per stream
+        const text = (type: OutputType) => papyros.io.output.filter(o => o.type === type).map(o => o.content).join("");
+        expect(text(OutputType.stdout)).toBe("to stdout\n");
+        expect(text(OutputType.stderr)).toBe("to stderr\n");
+    });
+
     it("should be able to interrupt code", async () => {
         // Interrupting a busy loop replaces the worker, so use a throwaway instance
         const jsPapyros = await launchPapyros(ProgrammingLanguage.JavaScript);


### PR DESCRIPTION
This pull request shows what a Python program writes to `sys.stderr` as error output, the way `console.error` output already shows for JavaScript. Stacked on #1120, which it needs: on `main` an error event still ends the run, so this change alone would re-enable Run as soon as a program printed a warning.

The redirected stderr stream tagged its output `"error"`, a type `runner_callback` does not map to the error event (it maps `"stderr"`, `"traceback"` and `"syntax_error"`), so stderr text was sent as regular output and rendered as stdout. The stream is now tagged `"stderr"`. Nothing changes on the frontend: `InputOutput.logError` already takes a string and `Output` renders it in the error style.

This is user-visible: `print(..., file=sys.stderr)`, `warnings.warn(...)` and `logging` output now render as error output instead of plain text.

before:
<img width="2200" height="820" alt="before" src="https://github.com/user-attachments/assets/6daa92bd-0794-43e2-afa3-eb1121cfafa7" />
after:
<img width="2200" height="820" alt="after" src="https://github.com/user-attachments/assets/90c63ab1-bae5-4497-87c9-b248451ec38f" />

<details>
<summary>The first commit: an interrupted JSPI wait no longer prints to stderr</summary>

The JSPI tests assert that interrupting an `input()` or a `sleep()` leaves no stderr entry, and they failed once stderr was typed correctly: every such interrupt had been writing `pyodide.ffi.JsException: InterruptError` into the program's output, hidden until now because it rendered as stdout. Tracing the write showed the cause: `interruptMessage()` rejected the promise the worker was suspended on, Pyodide turned that rejection into a future with an exception, and converting that exception back across the JSPI boundary went through `sys.excepthook`, which printed it into the redirected stderr. The promise now resolves with an `InterruptError` value instead, and `unwrap()` in `papyros.py` raises `KeyboardInterrupt` for it, so the interrupt reaches the same handler as before without a rejection. `suspendForSleep` passes the value through on an early wake-up.

</details>

**Manual testing instructions**
- Run `import sys; print("out"); print("err", file=sys.stderr); print("done")`: the middle line renders in the error style, the others as normal output, and the run reports "Code executed in".
- Run a program that raises: the traceback still renders as before.
- In a browser with JSPI (Chrome), run `x = input()` and press stop while it waits, then the same with `import time; time.sleep(10)`: the run reports "Code interrupted" and the output stays empty. On `main` the output shows `pyodide.ffi.JsException: InterruptError`.

**Verification**

| Check | Result |
|---|---|
| `yarn typecheck` | clean |
| `yarn lint` | clean |
| `yarn setup && yarn vitest --run` | 21 files / 170 tests, green |
| Demo page on this branch vs. its base | stderr line red vs. plain, screenshots above |

**Checklist**
- Tests: `Runner.test.ts` asserts that a Python run's stderr text arrives as `stderr` entries, its stdout text as `stdout`, and that the run still reaches `Ready`. The existing JSPI interrupt tests now actually check what they were written for.
- Docs: n/a
- Announcement: ✨ Text a Python program writes to stderr now shows as error output
- AI: Claude Code implemented the change, traced the interrupt artefact, and wrote the test and the screenshots

Part of #1118
