### PR TITLE
Keep the runner usable when no backend was launched

### DIFF
--- a/src/frontend/components/code_runner/ButtonLint.ts
+++ b/src/frontend/components/code_runner/ButtonLint.ts
@@ -28,7 +28,11 @@ export class ButtonLint extends PapyrosElement {
     }
 
     get buttons(): TemplateResult | TemplateResult[] {
-        if (this.papyros.runner.state === RunState.Ready) {
+        const state = this.papyros.runner.state;
+        if (state === RunState.Ready || state === RunState.Error) {
+            // Without a backend there is nothing to run or stop, so the run
+            // controls stay in place but inert
+            const disabled = state === RunState.Error;
             if (this.papyros.debugger.active) {
                 return html` <md-outlined-button @click=${() => (this.papyros.debugger.active = false)}>
                     <span slot="icon">${this.papyros.constants.icons.stopDebug}</span>
@@ -36,13 +40,19 @@ export class ButtonLint extends PapyrosElement {
                 </md-outlined-button>`;
             } else {
                 return [
-                    html` <md-filled-button @click=${() => this.papyros.runner.start(RunMode.Run)}>
+                    html` <md-filled-button
+                        ?disabled=${disabled}
+                        @click=${() => this.papyros.runner.start(RunMode.Run)}
+                    >
                         <span slot="icon">${this.papyros.constants.icons[RunMode.Run]}</span>
                         ${this.t(`Papyros.run_modes.${RunMode.Run}`)}
                     </md-filled-button>`,
                     ...this.papyros.runner.runModes.map(
                         (mode) =>
-                            html` <md-outlined-button @click=${() => this.papyros.runner.start(mode)}>
+                            html` <md-outlined-button
+                                ?disabled=${disabled}
+                                @click=${() => this.papyros.runner.start(mode)}
+                            >
                                 <span slot="icon">${this.papyros.constants.icons[mode]}</span>
                                 ${this.t(`Papyros.run_modes.${mode}`)}
                             </md-outlined-button>`,

--- a/src/frontend/state/Papyros.ts
+++ b/src/frontend/state/Papyros.ts
@@ -1,6 +1,6 @@
 import { State, stateProperty } from "@dodona/lit-state";
 import { Debugger } from "./Debugger";
-import { Runner } from "./Runner";
+import { Runner, RunState } from "./Runner";
 import { InputOutput } from "./InputOutput";
 import { Constants } from "./Constants";
 import { Examples } from "./Examples";
@@ -50,6 +50,9 @@ export class Papyros extends State {
      */
     public async launch(): Promise<Papyros> {
         if (!this.canDeferChannel() && !(await this.ensureChannel())) {
+            // Without a channel the backend is never launched, so the controls must not
+            // offer a run or stop that has nothing to act on
+            this.runner.setState(RunState.Error, this.i18n.t("Papyros.service_worker_error"));
             alert(this.i18n.t("Papyros.service_worker_error"));
         } else {
             try {

--- a/src/frontend/state/Runner.ts
+++ b/src/frontend/state/Runner.ts
@@ -474,6 +474,8 @@ export class Runner extends State {
         let unusable = false;
         const backend = await this.availableBackend();
         if (!backend) {
+            // Leaving the debugger active would offer a stop-debug button here
+            this.papyros.debugger.active = false;
             this.papyros.io.onRunEnd();
             this.papyros.debugger.onRunEnd();
             this.setState(RunState.Error);

--- a/src/frontend/state/Runner.ts
+++ b/src/frontend/state/Runner.ts
@@ -177,16 +177,10 @@ export class Runner extends State {
      * Async getter for the linting diagnostics of the current code
      */
     public async lintSource(): Promise<WorkerDiagnostic[]> {
-        let backend: SyncClient<Backend>;
-        try {
-            backend = await this.backend;
-        } catch {
-            // Launch failures surface through launch(), and a lint cannot recover
-            // from one: retrying the launch on every edit would loop on a runtime
-            // that fails to boot
-            return [];
-        }
-        const proxy = backend.workerProxy;
+        // A lint cannot recover from a failed launch: retrying the launch on every
+        // edit would loop on a runtime that fails to boot
+        const backend = await this.availableBackend();
+        const proxy = backend?.workerProxy;
 
         if (!proxy) {
             return [];
@@ -202,6 +196,19 @@ export class Runner extends State {
                 await this.recoverRuntime();
             }
             return [];
+        }
+    }
+
+    /**
+     * The backend once it is up, or undefined when none was launched or the launch
+     * failed. Launch failures are reported by launch() itself, so callers can treat
+     * both the same way.
+     */
+    private async availableBackend(): Promise<SyncClient<Backend> | undefined> {
+        try {
+            return await this.backend;
+        } catch {
+            return undefined;
         }
     }
 
@@ -251,7 +258,10 @@ export class Runner extends State {
     constructor(papyros: Papyros) {
         super();
         this.papyros = papyros;
-        this.backend = Promise.resolve({} as SyncClient<Backend>);
+        // Nothing is launched yet: a rejection every caller handles, instead of an
+        // empty object whose methods do not exist
+        this.backend = Promise.reject(new Error("No backend has been launched"));
+        this.backend.catch(() => undefined);
 
         this.papyros.events.subscribe(BackendEventType.Input, () => this.setState(RunState.AwaitingInput));
         this.papyros.events.subscribe(BackendEventType.Loading, (e) => this.onLoad(e));
@@ -303,7 +313,7 @@ export class Runner extends State {
      * @return {Promise<void>} Returns when the program has been reset
      */
     public async reset(): Promise<void> {
-        if (![RunState.Ready, RunState.Loading].includes(this.state)) {
+        if (![RunState.Ready, RunState.Loading, RunState.Error].includes(this.state)) {
             await this.stop();
         }
 
@@ -462,7 +472,13 @@ export class Runner extends State {
         let interrupted = false;
         let terminated = false;
         let unusable = false;
-        const backend = await this.backend;
+        const backend = await this.availableBackend();
+        if (!backend) {
+            this.papyros.io.onRunEnd();
+            this.papyros.debugger.onRunEnd();
+            this.setState(RunState.Error);
+            return;
+        }
         this.runStartTime = new Date().getTime();
         try {
             await backend.call(
@@ -512,7 +528,11 @@ export class Runner extends State {
         this.setState(RunState.Stopping);
         this.papyros.io.onRunEnd();
         this.papyros.debugger.onRunEnd();
-        const backend = await this.backend;
+        const backend = await this.availableBackend();
+        if (!backend) {
+            this.setState(RunState.Error);
+            return;
+        }
         await backend.interrupt();
 
         const startTime = new Date().getTime();
@@ -530,24 +550,27 @@ export class Runner extends State {
     }
 
     public async provideInput(input: string): Promise<void> {
-        const backend = await this.backend;
+        const backend = await this.availableBackend();
+        if (!backend) {
+            return;
+        }
         this.setState(RunState.Running);
         await backend.writeMessage(input);
     }
 
     public async deleteFile(name: string): Promise<void> {
-        const backend = await this.backend;
-        await backend.workerProxy.deleteFile(name);
+        const backend = await this.availableBackend();
+        await backend?.workerProxy.deleteFile(name);
     }
 
     public async updateFile(name: string, content: string, binary: boolean): Promise<void> {
-        const backend = await this.backend;
-        await backend.workerProxy.updateFile(name, content, binary);
+        const backend = await this.availableBackend();
+        await backend?.workerProxy.updateFile(name, content, binary);
     }
 
     public async renameFile(oldName: string, newName: string): Promise<void> {
-        const backend = await this.backend;
-        await backend.workerProxy.renameFile(oldName, newName);
+        const backend = await this.availableBackend();
+        await backend?.workerProxy.renameFile(oldName, newName);
     }
 
     public upsertFile(name: string, content: string, binary: boolean): void {
@@ -595,17 +618,27 @@ export class Runner extends State {
         }
         this.providedFiles = [inlinedFiles, hrefFiles];
         // parseData hands application/json data over as-is, so it must be the object
-        this.onLoad({
-            type: BackendEventType.Loading,
-            data: {
-                modules: fileNames,
-                status: "loading",
-            },
-            contentType: "application/json",
-        });
+        const report = (status: LoadingData["status"]): void =>
+            this.onLoad({
+                type: BackendEventType.Loading,
+                data: { modules: fileNames, status },
+                contentType: "application/json",
+            });
+        report("loading");
 
-        const backend = await this.backend;
-        await backend.workerProxy.provideFiles(inlinedFiles, hrefFiles);
+        const backend = await this.availableBackend();
+        if (!backend) {
+            report("failed");
+            return;
+        }
+        try {
+            await backend.workerProxy.provideFiles(inlinedFiles, hrefFiles);
+        } catch (error) {
+            // Nothing else reports these files as loaded, so the runner would stay
+            // loading forever behind a stop button that has nothing to stop
+            report("failed");
+            throw error;
+        }
     }
 
     /**

--- a/test/__tests__/components/ButtonLint.test.ts
+++ b/test/__tests__/components/ButtonLint.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { Papyros } from "../../../src/frontend/state/Papyros";
+import { RunState } from "../../../src/frontend/state/Runner";
+import type { ButtonLint } from "../../../src/frontend/components/code_runner/ButtonLint";
+import "../../../src/frontend/components/code_runner/ButtonLint";
+
+function buttons(element: ButtonLint): HTMLElement[] {
+    return Array.from(element.shadowRoot!.querySelectorAll("md-filled-button, md-outlined-button"));
+}
+
+describe("ButtonLint", () => {
+    it("offers inert run controls instead of a stop button when the backend failed", async () => {
+        const element = document.createElement("p-button-lint") as ButtonLint;
+        element.papyros = new Papyros();
+        document.body.append(element);
+
+        await element.updateComplete;
+        expect(buttons(element).map((b) => b.textContent!.trim())).toEqual(["Run", "Debug"]);
+        expect(buttons(element).every((b) => !b.hasAttribute("disabled"))).toBe(true);
+
+        element.papyros.runner.setState(RunState.Error);
+        await element.updateComplete;
+        expect(buttons(element).map((b) => b.textContent!.trim())).toEqual(["Run", "Debug"]);
+        expect(buttons(element).every((b) => b.hasAttribute("disabled"))).toBe(true);
+
+        element.papyros.runner.setState(RunState.Running);
+        await element.updateComplete;
+        expect(buttons(element).map((b) => b.textContent!.trim())).toEqual(["Stop"]);
+
+        element.remove();
+    });
+});

--- a/test/__tests__/state/NoBackend.test.ts
+++ b/test/__tests__/state/NoBackend.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { Papyros } from "../../../src/frontend/state/Papyros";
 import { ProgrammingLanguage } from "../../../src/ProgrammingLanguage";
 import { RunState } from "../../../src/frontend/state/Runner";
+import { RunMode } from "../../../src/backend/Backend";
 
 // Fails fast instead of letting a regression hit the suite timeout
 function withTimeout<T>(promise: Promise<T>, ms: number, what: string): Promise<T> {
@@ -27,10 +28,12 @@ describe("Runner without a backend", () => {
         const papyros = new Papyros();
         papyros.runner.code = "print(1)";
 
-        await withTimeout(papyros.runner.start(), 2000, "runner.start()");
+        await withTimeout(papyros.runner.start(RunMode.Debug), 2000, "runner.start()");
 
         expect(papyros.runner.state).toBe(RunState.Error);
         expect(papyros.io.output).toEqual([]);
+        // An active debugger would put a stop-debug button among the inert controls
+        expect(papyros.debugger.active).toBe(false);
     });
 
     it("does not stay loading when files cannot be handed over", async () => {

--- a/test/__tests__/state/NoBackend.test.ts
+++ b/test/__tests__/state/NoBackend.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import { Papyros } from "../../../src/frontend/state/Papyros";
+import { ProgrammingLanguage } from "../../../src/ProgrammingLanguage";
+import { RunState } from "../../../src/frontend/state/Runner";
+
+// Fails fast instead of letting a regression hit the suite timeout
+function withTimeout<T>(promise: Promise<T>, ms: number, what: string): Promise<T> {
+    let timer: ReturnType<typeof setTimeout>;
+    const timeout = new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${what} did not settle within ${ms} ms`)), ms);
+    });
+    return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+// Everything the controls can trigger must settle without a backend: the run and
+// stop buttons stay reachable when the launch never happened or failed
+describe("Runner without a backend", () => {
+    it("stops without throwing when nothing was launched", async () => {
+        const papyros = new Papyros();
+
+        await withTimeout(papyros.runner.stop(), 2000, "runner.stop()");
+
+        expect(papyros.runner.state).toBe(RunState.Error);
+    });
+
+    it("refuses to start when nothing was launched", async () => {
+        const papyros = new Papyros();
+        papyros.runner.code = "print(1)";
+
+        await withTimeout(papyros.runner.start(), 2000, "runner.start()");
+
+        expect(papyros.runner.state).toBe(RunState.Error);
+        expect(papyros.io.output).toEqual([]);
+    });
+
+    it("does not stay loading when files cannot be handed over", async () => {
+        const papyros = new Papyros();
+
+        await withTimeout(papyros.runner.provideFiles({ "data.txt": "1" }, {}), 2000, "runner.provideFiles()");
+
+        expect(papyros.runner.loadingPackages).toEqual([]);
+        expect(papyros.runner.state).not.toBe(RunState.Loading);
+    });
+
+    it("ignores input and file operations when nothing was launched", async () => {
+        const papyros = new Papyros();
+
+        await withTimeout(
+            Promise.all([
+                papyros.runner.provideInput("42"),
+                papyros.runner.updateFile("a.txt", "1", false),
+                papyros.runner.renameFile("a.txt", "b.txt"),
+                papyros.runner.deleteFile("b.txt"),
+            ]),
+            2000,
+            "runner file operations",
+        );
+
+        expect(await papyros.runner.lintSource()).toEqual([]);
+    });
+
+    it("stops without throwing after a failed launch", async () => {
+        vi.spyOn(window, "confirm").mockReturnValue(false);
+
+        const papyros = new Papyros();
+        papyros.setErrorHandler(vi.fn());
+        papyros.runner.registerBackend(
+            ProgrammingLanguage.Python,
+            () =>
+                ({
+                    workerProxy: {
+                        launch: () => Promise.reject(new Error("worker failed to start")),
+                    },
+                }) as any,
+        );
+        await withTimeout(papyros.launch(), 2000, "Papyros.launch()");
+        expect(papyros.runner.state).toBe(RunState.Error);
+
+        await withTimeout(papyros.runner.stop(), 2000, "runner.stop()");
+        expect(papyros.runner.state).toBe(RunState.Error);
+
+        await withTimeout(papyros.runner.start(), 2000, "runner.start()");
+        expect(papyros.runner.state).toBe(RunState.Error);
+
+        // Nothing is running, so there is nothing for a reset to stop
+        await withTimeout(papyros.runner.reset(), 2000, "runner.reset()");
+        expect(papyros.runner.state).toBe(RunState.Error);
+    });
+
+    it("marks the runner as failed when the input channel cannot be created", async () => {
+        const alert = vi.spyOn(window, "alert").mockImplementation(() => undefined);
+
+        const papyros = new Papyros();
+        vi.spyOn(papyros as any, "canDeferChannel").mockReturnValue(false);
+        vi.spyOn(papyros, "ensureChannel").mockResolvedValue(false);
+
+        await withTimeout(papyros.launch(), 2000, "Papyros.launch()");
+
+        expect(alert).toHaveBeenCalledOnce();
+        expect(papyros.runner.state).toBe(RunState.Error);
+        expect(papyros.runner.stateMessage).toBe(papyros.i18n.t("Papyros.service_worker_error"));
+        expect(papyros.runner.backendReady).toBe(false);
+
+        await withTimeout(papyros.runner.stop(), 2000, "runner.stop()");
+        expect(papyros.runner.state).toBe(RunState.Error);
+    });
+});


### PR DESCRIPTION
This pull request stops `Runner.stop()` and friends from crashing when no backend was ever launched. When the input service worker fails to register, `Papyros.launch()` never launches the runner, but the run controls stayed active on top of a placeholder backend (an empty object), so stopping crashed with `interrupt is not a function`. The Error state after a failed launch had the same problem: it still rendered a Stop button that re-threw the launch error.

Changes:
- The runner starts from a handled rejection instead of the placeholder, and every method the controls can reach (start, stop, input, file operations, file handover) settles quietly when no backend is available.
- A missing input channel puts the runner in the Error state with the service worker message, instead of leaving it Ready.
- In the Error state the Run buttons render disabled instead of a Stop button.
- A file handover that fails clears its loading entries, so the runner can no longer sit in Loading forever behind a Stop button with nothing to stop. This is the likely reason the Stop button was reachable in the Sentry breadcrumbs.

Scope left as is: the language and example pickers stay disabled in the Error state, so recovery from a failed launch still goes through the existing retry confirm dialog.

**Manual testing instructions**
- In the demo, make service worker registration fail (for instance by pointing `serviceWorkerName` at a missing file in a browser without SharedArrayBuffer and JSPI) and load the page. The alert still appears, the state line shows the service worker error, and the Run and Debug buttons are disabled. No Stop button appears and nothing throws in the console.
- Normal launch in Chrome, Firefox and Safari: run, stop, input and file operations behave as before.

**Checklist**
- Tests: `NoBackend.test.ts` covers stop, start, input, file operations and file handover on a never-launched runner, the same after a failed launch, and the failed-channel path through `Papyros.launch()`. `ButtonLint.test.ts` checks the buttons across the Ready, Error and Running states.
- Docs: n/a
- Announcement: n/a
- AI: Claude Code diagnosed the issue against the code, wrote the fix and the tests, human reviewed.

Closes #1139