### PR TITLE
Add a focus ring, accessible names and a visible escape hint to the editors

### DIFF
--- a/src/frontend/components/FileViewer.ts
+++ b/src/frontend/components/FileViewer.ts
@@ -104,6 +104,7 @@ export class FileViewer extends PapyrosElement {
                 .value=${this.file.content}
                 .readonly=${readonly}
                 .theme=${this.papyros.constants.CodeMirrorTheme}
+                .accessibleName=${this.t("Papyros.editor.file_label", { name: this.file.name })}
                 @change=${this.onEditorChange}
             ></p-file-editor>
         `;

--- a/src/frontend/components/code_mirror/CodeEditor.ts
+++ b/src/frontend/components/code_mirror/CodeEditor.ts
@@ -59,6 +59,7 @@ export class CodeEditor extends CodeMirrorEditor {
             :host {
                 width: 100%;
                 height: 100%;
+                position: relative;
             }
 
             .papyros-test-line {
@@ -105,6 +106,25 @@ export class CodeEditor extends CodeMirrorEditor {
                 clip-path: inset(50%);
                 white-space: nowrap;
                 border: 0;
+            }
+
+            /* Shown as a pill in the bottom-left corner while the editor is focused, the
+               counterpart of the run-state pill on the right; screen-reader-only otherwise. */
+            .cm-editor.cm-focused ~ #escape-hint {
+                position: absolute;
+                inset: auto auto 0 6px;
+                width: auto;
+                height: auto;
+                margin: 0;
+                padding: 0.25rem 1rem;
+                overflow: visible;
+                clip-path: none;
+                white-space: nowrap;
+                font-size: 0.75rem;
+                border-radius: 1rem 1rem 0 0;
+                color: var(--md-sys-color-on-surface-variant);
+                background-color: var(--md-sys-color-surface-container);
+                z-index: 5;
             }
         `;
     }

--- a/src/frontend/components/code_mirror/CodeMirrorEditor.ts
+++ b/src/frontend/components/code_mirror/CodeMirrorEditor.ts
@@ -61,6 +61,13 @@ export class CodeMirrorEditor extends LitElement {
         });
     }
 
+    // Accessible name for .cm-content, since CodeMirror itself doesn't label it.
+    set accessibleName(value: string) {
+        this.configure({
+            accessibleName: EditorView.contentAttributes.of({ "aria-label": value }),
+        });
+    }
+
     set theme(theme: Extension) {
         this.configure({ theme: theme });
     }

--- a/src/frontend/components/code_mirror/Extensions.ts
+++ b/src/frontend/components/code_mirror/Extensions.ts
@@ -136,6 +136,7 @@ export const [debugLineExtension, setDebugLines, debugLineState] = lineEffectExt
 export const [testLineExtension, setTestLines, testLineState] = lineEffectExtension({
     lineClass: "papyros-test-line",
     gutterClass: "",
+    marker: "T",
 });
 
 // Inline SVGs instead of unicode glyphs (🖉, ⨯), which many system fonts lack.

--- a/src/frontend/components/code_mirror/MaterialTheme.ts
+++ b/src/frontend/components/code_mirror/MaterialTheme.ts
@@ -29,8 +29,14 @@ export const materialTheme = EditorView.theme(
             backgroundColor: "color-mix(in srgb, var(--md-sys-color-primary) 10%, transparent) !important",
         },
 
+        // Inset so the ring stays inside the editor bounds instead of overflowing it.
         "&.cm-focused": {
-            outline: "none",
+            outline: "2px solid var(--md-sys-color-primary)",
+            outlineOffset: "-2px",
+        },
+
+        ".cm-placeholder": {
+            color: "var(--md-sys-color-on-surface-variant)",
         },
 
         ".cm-selectionBackground": {

--- a/src/frontend/components/code_runner/Code.ts
+++ b/src/frontend/components/code_runner/Code.ts
@@ -30,6 +30,7 @@ export class Code extends PapyrosElement {
                 .placeholder=${this.t("Papyros.code_placeholder", {
                     programmingLanguage: this.papyros.runner.programmingLanguage,
                 })}
+                .accessibleName=${this.t("Papyros.editor.code_label")}
                 .testLines=${this.papyros.test.testLines}
                 .testTranslations=${this.papyros.i18n.getTranslations("Papyros.editor.test_code")}
                 @edit-test-code=${() => this.papyros.test.editTestCode()}

--- a/src/frontend/components/input/BatchInput.ts
+++ b/src/frontend/components/input/BatchInput.ts
@@ -40,6 +40,7 @@ export class BatchInput extends PapyrosElement {
                 .placeholder=${this.placeholder}
                 .translations=${this.papyros.i18n.getTranslations("CodeMirror")}
                 .theme=${this.papyros.constants.CodeMirrorTheme}
+                .accessibleName=${this.t("Papyros.editor.input_label")}
                 @change=${(e: CustomEvent) => (this.papyros.io.inputBuffer = e.detail)}
             ></p-batch-input-editor>
         `;

--- a/src/frontend/state/Translations.ts
+++ b/src/frontend/state/Translations.ts
@@ -66,6 +66,9 @@ export const ENGLISH_TRANSLATION = {
             heap_objects: "Heap objects",
         },
         editor: {
+            code_label: "Code editor",
+            input_label: "Input",
+            file_label: "File %{name}",
             test_code: {
                 description: "# Appended testcase code for debugging purposes",
                 edit: "Edit",
@@ -168,6 +171,9 @@ export const DUTCH_TRANSLATION = {
             heap_objects: "Objecten op de heap",
         },
         editor: {
+            code_label: "Code-editor",
+            input_label: "Invoer",
+            file_label: "Bestand %{name}",
             test_code: {
                 description: "# Toegevoegde testcase code voor debugdoeleinden",
                 edit: "Bewerk",


### PR DESCRIPTION
This pull request fixes the accessibility gaps in the CodeMirror editors that an axe-core run and a manual audit turned up.

- The Material theme removed CodeMirror's focus outline without a replacement, so no editor showed that it had keyboard focus. Every editor now gets an inset 2px ring in the primary colour. (is tweaked in the later UI PR)
- No editor had an accessible name, so screen readers announced an unnamed text box. The code, batch input and file editors now set `aria-label` through a new `accessibleName` property on the base editor, wired into `EditorView.contentAttributes` the same way `placeholder` is, so it follows the locale.
- The "Press Escape followed by Tab" hint existed only for screen readers. It is now shown as a pill in the bottom-left corner while the editor is focused, the counterpart of the run-state pill on the right. (also restyle in the later PR)
- The placeholder colour uses the on-surface-variant token instead of CodeMirror's default `#888`, which failed the 4.5:1 contrast ratio in every theme.
- Test-code lines get a "T" gutter marker, like the debug and input line markers, so they are no longer distinguished by background colour alone.

![Focused code editor with a focus ring and the escape hint pill](https://github.com/user-attachments/assets/d41823db-771e-4d47-a21b-b8f65b4b5329)

**Manual testing instructions**
- Tab into the code editor: a ring appears around it and the hint shows bottom-left. Click elsewhere: both disappear.
- With VoiceOver on, focus the code editor, the batch input editor and a file editor: they are announced as "Code editor", "Input" and "File <name>".
- Switch the locale to Dutch and check the names follow.

Update #1141
