### PR TITLE
Recover from an exhausted Python runtime

### DIFF
--- a/src/frontend/state/Runner.ts
+++ b/src/frontend/state/Runner.ts
@@ -36,17 +36,25 @@ export interface LoadingData {
 
 /**
  * Signatures of errors that leave the runtime unable to run or lint anything
- * afterwards: its heap is exhausted, or a trap aborted it. The WebAssembly heap
+ * afterwards: its heap is exhausted, a trap aborted it, or Pyodide already
+ * declared it dead after a trap that surfaced elsewhere. The WebAssembly heap
  * only ever grows, so nothing short of a fresh worker recovers from these.
+ * Trap wording differs per engine (V8, JavaScriptCore, SpiderMonkey).
  */
 const UNUSABLE_RUNTIME_SIGNATURES = [
     "memoryerror",
     "out of bounds memory access",
     "memory access out of bounds",
+    "index out of bounds",
     "could not allocate memory",
     "call_indirect to a null table entry",
+    "call_indirect to a signature that does not match",
     "null function",
+    "indirect call to null",
+    "indirect call signature mismatch",
     "aborted(",
+    "pyodide already fatally failed",
+    "pyodide already exited",
 ];
 
 function isRuntimeUnusable(error: any): boolean {
@@ -169,7 +177,15 @@ export class Runner extends State {
      * Async getter for the linting diagnostics of the current code
      */
     public async lintSource(): Promise<WorkerDiagnostic[]> {
-        const backend = await this.backend;
+        let backend: SyncClient<Backend>;
+        try {
+            backend = await this.backend;
+        } catch {
+            // Launch failures surface through launch(), and a lint cannot recover
+            // from one: retrying the launch on every edit would loop on a runtime
+            // that fails to boot
+            return [];
+        }
         const proxy = backend.workerProxy;
 
         if (!proxy) {
@@ -225,6 +241,12 @@ export class Runner extends State {
      * old one is still exhausted fails too, and each failure asks for a recovery.
      */
     private recovering: boolean = false;
+    /**
+     * The files last handed over through provideFiles, replayed into a replacement
+     * runtime. Files over 1 MB never reach io.files, so they cannot be restored
+     * from there.
+     */
+    private providedFiles?: [Record<string, string>, Record<string, string>];
 
     constructor(papyros: Papyros) {
         super();
@@ -327,6 +349,10 @@ export class Runner extends State {
         }
         this.recovering = true;
         try {
+            // A run suspended in input() dies with its worker, so close its prompt
+            // and flush its frames the way stop() does
+            this.papyros.io.onRunEnd();
+            this.papyros.debugger.onRunEnd();
             const client = this.clients.get(this.programmingLanguage);
             try {
                 client?.restart();
@@ -347,7 +373,12 @@ export class Runner extends State {
      * empty filesystem while the editor still shows them.
      */
     private async restoreWorkspace(): Promise<void> {
+        // Snapshot first: replaying the provided files refreshes io.files from the
+        // worker, and the editor's copy of a file edited since must win
         const files = this.papyros.io.files;
+        if (this.providedFiles) {
+            await this.provideFiles(...this.providedFiles);
+        }
         if (files.length === 0) {
             return;
         }
@@ -562,6 +593,7 @@ export class Runner extends State {
         if (fileNames.length === 0) {
             return;
         }
+        this.providedFiles = [inlinedFiles, hrefFiles];
         // parseData hands application/json data over as-is, so it must be the object
         this.onLoad({
             type: BackendEventType.Loading,

--- a/src/frontend/state/Runner.ts
+++ b/src/frontend/state/Runner.ts
@@ -35,6 +35,26 @@ export interface LoadingData {
 }
 
 /**
+ * Signatures of errors that leave the runtime unable to run or lint anything
+ * afterwards: its heap is exhausted, or a trap aborted it. The WebAssembly heap
+ * only ever grows, so nothing short of a fresh worker recovers from these.
+ */
+const UNUSABLE_RUNTIME_SIGNATURES = [
+    "memoryerror",
+    "out of bounds memory access",
+    "memory access out of bounds",
+    "could not allocate memory",
+    "call_indirect to a null table entry",
+    "null function",
+    "aborted(",
+];
+
+function isRuntimeUnusable(error: any): boolean {
+    const description = `${error?.type ?? ""} ${error?.message ?? error ?? ""}`.toLowerCase();
+    return UNUSABLE_RUNTIME_SIGNATURES.some((signature) => description.includes(signature));
+}
+
+/**
  * Helper component to manage and visualize the current RunState
  */
 export class Runner extends State {
@@ -155,7 +175,18 @@ export class Runner extends State {
         if (!proxy) {
             return [];
         }
-        return await proxy.lintCode(this.code);
+        try {
+            return await proxy.lintCode(this.code);
+        } catch (error: any) {
+            // The editor lints in the background on every edit, and CodeMirror turns a
+            // rejected linter into an uncaught window error. Report it and show no
+            // diagnostics instead.
+            this.papyros.errorHandler(error);
+            if (isRuntimeUnusable(error)) {
+                await this.recoverRuntime();
+            }
+            return [];
+        }
     }
 
     /**
@@ -189,6 +220,11 @@ export class Runner extends State {
      * interrupted, which normally relaunches the worker; this suppresses it.
      */
     private disposed: boolean = false;
+    /**
+     * Whether a runtime is already being replaced. Every lint that lands while the
+     * old one is still exhausted fails too, and each failure asks for a recovery.
+     */
+    private recovering: boolean = false;
 
     constructor(papyros: Papyros) {
         super();
@@ -281,6 +317,46 @@ export class Runner extends State {
         }
     }
 
+    /**
+     * Replace a runtime that can no longer run or lint code, and put the files it
+     * held back into the fresh one.
+     */
+    private async recoverRuntime(): Promise<void> {
+        if (this.disposed || this.recovering) {
+            return;
+        }
+        this.recovering = true;
+        try {
+            const client = this.clients.get(this.programmingLanguage);
+            try {
+                client?.restart();
+            } catch {
+                // An injected or never-started client has no worker to replace
+            }
+            await this.launch();
+            await this.restoreWorkspace();
+        } catch (error: any) {
+            this.papyros.errorHandler(error);
+        } finally {
+            this.recovering = false;
+        }
+    }
+
+    /**
+     * Write the files back into a freshly started worker, which comes up with an
+     * empty filesystem while the editor still shows them.
+     */
+    private async restoreWorkspace(): Promise<void> {
+        const files = this.papyros.io.files;
+        if (files.length === 0) {
+            return;
+        }
+        const backend = await this.backend;
+        for (const file of files) {
+            await backend.workerProxy.updateFile(file.name, file.content, file.binary);
+        }
+    }
+
     private async launchBackend(
         language: ProgrammingLanguage,
         backend: SyncClient<Backend>,
@@ -355,6 +431,7 @@ export class Runner extends State {
         this.papyros.debugger.onRunStart();
         let interrupted = false;
         let terminated = false;
+        let unusable = false;
         const backend = await this.backend;
         this.runStartTime = new Date().getTime();
         try {
@@ -373,13 +450,16 @@ export class Runner extends State {
                 this.papyros.io.logError(error);
                 this.papyros.io.onRunEnd();
                 this.papyros.debugger.onRunEnd();
+                unusable = isRuntimeUnusable(error);
             }
         } finally {
             if (this.state === RunState.Stopping) {
                 // stop() already closed the input prompt and flushed the debugger
                 interrupted = true;
             }
-            if (terminated) {
+            if (unusable) {
+                await this.recoverRuntime();
+            } else if (terminated) {
                 await this.launch();
             }
             if (interrupted || terminated) {

--- a/src/sync/SyncClient.ts
+++ b/src/sync/SyncClient.ts
@@ -67,6 +67,14 @@ export class SyncClient<T = any> {
             return;
         }
 
+        this.restart();
+    }
+
+    /**
+     * Replace the worker with a fresh one, dropping everything the old one held.
+     * This client keeps its identity, so callers holding it stay valid.
+     */
+    public restart(): void {
         this.terminate();
         this._start();
     }

--- a/src/sync/SyncClient.ts
+++ b/src/sync/SyncClient.ts
@@ -155,8 +155,10 @@ export class SyncClient<T = any> {
 
     public terminate(): void {
         this._interruptRejector?.(new InterruptError("Worker terminated"));
-        this._workerProxy![Comlink.releaseProxy]();
-        this._worker!.terminate();
+        // A client that was already terminated has nothing left to release, so
+        // terminating it again is a no-op rather than an error
+        this._workerProxy?.[Comlink.releaseProxy]();
+        this._worker?.terminate();
         delete this._workerProxy;
         delete this._worker;
     }

--- a/test/__tests__/state/RuntimeRecovery.test.ts
+++ b/test/__tests__/state/RuntimeRecovery.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { Papyros } from "../../../src/frontend/state/Papyros";
+import { ProgrammingLanguage } from "../../../src/ProgrammingLanguage";
+
+/**
+ * Stand-in for a SyncClient whose worker can be replaced, so a recovery is
+ * observable the same way it is on a real one: a new worker object and a
+ * workerProxy that no longer fails.
+ */
+function fakeClient(lintCode: () => Promise<any>): any {
+    const updateFile = vi.fn(() => Promise.resolve());
+    const proxyFor = (lint: () => Promise<any>): any => ({
+        launch: () => Promise.resolve(),
+        usesJspi: () => Promise.resolve(true),
+        runModes: () => Promise.resolve([]),
+        lintCode: vi.fn(lint),
+        updateFile,
+    });
+    const client: any = {
+        worker: {},
+        workerProxy: proxyFor(lintCode),
+        updateFile,
+        restart: vi.fn(() => {
+            client.worker = {};
+            client.workerProxy = proxyFor(() => Promise.resolve([]));
+        }),
+        terminate: vi.fn(),
+    };
+    return client;
+}
+
+describe("recovering from an unusable runtime", () => {
+    it("reports a failed lint without throwing and keeps the runtime", async () => {
+        const client = fakeClient(() => Promise.reject(new Error("something went wrong")));
+        const papyros = new Papyros();
+        papyros.runner.registerBackend(ProgrammingLanguage.Python, () => client);
+        const errorHandler = vi.fn();
+        papyros.setErrorHandler(errorHandler);
+        await papyros.runner.launch();
+
+        await expect(papyros.runner.lintSource()).resolves.toEqual([]);
+
+        expect(errorHandler).toHaveBeenCalledOnce();
+        expect(client.restart).not.toHaveBeenCalled();
+
+        papyros.dispose();
+    });
+
+    it("replaces a runtime that ran out of memory and restores its files", async () => {
+        const memoryError = Object.assign(new Error("MemoryError"), { type: "PythonError" });
+        const client = fakeClient(() => Promise.reject(memoryError));
+        const papyros = new Papyros();
+        papyros.runner.registerBackend(ProgrammingLanguage.Python, () => client);
+        papyros.setErrorHandler(vi.fn());
+        await papyros.runner.launch();
+        papyros.io.addFile("data.txt", "hello", false);
+
+        await expect(papyros.runner.lintSource()).resolves.toEqual([]);
+
+        expect(client.restart).toHaveBeenCalledOnce();
+        expect(client.updateFile).toHaveBeenCalledWith("data.txt", "hello", false);
+        // The replacement runtime lints again instead of staying broken
+        await expect(papyros.runner.lintSource()).resolves.toEqual([]);
+        expect(client.restart).toHaveBeenCalledOnce();
+
+        papyros.dispose();
+    });
+});

--- a/test/__tests__/state/RuntimeRecovery.test.ts
+++ b/test/__tests__/state/RuntimeRecovery.test.ts
@@ -2,41 +2,63 @@ import { describe, expect, it, vi } from "vitest";
 import { Papyros } from "../../../src/frontend/state/Papyros";
 import { ProgrammingLanguage } from "../../../src/ProgrammingLanguage";
 
+const memoryError = (): Error => Object.assign(new Error("MemoryError"), { type: "PythonError" });
+
 /**
  * Stand-in for a SyncClient whose worker can be replaced, so a recovery is
  * observable the same way it is on a real one: a new worker object and a
  * workerProxy that no longer fails.
  */
-function fakeClient(lintCode: () => Promise<any>): any {
+function fakeClient({
+    lintCode = () => Promise.resolve([]),
+    runCode = () => Promise.resolve(),
+    launch = () => Promise.resolve(),
+}: {
+    lintCode?: () => Promise<any>;
+    runCode?: () => Promise<any>;
+    launch?: () => Promise<void>;
+} = {}): any {
     const updateFile = vi.fn(() => Promise.resolve());
-    const proxyFor = (lint: () => Promise<any>): any => ({
-        launch: () => Promise.resolve(),
+    const proxyFor = (lint: () => Promise<any>, run: () => Promise<any>): any => ({
+        launch,
         usesJspi: () => Promise.resolve(true),
         runModes: () => Promise.resolve([]),
         lintCode: vi.fn(lint),
+        runCode: vi.fn(run),
+        provideFiles: vi.fn(() => Promise.resolve()),
         updateFile,
     });
     const client: any = {
         worker: {},
-        workerProxy: proxyFor(lintCode),
+        workerProxy: proxyFor(lintCode, runCode),
         updateFile,
+        call: (method: (...args: any[]) => Promise<any>, ...args: any[]) => method(...args),
         restart: vi.fn(() => {
             client.worker = {};
-            client.workerProxy = proxyFor(() => Promise.resolve([]));
+            client.workerProxy = proxyFor(
+                () => Promise.resolve([]),
+                () => Promise.resolve(),
+            );
         }),
         terminate: vi.fn(),
     };
     return client;
 }
 
+async function launched(client: any): Promise<Papyros> {
+    const papyros = new Papyros();
+    papyros.runner.registerBackend(ProgrammingLanguage.Python, () => client);
+    papyros.setErrorHandler(vi.fn());
+    await papyros.runner.launch();
+    return papyros;
+}
+
 describe("recovering from an unusable runtime", () => {
     it("reports a failed lint without throwing and keeps the runtime", async () => {
-        const client = fakeClient(() => Promise.reject(new Error("something went wrong")));
-        const papyros = new Papyros();
-        papyros.runner.registerBackend(ProgrammingLanguage.Python, () => client);
+        const client = fakeClient({ lintCode: () => Promise.reject(new Error("something went wrong")) });
+        const papyros = await launched(client);
         const errorHandler = vi.fn();
         papyros.setErrorHandler(errorHandler);
-        await papyros.runner.launch();
 
         await expect(papyros.runner.lintSource()).resolves.toEqual([]);
 
@@ -47,12 +69,8 @@ describe("recovering from an unusable runtime", () => {
     });
 
     it("replaces a runtime that ran out of memory and restores its files", async () => {
-        const memoryError = Object.assign(new Error("MemoryError"), { type: "PythonError" });
-        const client = fakeClient(() => Promise.reject(memoryError));
-        const papyros = new Papyros();
-        papyros.runner.registerBackend(ProgrammingLanguage.Python, () => client);
-        papyros.setErrorHandler(vi.fn());
-        await papyros.runner.launch();
+        const client = fakeClient({ lintCode: () => Promise.reject(memoryError()) });
+        const papyros = await launched(client);
         papyros.io.addFile("data.txt", "hello", false);
 
         await expect(papyros.runner.lintSource()).resolves.toEqual([]);
@@ -62,6 +80,66 @@ describe("recovering from an unusable runtime", () => {
         // The replacement runtime lints again instead of staying broken
         await expect(papyros.runner.lintSource()).resolves.toEqual([]);
         expect(client.restart).toHaveBeenCalledOnce();
+
+        papyros.dispose();
+    });
+
+    it("replaces a runtime that a run left unusable", async () => {
+        const client = fakeClient({ runCode: () => Promise.reject(memoryError()) });
+        const papyros = await launched(client);
+        papyros.io.addFile("data.txt", "hello", false);
+
+        await papyros.runner.start();
+
+        expect(client.restart).toHaveBeenCalledOnce();
+        expect(client.updateFile).toHaveBeenCalledWith("data.txt", "hello", false);
+        expect(papyros.io.awaitingInput).toBe(false);
+
+        papyros.dispose();
+    });
+
+    it("closes the input prompt of a run the recovery abandons", async () => {
+        const client = fakeClient({ lintCode: () => Promise.reject(memoryError()) });
+        const papyros = await launched(client);
+        // A lint can fail while a run is suspended in input(), and the restart
+        // takes that run down with the worker
+        papyros.io.awaitingInput = true;
+
+        await papyros.runner.lintSource();
+
+        expect(client.restart).toHaveBeenCalledOnce();
+        expect(papyros.io.awaitingInput).toBe(false);
+
+        papyros.dispose();
+    });
+
+    it("hands provided files over again, since io.files omits the large ones", async () => {
+        const client = fakeClient({ lintCode: () => Promise.reject(memoryError()) });
+        const papyros = await launched(client);
+        const inlined = { "data.csv": "a,b\n1,2" };
+        const hrefs = { "big.bin": "https://example.org/big.bin" };
+        await papyros.runner.provideFiles(inlined, hrefs);
+
+        await papyros.runner.lintSource();
+
+        expect(client.restart).toHaveBeenCalledOnce();
+        expect(client.workerProxy.provideFiles).toHaveBeenCalledWith(inlined, hrefs);
+
+        papyros.dispose();
+    });
+
+    it("lints nothing after a failed launch instead of retrying it", async () => {
+        const client = fakeClient({ launch: () => Promise.reject(new Error("Out of bounds memory access")) });
+        const papyros = new Papyros();
+        papyros.runner.registerBackend(ProgrammingLanguage.Python, () => client);
+        const errorHandler = vi.fn();
+        papyros.setErrorHandler(errorHandler);
+        await expect(papyros.runner.launch()).rejects.toThrow("Out of bounds memory access");
+
+        await expect(papyros.runner.lintSource()).resolves.toEqual([]);
+
+        expect(client.restart).not.toHaveBeenCalled();
+        expect(errorHandler).not.toHaveBeenCalled();
 
         papyros.dispose();
     });

--- a/test/__tests__/sync/SyncClient.test.ts
+++ b/test/__tests__/sync/SyncClient.test.ts
@@ -48,6 +48,17 @@ describe("SyncClient", () => {
         client.terminate();
     });
 
+    it("restarts into a fresh worker even when already terminated", async () => {
+        const client = idleClient();
+        client.terminate();
+
+        client.restart();
+
+        expect(client.worker).toBeInstanceOf(Worker);
+        expect(client.state).toBe("idle");
+        client.terminate();
+    });
+
     it("fails a queued write instead of hanging when the call ends first", async () => {
         const client = idleClient();
         const call = client.call(() => new Promise(() => undefined));


### PR DESCRIPTION
This pull request lets the scratchpad recover when its Python runtime can no longer run or lint code, instead of silently losing linting for the rest of the session.

Reported as Sentry DODONA-FRONTEND-2CV: a `MemoryError` raised by `NamedTemporaryFile` in `linting.py`, which is the *first* allocation `lint()` makes, so the WebAssembly heap was already full before linting started. `Runner.lintSource()` had no error handling, so `@codemirror/lint` turned the rejected linter into an uncaught `window.onerror`, and nothing ever replaced the exhausted runtime.

Three changes:

- `SyncClient.restart()` replaces the worker. `interrupt()` already did exactly this when no interrupt buffer is available, but it returns early when the client is idle, which it is after a failed lint. `Runner.launch()` on its own does not recycle Pyodide either: it hands back the cached client and reuses its `launched` entry.
- A failed lint now goes to `papyros.errorHandler` and shows no diagnostics, rather than escaping to the page.
- An error that leaves the runtime unusable triggers a restart, a relaunch, and a rewrite of the workspace files, which a fresh worker comes up without while the editor still lists them. Files handed over through `provideFiles` are replayed as well, since `io.files` skips anything over 1 MB. A run suspended in `input()` at that moment has its prompt closed, as `stop()` does. The run path gets the same wiring as a precaution: both Sentry issues in this family so far (DODONA-FRONTEND-2CV and DODONA-FRONTEND-29S) failed on the lint path, and the Safari 18.3 `Out of bounds memory access` events (DODONA-FRONTEND-2BQ) fail inside `loadPyodide`, which goes through the launch path and is unchanged here.
- The signatures that count as an unusable runtime cover V8, JavaScriptCore and SpiderMonkey trap wording (checked against Chromium 151, the macOS `jsc` shell and Firefox 154) and Pyodide's own "already fatally failed" post-mortem.

**Not fixed here: what fills the heap.** Linting leaks roughly 0.5 MB per lint, and the editor lints about 750 ms after every edit, so a long session walks into the ceiling. Fixing that needs private pylint, astroid and isort APIs, which we decided against; students still reach the ceiling, they now recover from it.

<details>
<summary>Measurements behind the leak claim</summary>

Measured natively against the pinned versions (Python 3.14, pylint 4.0.6, astroid 4.0.4), driving this repo's own `linting.py` with its plugins and rc file. 300 lints of an unchanged 20 line program:

| | RSS after 300 lints | live `MessageDefinition` |
|---|---|---|
| as is | 73 to 235 MB, linear, no plateau | 120,000 |
| releasing the caches | 73 to 95 MB, flat from lint 100 on | 400 |

Three caches hold the per lint object graph:

- `MessageDefinitionStore.get_message_definitions` is a `@functools.cache` on a *method*, keyed `(self, msgid)`, so every store ever built stays alive with about 390 `MessageDefinition` objects. That line even carries `# pylint: disable=method-cache-max-size-none`, arguing the cache "will likely stay minimal", which holds for a one shot CLI and not for a worker that lives for a whole session.
- `isort.place.module_with_reason` is an `lru_cache` keyed on `(name, Config)`, pinning the fresh `isort.Config` that pylint's `ImportsChecker` builds per run.
- astroid's `astroid_cache` keeps the linted module, since `lint()` gives every lint a new `NamedTemporaryFile` and so a new module name.

Pylint's own supported release (`--clear-cache-post-run`) is not usable here: it is 14 times slower (290 ms versus 20 ms per lint), its RSS is worse, and it wipes `AstroidManager.brain["_transform"]`, which permanently drops our turtle brain. Verified: after one `clear_cache()`, `turtle.forward(100)` starts reporting "Module 'turtle' has no 'forward' member".

</details>

**Manual testing instructions**
- Open the scratchpad, run code that exhausts memory (a loop appending to a list until it dies), then keep typing. Linting keeps working and no uncaught error reaches the console.
- Do the same with a file added through the dropzone. After the restart the file is still listed and still readable from Python.

**Checklist**
- Tests: `test/__tests__/state/RuntimeRecovery.test.ts`, six cases. A failed lint resolves instead of throwing and leaves the runtime alone; a `MemoryError` replaces the runtime and restores its files, whether it came from a lint or from a run; a recovery closes the input prompt of the run it abandons; provided files are handed over again; a failed launch stops linting without retrying it. All fail before this change. `SyncClient.test.ts` gains one case for restarting an already terminated client, which fails before this change too.
- Docs: n/a
- Announcement: 🐛 The coding scratchpad now recovers by itself when it runs out of memory, instead of quietly losing its error highlighting.
- AI: Claude Code traced the Sentry issue to its root cause and wrote this change, via the sentry-triage skill.

Reaches production once Dodona bumps `@dodona/papyros`.


