### PR TITLE
Upgrade the trace component to 1.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@codemirror/state": "^6.3.2",
     "@codemirror/view": "^6.28.0",
     "@dodona/lit-state": "^1.1.1",
-    "@dodona/trace-component": "1.6.2",
+    "@dodona/trace-component": "1.6.3",
     "@material/web": "^2.4.0",
     "codemirror-readonly-ranges": "^0.1.0-alpha.2",
     "comlink": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@codemirror/state": "^6.3.2",
     "@codemirror/view": "^6.28.0",
     "@dodona/lit-state": "^1.1.1",
-    "@dodona/trace-component": "1.6.1",
+    "@dodona/trace-component": "1.6.2",
     "@material/web": "^2.4.0",
     "codemirror-readonly-ranges": "^0.1.0-alpha.2",
     "comlink": "^4.4.1",

--- a/src/frontend/state/Translations.ts
+++ b/src/frontend/state/Translations.ts
@@ -64,6 +64,8 @@ export const ENGLISH_TRANSLATION = {
             current_step: "Current step",
             call_stack: "Call stack",
             heap_objects: "Heap objects",
+            reference_to: "reference to %{type} #%{id}",
+            trace_label: "Execution trace",
         },
         editor: {
             test_code: {
@@ -166,6 +168,8 @@ export const DUTCH_TRANSLATION = {
             current_step: "Huidige stap",
             call_stack: "Call stack",
             heap_objects: "Objecten op de heap",
+            reference_to: "verwijzing naar %{type} #%{id}",
+            trace_label: "Uitvoeringstrace",
         },
         editor: {
             test_code: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,10 +105,10 @@
   dependencies:
     lit "^3.3.3"
 
-"@dodona/trace-component@1.6.2":
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/@dodona/trace-component/-/trace-component-1.6.2.tgz#ec1b4ac926ed59674f2015ef21260fcae8e703a0"
-  integrity sha512-4D+LBiW2zsgOZeRYSm296Yc1f81IxnW2IxNx4M7pkq+8CMlIrnVBqovaQuF+vNIuTE57A8iTEs0Xm4HPuMQ3Dg==
+"@dodona/trace-component@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@dodona/trace-component/-/trace-component-1.6.3.tgz#d78eb53f592c8991855ad096e0fd8ea444bf9579"
+  integrity sha512-MMckx/Pzd4sZM2Mcp4+YEH9TlvZIdqqWvXqADgcUPH39dwnIx0bawD4+glKaXhtDYvuDxHZs1traVjEOiwpG3w==
   dependencies:
     lit "^3.3.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,10 +105,10 @@
   dependencies:
     lit "^3.3.3"
 
-"@dodona/trace-component@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@dodona/trace-component/-/trace-component-1.6.1.tgz#f470d02e710d3a38013816c9c024b0e86c51d2a4"
-  integrity sha512-A8xAWr5Ytmdzayfi4cTYGUQ7WZj8eqvBBpCvqOXuAGufaEASDBYve86X38zS2pWdqcV4Ep8hlIKCSRVjcTdlow==
+"@dodona/trace-component@1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@dodona/trace-component/-/trace-component-1.6.2.tgz#ec1b4ac926ed59674f2015ef21260fcae8e703a0"
+  integrity sha512-4D+LBiW2zsgOZeRYSm296Yc1f81IxnW2IxNx4M7pkq+8CMlIrnVBqovaQuF+vNIuTE57A8iTEs0Xm4HPuMQ3Dg==
   dependencies:
     lit "^3.3.3"
 


### PR DESCRIPTION
This pull request upgrades `@dodona/trace-component` from 1.6.1 to 1.6.3 and adds Dutch names for the two translation keys 1.6.3 introduces.

## 1.6.2 — the stale inline container

`FrameComponent.drawConnection()` renders a heap object into the light DOM of its `tc-reference` when the object has no box on the heap, and nothing took that copy away again. An empty dict or list renders inside the cell that points at it; as soon as the program puts a reference in it, the object earns a box of its own, the component switches to drawing an arrow, and the inline copy stays behind frozen at its last inline contents. The frame view keeps its DOM between steps, so the stale copy survived every later step. Pressing `>` through a trace showed an empty `dict` in the cell next to the filled one on the heap, while dragging the slider to the same step showed it correctly.

Release notes: https://github.com/dodona-edu/trace-component/releases/tag/v1.6.2 (dodona-edu/trace-component#161, closes dodona-edu/trace-component#160)

## 1.6.3 — the accessibility gaps from the audit

This is the component half of the September accessibility audit.

- Variable, attribute, dict key, and list, tuple and grid index cells were `<td>`, so a screen reader navigating a table announced values with no idea which variable or index they belonged to. They are now `<th>`, scoped `row` or `col`. Padding was measured cell by cell against the previous release: nothing moved.
- A `tc-reference` whose target is drawn in a box of its own holds nothing but an arrow anchor. Such a cell now carries `role="img"` and an `aria-label`, from the new `reference_to` key.
- The scrollable body of `tc-trace` could not be reached with a keyboard (axe: `scrollable-region-focusable`). It is now a focusable `role="region"` named by the new `trace_label` key.
- `tc-exception-card` sets `role="alert"`, so an uncaught exception is announced when it appears.

Release notes: https://github.com/dodona-edu/trace-component/releases/tag/v1.6.3 (dodona-edu/trace-component#159)

## The two new translation keys

Both are accessible names that are never on screen, so a missing one is easy to overlook: the component silently falls back to English.

| Key | `en` | `nl` |
| --- | --- | --- |
| `reference_to` | reference to %{type} #%{id} | verwijzing naar %{type} #%{id} |
| `trace_label` | Execution trace | Uitvoeringstrace |

**One Dutch term worth a read:** `trace_label` is "Uitvoeringstrace", chosen to sit alongside the existing "Uitvoeringsstappen" and "Uitvoeringsstap". "Trace van de uitvoering" is an alternative if that compound reads badly aloud. `%{type}` is a Python type name (`list`, `dict`, …), which the component deliberately leaves untranslated.

**Manual testing instructions**
- Debug a program that fills a dict or a list which starts out empty, for example `d = {}` followed by `d["a"] = [1]`, and step through it with the `>` button rather than the slider. The cell should point an arrow at the container once it has contents, instead of showing an empty `dict`.
- With VoiceOver on and the interface in Dutch, read the stack table: a variable name is announced as a row header, and a cell holding only an arrow as "verwijzing naar list #1".
- Tab past the step slider: the trace region takes focus with a ring and scrolls with the arrow keys.
- Everything that rendered correctly before renders the same; neither release changes layout.

**Verification**

| Check | Result |
|---|---|
| `yarn typecheck` | clean |
| `yarn lint` | clean |
| `yarn vitest --run` | 24 files / 184 tests, green |

The lockfile change is the resolved tarball for the new version only; `lit` stays at `^3.3.3`.

**Checklist**
- Tests: n/a for the bump. `test/__tests__/state/Translations.test.ts` already checks `en`/`nl` parity and covers the two added keys; the component-side changes are covered by tests in dodona-edu/trace-component#159 and #161
- Accessibility: this is the component half of the audit; the two new keys are what makes the Dutch interface announce the new names
- Docs: n/a
- Announcement: 🐛 The debugger no longer shows an empty, outdated version of a dictionary or list after stepping through the frames one at a time, and its tables, references and trace region now carry the names a screen reader needs
- AI: Claude Code handled the review comments on both component pull requests, cut both releases and prepared this bump; the Dutch term above wants a human read

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdDZsvYGnDpjnCRjTyujuN
