### PR TITLE
Upgrade the trace component to 1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@codemirror/state": "^6.3.2",
     "@codemirror/view": "^6.28.0",
     "@dodona/lit-state": "^1.1.1",
-    "@dodona/trace-component": "1.6.0",
+    "@dodona/trace-component": "1.6.1",
     "@material/web": "^2.4.0",
     "codemirror-readonly-ranges": "^0.1.0-alpha.2",
     "comlink": "^4.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,10 +105,10 @@
   dependencies:
     lit "^3.3.1"
 
-"@dodona/trace-component@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@dodona/trace-component/-/trace-component-1.6.0.tgz#76146bbdd51a306d42bef2d4cc47add9e9315ecf"
-  integrity sha512-rzOR8NUAFFN+palB4DLuEX00dFvu5lp+HL4TeZM0ggYANFESWsLt9scAPVpBIquabVuZs1JCGBsMn4YB8hBodw==
+"@dodona/trace-component@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@dodona/trace-component/-/trace-component-1.6.1.tgz#f470d02e710d3a38013816c9c024b0e86c51d2a4"
+  integrity sha512-A8xAWr5Ytmdzayfi4cTYGUQ7WZj8eqvBBpCvqOXuAGufaEASDBYve86X38zS2pWdqcV4Ep8hlIKCSRVjcTdlow==
   dependencies:
     lit "^3.3.3"
 


### PR DESCRIPTION
This pull request upgrades `@dodona/trace-component` from 1.6.0 to 1.6.1, a patch release with a single fix: `HeapLayout` returned from its constructor without assigning a field for an `uncaught_exception` frame, so a frame appended after one threw `Cannot read properties of undefined (reading 'forEach')` — the crash Sentry reported in #1118. The fields now carry initializers, so an exception frame is a valid empty layout and a frame built on top of it starts from nothing. Nothing else changed: no API, no translation keys, no rendering.

#1119 is the papyros-side fix that stops the debugger from producing that frame ordering in the first place. This bump is the independent guard on the component side, so a producer that gets it wrong does not take the trace view down with it. The two are unrelated in the tree and can land in either order.

Release notes: https://github.com/dodona-edu/trace-component/releases/tag/v1.6.1 (dodona-edu/trace-component#152)

**Manual testing instructions**
- Debug any program in the demo page and check that the trace still renders and steps as before; this release changes no rendering.

**Verification**

| Check | Result |
|---|---|
| \`yarn typecheck\` | clean |
| \`yarn lint\` | clean |
| \`yarn vitest --run\` | 21 files / 164 tests, 2 failed |

The two failures are \`Jspi.test.ts > interrupts a waiting input / a sleep without replacing the worker\`. They fail on unmodified \`main\` as well, before this bump, and are fixed by #1121 in the open stack — nothing to do with the trace component.

**Checklist**
- Tests: n/a, the fix is covered by tests in dodona-edu/trace-component#152
- Docs: n/a
- Announcement: n/a, the user-facing line for this crash is on #1119
- AI: Claude Code cut the trace-component release and prepared this bump