### PR TITLE
Report a language switch whose backend fails to launch

### DIFF
--- a/src/frontend/state/Papyros.ts
+++ b/src/frontend/state/Papyros.ts
@@ -45,7 +45,12 @@ export class Papyros extends State {
     private channelPromise?: Promise<Channel | null>;
 
     /**
-     * Launch this instance of Papyros, making it ready to run code
+     * Launch this instance of Papyros, making it ready to run code.
+     *
+     * Resolves once the runtime can run code, so awaiting this waits for the whole
+     * runtime to download. A failed launch is reported to the error handler and
+     * offered as a retry instead of being thrown.
+     *
      * @return {Promise<Papyros>} Promise of launching, chainable
      */
     public async launch(): Promise<Papyros> {

--- a/src/frontend/state/Runner.ts
+++ b/src/frontend/state/Runner.ts
@@ -7,6 +7,7 @@ import { arrayBufferToBase64, isTextMimeType, isValidFileName, parseData } from 
 import { State, stateProperty } from "@dodona/lit-state";
 import { Papyros } from "./Papyros";
 import { ProgrammingLanguage } from "../../ProgrammingLanguage";
+import { PapyrosLaunchError } from "./PapyrosErrors";
 
 /**
  * Enum representing the possible states while processing code
@@ -78,7 +79,11 @@ export class Runner extends State {
     public set programmingLanguage(value: ProgrammingLanguage) {
         if (this._programmingLanguage !== value) {
             this._programmingLanguage = value;
-            this.launch();
+            this.launch().catch((error) => {
+                this.papyros.errorHandler(
+                    new PapyrosLaunchError("Error launching papyros after a language switch", { cause: error }),
+                );
+            });
         }
     }
 
@@ -321,7 +326,11 @@ export class Runner extends State {
     }
 
     /**
-     * Start the backend to enable running code
+     * Start the backend to enable running code.
+     *
+     * Resolves once the backend can run code and rejects when it fails to start, so
+     * awaiting this waits for the whole runtime to download. `backend` is assigned
+     * before that, so a caller that does not await can already queue runs.
      */
     public async launch(): Promise<void> {
         if (this.disposed) {
@@ -334,7 +343,6 @@ export class Runner extends State {
         const launchId = ++this.launchId;
         const language = this.programmingLanguage;
         const backend = this.getClient(language);
-        // Expose the promise before it settles so runs can already be queued while downloading
         const backendLaunched = this.launchBackend(language, backend, launchId);
         this.backend = backendLaunched;
         this.setState(RunState.Ready);

--- a/src/frontend/state/Runner.ts
+++ b/src/frontend/state/Runner.ts
@@ -79,7 +79,14 @@ export class Runner extends State {
     public set programmingLanguage(value: ProgrammingLanguage) {
         if (this._programmingLanguage !== value) {
             this._programmingLanguage = value;
-            this.launch().catch((error) => {
+            const launching = this.launch();
+            // launch() claims its id synchronously, so a newer id means a later launch
+            // superseded this one and its failure no longer concerns the user
+            const launchId = this.launchId;
+            launching.catch((error) => {
+                if (launchId !== this.launchId) {
+                    return;
+                }
                 this.papyros.errorHandler(
                     new PapyrosLaunchError("Error launching papyros after a language switch", { cause: error }),
                 );

--- a/test/__tests__/state/LaunchFailure.test.ts
+++ b/test/__tests__/state/LaunchFailure.test.ts
@@ -85,6 +85,33 @@ describe("Papyros launch failure", () => {
 
         papyros.dispose();
     });
+    it("reports a launch that fails after a language switch", async () => {
+        const papyros = new Papyros();
+        const errorHandler = vi.fn();
+        papyros.setErrorHandler(errorHandler);
+        papyros.runner.registerBackend(
+            ProgrammingLanguage.JavaScript,
+            () =>
+                ({
+                    workerProxy: {
+                        launch: () => Promise.reject(new Error("worker failed to start")),
+                    },
+                }) as any,
+        );
+
+        const unhandled = vi.fn();
+        window.addEventListener("unhandledrejection", unhandled);
+        papyros.runner.programmingLanguage = ProgrammingLanguage.JavaScript;
+        await vi.waitFor(() => expect(errorHandler).toHaveBeenCalledOnce());
+        window.removeEventListener("unhandledrejection", unhandled);
+
+        expect(errorHandler.mock.calls[0][0]).toBeInstanceOf(PapyrosLaunchError);
+        expect(unhandled).not.toHaveBeenCalled();
+        expect(papyros.runner.state).toBe(RunState.Error);
+
+        papyros.dispose();
+    });
+
     it("cleans up a failed launch that a language switch superseded", async () => {
         vi.spyOn(window, "confirm").mockReturnValue(false);
 

--- a/test/__tests__/state/LaunchFailure.test.ts
+++ b/test/__tests__/state/LaunchFailure.test.ts
@@ -15,6 +15,16 @@ function withTimeout<T>(promise: Promise<T>, ms: number, what: string): Promise<
     return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }
 
+// A backend that launches and needs no channel
+const working = (): any =>
+    ({
+        workerProxy: {
+            launch: () => Promise.resolve(),
+            usesJspi: () => Promise.resolve(true),
+            runModes: () => Promise.resolve([]),
+        },
+    }) as any;
+
 describe("Papyros launch failure", () => {
     it("surfaces a failed backend launch instead of hanging", async () => {
         vi.spyOn(window, "confirm").mockReturnValue(false);
@@ -101,15 +111,49 @@ describe("Papyros launch failure", () => {
 
         const unhandled = vi.fn();
         window.addEventListener("unhandledrejection", unhandled);
-        papyros.runner.programmingLanguage = ProgrammingLanguage.JavaScript;
-        await vi.waitFor(() => expect(errorHandler).toHaveBeenCalledOnce());
-        window.removeEventListener("unhandledrejection", unhandled);
+        try {
+            papyros.runner.programmingLanguage = ProgrammingLanguage.JavaScript;
+            await vi.waitFor(() => expect(errorHandler).toHaveBeenCalledOnce());
 
-        expect(errorHandler.mock.calls[0][0]).toBeInstanceOf(PapyrosLaunchError);
-        expect(unhandled).not.toHaveBeenCalled();
-        expect(papyros.runner.state).toBe(RunState.Error);
+            expect(errorHandler.mock.calls[0][0]).toBeInstanceOf(PapyrosLaunchError);
+            expect(unhandled).not.toHaveBeenCalled();
+            expect(papyros.runner.state).toBe(RunState.Error);
+        } finally {
+            window.removeEventListener("unhandledrejection", unhandled);
+            papyros.dispose();
+        }
+    });
 
-        papyros.dispose();
+    it("keeps quiet about a switch launch that a later switch superseded", async () => {
+        let failLaunch: (error: Error) => void;
+        const papyros = new Papyros();
+        const errorHandler = vi.fn();
+        papyros.setErrorHandler(errorHandler);
+        papyros.runner.registerBackend(
+            ProgrammingLanguage.JavaScript,
+            () =>
+                ({
+                    workerProxy: {
+                        launch: () =>
+                            new Promise((_, reject) => {
+                                failLaunch = reject;
+                            }),
+                    },
+                    terminate: vi.fn(),
+                }) as any,
+        );
+        papyros.runner.registerBackend(ProgrammingLanguage.Python, working);
+
+        try {
+            papyros.runner.programmingLanguage = ProgrammingLanguage.JavaScript;
+            papyros.runner.programmingLanguage = ProgrammingLanguage.Python;
+            failLaunch!(new Error("worker failed to start"));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(errorHandler).not.toHaveBeenCalled();
+        } finally {
+            papyros.dispose();
+        }
     });
 
     it("cleans up a failed launch that a language switch superseded", async () => {
@@ -117,14 +161,6 @@ describe("Papyros launch failure", () => {
 
         const terminate = vi.fn();
         let failLaunch: (error: Error) => void;
-        const working = (): any =>
-            ({
-                workerProxy: {
-                    launch: () => Promise.resolve(),
-                    usesJspi: () => Promise.resolve(true),
-                    runModes: () => Promise.resolve([]),
-                },
-            }) as any;
         const pythonCreator = vi
             .fn()
             .mockImplementationOnce(


### PR DESCRIPTION
This pull request handles the rejection from a backend launch started by a programming language switch, and documents what `launch` waits for.

**Cause**: #1096 made `Runner.launch` reject when the backend fails to start; before that the backend promise simply never settled. The `programmingLanguage` setter calls `this.launch()` without awaiting it and without a catch, so from then on a failed launch after a language switch became an unhandled rejection: no error handler call, nothing in Sentry for the embedder, just a console error.

**Fix**: the setter catches and passes the failure to the error handler wrapped in `PapyrosLaunchError`, which is what `Papyros.launch` does for the initial launch. Dodona keys its "sandbox failed to load" alert on that class, so a failed language switch now reaches it.

The same PR left `launch` with a comment saying it exposes the backend promise before it settles "so runs can already be queued while downloading", directly above the `await` that makes it wait for the whole runtime. Awaiting is deliberate and tested, so the comment is replaced by a docstring that says what the method actually promises. Dodona was awaiting `launch()` on the strength of that comment and its first debug session waited seconds for pyodide before opening the sandbox (dodona-edu/dodona#9077).

**Manual testing instructions**
- `yarn test test/__tests__/state/LaunchFailure.test.ts`. The new case fails on main with the error handler never called.
- In the demo app, switch the programming language and confirm running code still works.

**Checklist**
- Tests: `LaunchFailure.test.ts` asserts a language switch to a backend that rejects reports through the error handler, leaves the runner in Error state, and raises no unhandled rejection.
- Docs: `Runner.launch` and `Papyros.launch` docstrings now state that awaiting them waits for the runtime download.