### PR TITLE
Keep keyboard focus on the run controls when the button set changes

### DIFF
--- a/src/frontend/components/Debugger.ts
+++ b/src/frontend/components/Debugger.ts
@@ -47,8 +47,7 @@ export class Debugger extends PapyrosElement {
             }
 
             .place-holder {
-                color: var(--md-sys-color-on-surface);
-                opacity: 0.5;
+                color: var(--md-sys-color-on-surface-variant);
             }
 
             .scroll-region {

--- a/src/frontend/components/Debugger.ts
+++ b/src/frontend/components/Debugger.ts
@@ -50,21 +50,31 @@ export class Debugger extends PapyrosElement {
                 color: var(--md-sys-color-on-surface);
                 opacity: 0.5;
             }
+
+            .scroll-region {
+                height: 100%;
+                overflow: auto;
+            }
         `;
     }
 
     protected override render(): TemplateResult {
-        if (!this.papyros.debugger.active || this.papyros.debugger.trace.length === 0) {
-            return html`<div class="place-holder">${this.t("Papyros.debug_placeholder")}</div>`;
-        }
-
-        return html`<tc-trace
-            .trace=${this.papyros.debugger.trace}
-            .translations=${this.papyros.i18n.getTranslations("Papyros.debugger")}
-            .selectedFrame=${this.papyros.debugger.activeFrame ?? 0}
-            @frame-change=${(e: CustomEvent) => {
-                this.papyros.debugger.activeFrame = e.detail.frame;
-            }}
-        ></tc-trace>`;
+        const hasTrace = this.papyros.debugger.active && this.papyros.debugger.trace.length > 0;
+        return html`
+            <div class="scroll-region" role="region" tabindex="0" aria-label=${this.t("Papyros.debugger.title")}>
+                ${
+                    hasTrace
+                        ? html`<tc-trace
+                              .trace=${this.papyros.debugger.trace}
+                              .translations=${this.papyros.i18n.getTranslations("Papyros.debugger")}
+                              .selectedFrame=${this.papyros.debugger.activeFrame ?? 0}
+                              @frame-change=${(e: CustomEvent) => {
+                                  this.papyros.debugger.activeFrame = e.detail.frame;
+                              }}
+                          ></tc-trace>`
+                        : html`<div class="place-holder">${this.t("Papyros.debug_placeholder")}</div>`
+                }
+            </div>
+        `;
     }
 }

--- a/src/frontend/components/code_runner/ButtonLint.ts
+++ b/src/frontend/components/code_runner/ButtonLint.ts
@@ -1,10 +1,17 @@
 import { customElement } from "lit/decorators.js";
-import { css, CSSResult, html, TemplateResult } from "lit";
+import { css, CSSResult, html, PropertyValues, TemplateResult } from "lit";
+import { createRef, Ref, ref } from "lit/directives/ref.js";
 import { RunState } from "../../state/Runner";
 import { PapyrosElement } from "../PapyrosElement";
 import { RunMode } from "../../../backend/Backend";
 import "@material/web/button/filled-button";
 import "@material/web/button/outlined-button";
+
+/**
+ * Which button set is currently rendered. Distinct from RunState: several
+ * states (e.g. Running, Loading) all render the same single Stop button.
+ */
+type ButtonSet = "run" | "stop" | "stop-debugging";
 
 @customElement("p-button-lint")
 export class ButtonLint extends PapyrosElement {
@@ -27,6 +34,46 @@ export class ButtonLint extends PapyrosElement {
         `;
     }
 
+    /**
+     * The first (primary) button of the currently rendered set, so focus can
+     * follow it when that set changes.
+     */
+    private firstButtonRef: Ref<HTMLElement> = createRef();
+    private renderedSet: ButtonSet | undefined = undefined;
+    /**
+     * Whether focus was inside this component right before the button set
+     * changes, so the successor button is only focused when a keyboard user
+     * was actually driving this component, never when e.g. typing elsewhere.
+     */
+    private shouldRefocus = false;
+
+    private get buttonSet(): ButtonSet {
+        const state = this.papyros.runner.state;
+        if (state === RunState.Ready || state === RunState.Error) {
+            return this.papyros.debugger.active ? "stop-debugging" : "run";
+        }
+        return "stop";
+    }
+
+    protected override willUpdate(changedProperties: PropertyValues): void {
+        super.willUpdate(changedProperties);
+        const newSet = this.buttonSet;
+        const focusWasInside = this.shadowRoot?.activeElement != null;
+        this.shouldRefocus = focusWasInside && newSet !== this.renderedSet;
+        this.renderedSet = newSet;
+    }
+
+    protected override updated(changedProperties: PropertyValues): void {
+        super.updated(changedProperties);
+        if (this.shouldRefocus) {
+            const button = this.firstButtonRef.value;
+            // The button set was just (re)created: a freshly minted md-* element has
+            // not rendered its own focusable internals yet. Its own render is queued
+            // as a microtask, which is guaranteed to flush before the next frame.
+            requestAnimationFrame(() => button?.focus());
+        }
+    }
+
     get buttons(): TemplateResult | TemplateResult[] {
         const state = this.papyros.runner.state;
         if (state === RunState.Ready || state === RunState.Error) {
@@ -34,13 +81,17 @@ export class ButtonLint extends PapyrosElement {
             // controls stay in place but inert
             const disabled = state === RunState.Error;
             if (this.papyros.debugger.active) {
-                return html` <md-outlined-button @click=${() => (this.papyros.debugger.active = false)}>
+                return html` <md-outlined-button
+                    ${ref(this.firstButtonRef)}
+                    @click=${() => (this.papyros.debugger.active = false)}
+                >
                     <span slot="icon">${this.papyros.constants.icons.stopDebug}</span>
                     ${this.t("Papyros.debug.stop")}
                 </md-outlined-button>`;
             } else {
                 return [
                     html` <md-filled-button
+                        ${ref(this.firstButtonRef)}
                         ?disabled=${disabled}
                         @click=${() => this.papyros.runner.start(RunMode.Run)}
                     >
@@ -60,7 +111,7 @@ export class ButtonLint extends PapyrosElement {
                 ];
             }
         } else {
-            return html` <md-filled-button @click=${() => this.papyros.runner.stop()}>
+            return html` <md-filled-button ${ref(this.firstButtonRef)} @click=${() => this.papyros.runner.stop()}>
                 <span slot="icon">${this.papyros.constants.icons.stop}</span>
                 ${this.t("Papyros.stop")}
             </md-filled-button>`;

--- a/src/frontend/components/code_runner/ButtonLint.ts
+++ b/src/frontend/components/code_runner/ButtonLint.ts
@@ -66,11 +66,14 @@ export class ButtonLint extends PapyrosElement {
     protected override updated(changedProperties: PropertyValues): void {
         super.updated(changedProperties);
         if (this.shouldRefocus) {
-            const button = this.firstButtonRef.value;
             // The button set was just (re)created: a freshly minted md-* element has
             // not rendered its own focusable internals yet. Its own render is queued
             // as a microtask, which is guaranteed to flush before the next frame.
-            requestAnimationFrame(() => button?.focus());
+            requestAnimationFrame(() => {
+                // A render in between can have replaced the button, so take the current one.
+                const button = this.firstButtonRef.value;
+                if (button?.isConnected) button.focus();
+            });
         }
     }
 

--- a/test/__tests__/components/ButtonLint.test.ts
+++ b/test/__tests__/components/ButtonLint.test.ts
@@ -8,6 +8,12 @@ function buttons(element: ButtonLint): HTMLElement[] {
     return Array.from(element.shadowRoot!.querySelectorAll("md-filled-button, md-outlined-button"));
 }
 
+// Focus-follow is deferred to the next frame, so newly created md-* buttons have
+// finished their own initial render before .focus() is called on them.
+function nextFrame(): Promise<void> {
+    return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
 describe("ButtonLint", () => {
     it("offers inert run controls instead of a stop button when the backend failed", async () => {
         const element = document.createElement("p-button-lint") as ButtonLint;
@@ -27,6 +33,53 @@ describe("ButtonLint", () => {
         await element.updateComplete;
         expect(buttons(element).map((b) => b.textContent!.trim())).toEqual(["Stop"]);
 
+        element.remove();
+    });
+
+    it("moves focus to the next button set when the user was driving this component", async () => {
+        const element = document.createElement("p-button-lint") as ButtonLint;
+        element.papyros = new Papyros();
+        document.body.append(element);
+        await element.updateComplete;
+
+        const runButton = buttons(element)[0];
+        runButton.focus();
+        expect(element.shadowRoot!.activeElement).toBe(runButton);
+
+        element.papyros.runner.setState(RunState.Running);
+        await element.updateComplete;
+        await nextFrame();
+        const stopButton = buttons(element)[0];
+        expect(stopButton.textContent!.trim()).toBe("Stop");
+        expect(element.shadowRoot!.activeElement).toBe(stopButton);
+
+        element.papyros.runner.setState(RunState.Ready);
+        await element.updateComplete;
+        await nextFrame();
+        const nextRunButton = buttons(element)[0];
+        expect(nextRunButton.textContent!.trim()).toBe("Run");
+        expect(element.shadowRoot!.activeElement).toBe(nextRunButton);
+
+        element.remove();
+    });
+
+    it("never steals focus when the user was driving something else", async () => {
+        const element = document.createElement("p-button-lint") as ButtonLint;
+        element.papyros = new Papyros();
+        document.body.append(element);
+        await element.updateComplete;
+
+        const input = document.createElement("input");
+        document.body.append(input);
+        input.focus();
+        expect(document.activeElement).toBe(input);
+
+        element.papyros.runner.setState(RunState.Running);
+        await element.updateComplete;
+        expect(buttons(element).map((b) => b.textContent!.trim())).toEqual(["Stop"]);
+        expect(document.activeElement).toBe(input);
+
+        input.remove();
         element.remove();
     });
 });


### PR DESCRIPTION
This pull request stops keyboard focus from falling back to `<body>` around a run.

- The run controls render a different set of buttons per state (Run/Doctest/Debug, Stop, Stop debugging), so activating one with the keyboard removed the focused element. `ButtonLint` now remembers whether focus was inside it before the swap and focuses the first button of the new set afterwards. Focus is never moved when it was elsewhere, for instance while typing in the editor when a run finishes.
- The debugger pane is wrapped in a focusable `role="region"`, so it is reachable and scrollable by keyboard.
- The debugger placeholder uses the on-surface-variant token instead of a half-transparent on-surface colour, which failed the contrast ratio.

Two tests cover the focus hand-off and the no-theft case.

**Manual testing instructions**
- Tab to Run and press Enter: focus is on Stop. When the run ends, focus is on Run again.
- Tab to Debug and press Enter, then Tab once: focus enters the debugger pane.
- Put the cursor in the editor, run with Ctrl+Enter or the mouse: focus stays in the editor.

Update #1141
