### PR TITLE
Announce program output and make the output tabs keyboard accessible

### DIFF
--- a/src/frontend/components/Output.ts
+++ b/src/frontend/components/Output.ts
@@ -267,6 +267,7 @@ export class Output extends PapyrosElement {
                     id="tab-output"
                     role="tab"
                     aria-selected=${activeTab === OUTPUT_TAB}
+                    aria-controls="output-panel"
                     tabindex=${activeTab === OUTPUT_TAB ? 0 : -1}
                     class=${activeTab === OUTPUT_TAB ? "active" : ""}
                     @click=${() => this.papyros.io.selectOutputTab(OUTPUT_TAB)}
@@ -280,6 +281,7 @@ export class Output extends PapyrosElement {
                                   id="tab-turtle"
                                   role="tab"
                                   aria-selected=${activeTab === TURTLE_TAB}
+                                  aria-controls="output-panel"
                                   tabindex=${activeTab === TURTLE_TAB ? 0 : -1}
                                   class=${activeTab === TURTLE_TAB ? "active" : ""}
                                   @click=${() => this.papyros.io.selectOutputTab(TURTLE_TAB)}
@@ -303,6 +305,7 @@ export class Output extends PapyrosElement {
             ${this.renderTabs()}
             <div
                 class="content ${activeTab === TURTLE_TAB ? "turtle" : ""}"
+                id="output-panel"
                 role="tabpanel"
                 aria-labelledby="tab-${activeTab}"
                 tabindex="0"

--- a/src/frontend/components/Output.ts
+++ b/src/frontend/components/Output.ts
@@ -1,6 +1,6 @@
 import { customElement } from "lit/decorators.js";
 import { css, CSSResult, html, TemplateResult } from "lit";
-import { FriendlyError, OutputEntry, OutputType, OUTPUT_TAB, TURTLE_TAB } from "../state/InputOutput";
+import { FriendlyError, OutputEntry, OutputTab, OutputType, OUTPUT_TAB, TURTLE_TAB } from "../state/InputOutput";
 import { PapyrosElement } from "./PapyrosElement";
 import { tabButtonStyles } from "./shared-styles";
 import { TurtlePatch, TurtleSvgBuilder } from "../state/TurtleSvg";
@@ -33,6 +33,11 @@ export class Output extends PapyrosElement {
                 container-type: size;
                 padding: 0.75rem;
                 background-color: var(--md-sys-color-surface-container-highest);
+            }
+
+            .content:focus-visible {
+                outline: 2px solid var(--md-sys-color-primary);
+                outline-offset: -2px;
             }
 
             .content.turtle {
@@ -77,8 +82,16 @@ export class Output extends PapyrosElement {
             }
 
             .place-holder {
-                color: var(--md-sys-color-on-surface);
-                opacity: 0.5;
+                color: var(--md-sys-color-on-surface-variant);
+            }
+
+            .visually-hidden {
+                position: absolute;
+                width: 1px;
+                height: 1px;
+                overflow: hidden;
+                clip: rect(0 0 0 0);
+                white-space: nowrap;
             }
 
             md-icon {
@@ -157,7 +170,13 @@ export class Output extends PapyrosElement {
             const svg = this.turtleSvg.build(patches);
             return svg === undefined
                 ? []
-                : [html`<img class="turtle" src="data:image/svg+xml,${encodeURIComponent(svg)}"></img>`];
+                : [
+                      html`<img
+                          class="turtle"
+                          src="data:image/svg+xml,${encodeURIComponent(svg)}"
+                          alt=${this.t("Papyros.turtle_alt")}
+                      />`,
+                  ];
         }
         const outputsToRender: OutputEntry[] = this.outputs.filter((o) => o.type !== OutputType.turtle);
         return outputsToRender.map((o) => {
@@ -165,18 +184,23 @@ export class Output extends PapyrosElement {
                 return html`${o.content}`;
             } else if (o.type === OutputType.img) {
                 const mimeType = o.contentType ?? "image/png";
-                return html`<img src="data:${mimeType},${o.content as string}"></img>`;
+                return html`<img src="data:${mimeType},${o.content as string}" alt=${this.t("Papyros.image_alt")} />`;
             } else if (o.type === OutputType.stderr) {
                 if (typeof o.content === "string") {
-                    return html`<span class="error">${o.content}</span>`;
+                    return html`<span class="error"
+                        ><span class="visually-hidden">${this.t("Papyros.error_prefix")}</span>${o.content}</span
+                    >`;
                 } else {
                     const errorObject = o.content as FriendlyError;
                     const errorHTML = [
                         // an array to avoid unintentional spaces/newlines
-                        html`<md-icon title="${errorObject.info}">${this.papyros.constants.icons.help}</md-icon
+                        html`<md-icon title="${errorObject.info}" aria-label="${errorObject.info}" role="img"
+                                >${this.papyros.constants.icons.help}</md-icon
                             >${errorObject.name} traceback:`,
                         "\n",
-                        html`<md-icon title="${errorObject.traceback}">${this.papyros.constants.icons.info}</md-icon>`,
+                        html`<md-icon title="${errorObject.traceback}" aria-label="${errorObject.traceback}" role="img"
+                            >${this.papyros.constants.icons.info}</md-icon
+                        >`,
                         html`<span class="where">${errorObject.where?.trim()}</span>`,
                     ];
                     if (errorObject.what) {
@@ -197,11 +221,53 @@ export class Output extends PapyrosElement {
         return this.papyros.io.hasTurtleOutput || this.papyros.io.activeOutputTab === TURTLE_TAB;
     }
 
+    private get visibleTabs(): OutputTab[] {
+        return this.showTurtleTab ? [OUTPUT_TAB, TURTLE_TAB] : [OUTPUT_TAB];
+    }
+
+    /** Standard ARIA tabs pattern: arrow keys move focus and select in one step. */
+    private handleTabsKeydown(e: KeyboardEvent): void {
+        const tabs = this.visibleTabs;
+        const currentIndex = tabs.indexOf(this.papyros.io.activeOutputTab);
+        let nextIndex: number;
+        switch (e.key) {
+            case "ArrowLeft":
+                nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+                break;
+            case "ArrowRight":
+                nextIndex = (currentIndex + 1) % tabs.length;
+                break;
+            case "Home":
+                nextIndex = 0;
+                break;
+            case "End":
+                nextIndex = tabs.length - 1;
+                break;
+            default:
+                return;
+        }
+        e.preventDefault();
+        const nextTab = tabs[nextIndex];
+        this.papyros.io.selectOutputTab(nextTab);
+        this.updateComplete.then(() => {
+            this.renderRoot.querySelector<HTMLElement>(`#tab-${nextTab}`)?.focus();
+        });
+    }
+
     private renderTabs(): TemplateResult {
         const activeTab = this.papyros.io.activeOutputTab;
         return html`
-            <div class="tabs">
+            <div
+                class="tabs"
+                role="tablist"
+                aria-label=${this.t("Papyros.output_tabs")}
+                @keydown=${this.handleTabsKeydown}
+            >
                 <button
+                    id="tab-output"
+                    role="tab"
+                    aria-selected=${activeTab === OUTPUT_TAB}
+                    tabindex=${activeTab === OUTPUT_TAB ? 0 : -1}
                     class=${activeTab === OUTPUT_TAB ? "active" : ""}
                     @click=${() => this.papyros.io.selectOutputTab(OUTPUT_TAB)}
                 >
@@ -211,6 +277,10 @@ export class Output extends PapyrosElement {
                     this.showTurtleTab
                         ? html`
                               <button
+                                  id="tab-turtle"
+                                  role="tab"
+                                  aria-selected=${activeTab === TURTLE_TAB}
+                                  tabindex=${activeTab === TURTLE_TAB ? 0 : -1}
                                   class=${activeTab === TURTLE_TAB ? "active" : ""}
                                   @click=${() => this.papyros.io.selectOutputTab(TURTLE_TAB)}
                               >
@@ -231,13 +301,20 @@ export class Output extends PapyrosElement {
         const showOverflow = activeTab === OUTPUT_TAB && this.showOverflowWarning;
         return html`
             ${this.renderTabs()}
-            <div class="content ${activeTab === TURTLE_TAB ? "turtle" : ""}">
+            <div
+                class="content ${activeTab === TURTLE_TAB ? "turtle" : ""}"
+                role="tabpanel"
+                aria-labelledby="tab-${activeTab}"
+                tabindex="0"
+            >
                 ${
                     showPlaceholder
                         ? html`<pre class="place-holder">${this.t("Papyros.output_placeholder")}</pre>`
                         : showTurtlePlaceholder
                           ? html`<div class="turtle-placeholder"></div>`
-                          : html`<pre>${rendered}</pre>`
+                          : activeTab === OUTPUT_TAB
+                            ? html`<pre role="log" aria-live="polite" aria-relevant="additions text">${rendered}</pre>`
+                            : html`<pre>${rendered}</pre>`
                 }
                 ${
                     showOverflow

--- a/src/frontend/state/Translations.ts
+++ b/src/frontend/state/Translations.ts
@@ -88,6 +88,10 @@ export const ENGLISH_TRANSLATION = {
         files_binary: "Binary file",
         output_tab_output: "Output",
         output_tab_turtle: "Turtle",
+        output_tabs: "Output panes",
+        error_prefix: "Error: ",
+        turtle_alt: "Turtle drawing",
+        image_alt: "Image output",
     },
     CodeMirror: {
         // Papyros
@@ -193,6 +197,10 @@ export const DUTCH_TRANSLATION = {
         files_binary: "Binair bestand",
         output_tab_output: "Uitvoer",
         output_tab_turtle: "Turtle",
+        output_tabs: "Uitvoerpanelen",
+        error_prefix: "Fout: ",
+        turtle_alt: "Turtle-tekening",
+        image_alt: "Afbeelding als uitvoer",
     },
     CodeMirror: {
         // Papyros


### PR DESCRIPTION
This pull request makes the output pane usable with a screen reader and a keyboard.

- The output `<pre>` is a `role="log"` live region, so printed text and errors are announced as they appear.
- The output pane is focusable (`tabindex="0"`) with a focus ring, so keyboard users can scroll long output.
- Plain stderr text was distinguished by colour only. It now carries a visually hidden "Error: " prefix; the visible output is unchanged.
- Turtle drawings and image output get `alt` text, and the traceback icons expose their `title` as `aria-label` too.
- The Output and Turtle tabs follow the ARIA tabs pattern: `tablist`, `tab`, `tabpanel`, `aria-selected`, `aria-controls`, roving tabindex and arrow-key navigation.
- The placeholder text uses the on-surface-variant token instead of a half-transparent on-surface colour, which sat at 3.3:1.

**Manual testing instructions**
- With VoiceOver on, run a program that prints to stdout and stderr: the output is read as it appears and stderr lines are prefixed with "Error:".
- Run a turtle program, Tab to the Output tab and press the right arrow: the Turtle tab is selected and focused.
- Tab into the output pane of a long-running print loop and scroll it with the arrow keys.

Update #1141
