### PR TITLE
Name the header controls and announce run-state changes

### DIFF
--- a/src/frontend/components/CodeRunner.ts
+++ b/src/frontend/components/CodeRunner.ts
@@ -55,10 +55,13 @@ export class CodeRunner extends PapyrosElement {
                 position: absolute;
                 bottom: 0;
                 right: 6px;
-                background-color: var(--md-sys-color-surface-container);
-                padding: 0.25rem 1rem;
                 border-top-right-radius: 1rem;
                 border-top-left-radius: 1rem;
+            }
+
+            p-run-state:not([empty]) {
+                background-color: var(--md-sys-color-surface-container);
+                padding: 0.25rem 1rem;
             }
 
             p-button-lint {
@@ -166,11 +169,7 @@ export class CodeRunner extends PapyrosElement {
                             ? html`<p-code .papyros=${this.papyros}></p-code>`
                             : html`<p-file-viewer .papyros=${this.papyros} .file=${activeFile}></p-file-viewer>`
                     }
-                    ${
-                        this.papyros.runner.stateMessage
-                            ? html`<p-run-state .papyros=${this.papyros}></p-run-state>`
-                            : ""
-                    }
+                    <p-run-state .papyros=${this.papyros}></p-run-state>
                 </div>
                 <p-button-lint .papyros=${this.papyros}>
                     <slot name="buttons"></slot>

--- a/src/frontend/components/app/App.ts
+++ b/src/frontend/components/app/App.ts
@@ -164,13 +164,19 @@ export class App extends PapyrosElement {
 
     protected override render(): TemplateResult {
         this.setTheme(this.papyros.constants.activeTheme);
+        document.documentElement.lang = this.papyros.i18n.locale;
         return html`
             <div class="rows">
                 <div class="header">
                     <div class="header-options">
                         <span class="title">${this.t("Papyros.Papyros")}</span>
-                        <md-icon-button href="https://github.com/dodona-edu/papyros" target="_blank" rel="noopener">
-                            <md-icon>
+                        <md-icon-button
+                            href="https://github.com/dodona-edu/papyros"
+                            target="_blank"
+                            rel="noopener"
+                            aria-label=${this.t("Papyros.github_link")}
+                        >
+                            <md-icon aria-hidden="true">
                                 <svg viewBox="0 0 24 24" fill="currentColor">
                                     <path
                                         d="M12 1.27a11 11 0 00-3.48 21.46c.55.09.73-.28.73-.55v-1.84c-3.03.64-3.67-1.46-3.67-1.46-.55-1.29-1.28-1.65-1.28-1.65-.92-.65.1-.65.1-.65 1.1 0 1.73 1.1 1.73 1.1.92 1.65 2.57 1.2 3.21.92a2 2 0 01.64-1.47c-2.47-.27-5.04-1.19-5.04-5.5 0-1.1.46-2.1 1.2-2.84a3.76 3.76 0 010-2.93s.91-.28 3.11 1.1c1.8-.49 3.7-.49 5.5 0 2.1-1.38 3.02-1.1 3.02-1.1a3.76 3.76 0 010 2.93c.83.74 1.2 1.74 1.2 2.94 0 4.21-2.57 5.13-5.04 5.4.45.37.82.92.82 2.02v3.03c0 .27.1.64.73.55A11 11 0 0012 1.27"

--- a/src/frontend/components/app/App.ts
+++ b/src/frontend/components/app/App.ts
@@ -97,6 +97,7 @@ export class App extends PapyrosElement {
             }
 
             .title {
+                margin: 0;
                 font-size: 1.5rem;
                 font-weight: bold;
                 color: var(--md-sys-color-primary);
@@ -167,9 +168,9 @@ export class App extends PapyrosElement {
         document.documentElement.lang = this.papyros.i18n.locale;
         return html`
             <div class="rows">
-                <div class="header">
+                <header class="header">
                     <div class="header-options">
-                        <span class="title">${this.t("Papyros.Papyros")}</span>
+                        <h1 class="title">${this.t("Papyros.Papyros")}</h1>
                         <md-icon-button
                             href="https://github.com/dodona-edu/papyros"
                             target="_blank"
@@ -190,8 +191,8 @@ export class App extends PapyrosElement {
                         <p-language-picker .papyros=${this.papyros}></p-language-picker>
                         <p-programming-language-picker .papyros=${this.papyros}></p-programming-language-picker>
                     </div>
-                </div>
-                <div class="content">
+                </header>
+                <main class="content">
                     <div class="top">
                         <div class="left container">
                             <p-code-runner .papyros=${this.papyros} class="overflow">
@@ -210,7 +211,7 @@ export class App extends PapyrosElement {
                     <div class="bottom container overflow">
                         <p-debugger .papyros=${this.papyros}></p-debugger>
                     </div>
-                </div>
+                </main>
             </div>
         `;
     }

--- a/src/frontend/components/app/LanguagePicker.ts
+++ b/src/frontend/components/app/LanguagePicker.ts
@@ -9,6 +9,7 @@ export class LanguagePicker extends PapyrosElement {
     protected override render(): TemplateResult {
         return html`
             <md-outlined-select
+                label=${this.t("Papyros.language")}
                 @input=${(e: InputEvent) => {
                     this.papyros.i18n.locale = (e.target as HTMLInputElement).value;
                 }}

--- a/src/frontend/components/app/themes/ThemePicker.ts
+++ b/src/frontend/components/app/themes/ThemePicker.ts
@@ -1,5 +1,5 @@
-import { customElement, property } from "lit/decorators.js";
-import { html, TemplateResult } from "lit";
+import { customElement, property, query } from "lit/decorators.js";
+import { html, PropertyValues, TemplateResult } from "lit";
 import "./ThemedButton";
 import "@material/web/icon/icon";
 import "@material/web/iconbutton/icon-button";
@@ -11,17 +11,43 @@ export class ThemePicker extends PapyrosElement {
     @property({ state: true })
     picking = false;
 
-    setTheme(theme: ThemeOption): void {
+    @query("md-icon-button")
+    private toggleButton?: HTMLElement;
+
+    @query("p-themed-button")
+    private firstThemedButton?: HTMLElement;
+
+    private async close(): Promise<void> {
         this.picking = false;
+        await this.updateComplete;
+        this.toggleButton?.focus();
+    }
+
+    setTheme(theme: ThemeOption): void {
+        void this.close();
         this.papyros.constants.activeTheme = theme;
     }
 
-    protected override render(): TemplateResult[] | TemplateResult {
+    private onKeydown = (e: KeyboardEvent): void => {
+        if (e.key === "Escape") {
+            e.stopPropagation();
+            void this.close();
+        }
+    };
+
+    protected override updated(changed: PropertyValues): void {
+        super.updated(changed);
+        if (changed.has("picking") && this.picking) {
+            this.firstThemedButton?.focus();
+        }
+    }
+
+    protected override render(): TemplateResult {
         if (!this.picking) {
             return html`
-                <md-icon-button @click=${() => (this.picking = true)}>
-                    <md-icon>
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" fill="#currentCollor">
+                <md-icon-button aria-label=${this.t("Papyros.themes.pick")} @click=${() => (this.picking = true)}>
+                    <md-icon aria-hidden="true">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" fill="currentColor">
                             <path
                                 d="M480-80q-82 0-155-31.5t-127.5-86Q143-252 111.5-325T80-480q0-83 32.5-156t88-127Q256-817 330-848.5T488-880q80 0 151 27.5t124.5 76q53.5 48.5 85 115T880-518q0 115-70 176.5T640-280h-74q-9 0-12.5 5t-3.5 11q0 12 15 34.5t15 51.5q0 50-27.5 74T480-80Zm0-400Zm-220 40q26 0 43-17t17-43q0-26-17-43t-43-17q-26 0-43 17t-17 43q0 26 17 43t43 17Zm120-160q26 0 43-17t17-43q0-26-17-43t-43-17q-26 0-43 17t-17 43q0 26 17 43t43 17Zm200 0q26 0 43-17t17-43q0-26-17-43t-43-17q-26 0-43 17t-17 43q0 26 17 43t43 17Zm120 160q26 0 43-17t17-43q0-26-17-43t-43-17q-26 0-43 17t-17 43q0 26 17 43t43 17ZM480-160q9 0 14.5-5t5.5-13q0-14-15-33t-15-57q0-42 29-67t71-25h70q66 0 113-38.5T800-518q0-121-92.5-201.5T488-800q-136 0-232 93t-96 227q0 133 93.5 226.5T480-160Z"
                             />
@@ -31,10 +57,20 @@ export class ThemePicker extends PapyrosElement {
             `;
         }
 
-        return Object.values(this.papyros.constants.themes).map(
-            (t) => html`
-                <p-themed-button .theme=${t.theme} .dark=${t.dark} @click=${() => this.setTheme(t)}></p-themed-button>
-            `,
-        );
+        return html`
+            <div role="group" aria-label=${this.t("Papyros.themes.pick")} @keydown=${this.onKeydown}>
+                ${Object.values(this.papyros.constants.themes).map(
+                    (t) => html`
+                        <p-themed-button
+                            .papyros=${this.papyros}
+                            .theme=${t.theme}
+                            .dark=${t.dark}
+                            .name=${t.name}
+                            @click=${() => this.setTheme(t)}
+                        ></p-themed-button>
+                    `,
+                )}
+            </div>
+        `;
     }
 }

--- a/src/frontend/components/app/themes/ThemedButton.ts
+++ b/src/frontend/components/app/themes/ThemedButton.ts
@@ -1,13 +1,16 @@
-import { adoptStyles, CSSResult, html, LitElement, TemplateResult } from "lit";
+import { adoptStyles, CSSResult, html, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import "@material/web/icon/icon";
 import "@material/web/iconbutton/filled-icon-button";
+import { PapyrosElement } from "../../PapyrosElement";
 
 @customElement("p-themed-button")
-export class ThemedButton extends LitElement {
+export class ThemedButton extends PapyrosElement {
     theme: CSSResult | undefined;
     @property({ type: Boolean })
     dark: boolean = false;
+    @property()
+    name: string = "";
 
     public override connectedCallback(): void {
         super.connectedCallback();
@@ -16,10 +19,23 @@ export class ThemedButton extends LitElement {
         }
     }
 
+    // Focusing the custom element doesn't reach the inner button without delegatesFocus,
+    // and the button may not exist yet on first render.
+    public override focus(options?: FocusOptions): void {
+        void this.updateComplete.then(() => {
+            (this.renderRoot.querySelector("md-filled-icon-button") as HTMLElement | null)?.focus(options);
+        });
+    }
+
     protected override render(): TemplateResult {
+        const colorName = this.t(`Papyros.themes.names.${this.name.split(" ")[0].toLowerCase()}`);
+        const label = this.dark
+            ? this.t("Papyros.themes.dark", { name: colorName })
+            : this.t("Papyros.themes.light", { name: colorName });
+        const active = this.papyros.constants.activeTheme.name === this.name;
         return html`
-            <md-filled-icon-button>
-                <md-icon>
+            <md-filled-icon-button aria-label=${label} aria-pressed=${active}>
+                <md-icon aria-hidden="true">
                     ${
                         this.dark
                             ? html`

--- a/src/frontend/components/code_runner/RunState.ts
+++ b/src/frontend/components/code_runner/RunState.ts
@@ -1,7 +1,7 @@
 import { customElement } from "lit/decorators.js";
 import { PapyrosElement } from "../PapyrosElement";
 import { RunState } from "../../state/Runner";
-import { css, CSSResult, html, TemplateResult } from "lit";
+import { css, CSSResult, html, PropertyValues, TemplateResult } from "lit";
 import "@material/web/progress/circular-progress";
 
 @customElement("p-run-state")
@@ -20,16 +20,22 @@ export class RunStateEl extends PapyrosElement {
         `;
     }
 
+    // Always mounted so the aria-live region exists before content changes,
+    // otherwise screen readers can miss the first announcement.
+    protected override update(changedProperties: PropertyValues): void {
+        this.toggleAttribute("empty", !this.papyros.runner.stateMessage);
+        super.update(changedProperties);
+    }
+
     protected override render(): TemplateResult {
-        if (!this.papyros.runner.stateMessage) return html``;
+        const message = this.papyros.runner.stateMessage;
+        const showSpinner = !!message && ![RunState.Ready, RunState.Error].includes(this.papyros.runner.state);
 
         return html`
-            ${
-                [RunState.Ready, RunState.Error].includes(this.papyros.runner.state)
-                    ? ""
-                    : html` <md-circular-progress indeterminate></md-circular-progress> `
-            }
-            ${this.papyros.runner.stateMessage}
+            <div role="status" aria-live="polite">
+                ${showSpinner ? html`<md-circular-progress indeterminate aria-hidden="true"></md-circular-progress>` : ""}
+                ${message}
+            </div>
         `;
     }
 }

--- a/src/frontend/components/code_runner/RunState.ts
+++ b/src/frontend/components/code_runner/RunState.ts
@@ -11,6 +11,11 @@ export class RunStateEl extends PapyrosElement {
             :host {
                 display: flex;
                 align-items: center;
+            }
+
+            [role="status"] {
+                display: flex;
+                align-items: center;
                 gap: 0.5rem;
             }
 

--- a/src/frontend/state/Translations.ts
+++ b/src/frontend/state/Translations.ts
@@ -7,6 +7,7 @@
 export const ENGLISH_TRANSLATION = {
     Papyros: {
         Papyros: "Papyros",
+        github_link: "Papyros on GitHub",
         code_placeholder: "Write your %{programmingLanguage} code here and click 'Run' to execute...",
         input_placeholder: {
             interactive: "Provide input and press enter to send",
@@ -27,9 +28,21 @@ export const ENGLISH_TRANSLATION = {
             error: "Failed to load",
         },
         programming_language: "Programming language",
+        language: "Language",
         locales: {
             en: "English",
             nl: "Nederlands",
+        },
+        themes: {
+            // Accessible names: announced by screen readers, never shown on screen.
+            pick: "Choose a theme",
+            light: "Light theme %{name}",
+            dark: "Dark theme %{name}",
+            names: {
+                blue: "blue",
+                green: "green",
+                red: "red",
+            },
         },
         input_modes: {
             interactive: "Interactive input",
@@ -120,6 +133,7 @@ export const ENGLISH_TRANSLATION = {
 export const DUTCH_TRANSLATION = {
     Papyros: {
         Papyros: "Papyros",
+        github_link: "Papyros op GitHub",
         code_placeholder: "Schrijf hier je %{programmingLanguage} code en klik op 'Uitvoeren' om uit te voeren...",
         input_placeholder: {
             interactive: "Geef invoer in en druk op enter",
@@ -141,9 +155,21 @@ export const DUTCH_TRANSLATION = {
         finished: "Code uitgevoerd in %{time} s",
         interrupted: "Code onderbroken na %{time} s",
         programming_language: "Programmeertaal",
+        language: "Taal",
         locales: {
             en: "English",
             nl: "Nederlands",
+        },
+        themes: {
+            // Toegankelijkheidslabels: worden voorgelezen door schermlezers, nooit getoond.
+            pick: "Kies een thema",
+            light: "Licht thema %{name}",
+            dark: "Donker thema %{name}",
+            names: {
+                blue: "blauw",
+                green: "groen",
+                red: "rood",
+            },
         },
         input_modes: {
             interactive: "Interactieve invoer",


### PR DESCRIPTION
This pull request gives the header controls of the demo shell accessible names and turns the run state into a live region.

- The GitHub link, the theme picker toggle and the theme swatches were icon-only buttons with no name. They now carry `aria-label`s; each swatch is named after its theme and reports `aria-pressed` for the active one.
- The language selector had no `label`, unlike the example and programming-language pickers.
- Opening the theme picker moves focus to the first swatch, Escape closes it, and closing returns focus to the toggle.
- `document.documentElement.lang` follows the chosen locale, so screen readers switch to Dutch pronunciation with the UI.
- `p-run-state` was only rendered while there was a message, so Running, Loading, Awaiting input and Code executed were never announced. It is now always mounted with a persistent `role="status"` region; the host paints nothing while empty.
- The demo shell gets a `<header>`, an `<h1>` for the title and a `<main>` around the content, which clears axe's landmark and heading rules.
- The palette icon's `fill="#currentCollor"` typo is fixed, so the icon takes the theme colour instead of black.

**Manual testing instructions**
- With VoiceOver on, Tab through the header: the GitHub link, theme picker and language selector are announced by name. Open the theme picker: focus lands on the first swatch, Escape closes it.
- Run a program: "Running" and "Code executed in x s" are announced without moving focus.
- Switch to Nederlands and check `<html lang>` in the inspector.

Update #1141
