### PR TITLE
Request reviews from the maintainers via CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Requested as reviewers on every pull request, except the author.
+* @bmesuere @TomNaessens @thvmulle


### PR DESCRIPTION
This pull request adds a `.github/CODEOWNERS` file that makes GitHub request a review from @bmesuere, @TomNaessens and @thvmulle on every pull request. GitHub never requests a review from the PR author, so in practice each PR goes to the other two.

This only requests reviews. It does not block merging, because "Require review from Code Owners" is a separate ruleset setting that stays off.