### PR TITLE
Stringify the input prompt before it reaches the frontend

### DIFF
--- a/src/backend/workers/javascript/JavaScriptWorker.ts
+++ b/src/backend/workers/javascript/JavaScriptWorker.ts
@@ -50,7 +50,7 @@ export class JavaScriptWorker extends Backend {
     private prompt(text = ""): string {
         return this.onEvent({
             type: BackendEventType.Input,
-            data: text,
+            data: String(text),
             contentType: "text/plain",
         });
     }

--- a/src/backend/workers/python/papyros/papyros.py
+++ b/src/backend/workers/python/papyros/papyros.py
@@ -88,7 +88,7 @@ class Papyros(python_runner.PyodideRunner):
                         cb("output", data, contentType=part.get("contentType"))
             elif event_type == "input":
                 self._emit_turtle_snapshot()
-                return unwrap(cb("input", data["prompt"]))
+                return unwrap(cb("input", str(data["prompt"])))
             elif event_type == "sleep":
                 self._emit_turtle_snapshot()
                 return unwrap(cb("sleep", data["seconds"]*1000, contentType="application/number"))

--- a/src/frontend/state/InputOutput.ts
+++ b/src/frontend/state/InputOutput.ts
@@ -142,7 +142,7 @@ export class InputOutput extends State {
                 return;
             }
 
-            this.prompt = e.data || "";
+            this.prompt = String(e.data ?? "");
             this.awaitingInput = true;
         });
         this.papyros.events.subscribe(BackendEventType.End, () => this.onRunEnd());

--- a/test/__tests__/state/InputOutput.test.ts
+++ b/test/__tests__/state/InputOutput.test.ts
@@ -66,6 +66,28 @@ console.log("world!");
         unsubscribe();
     });
 
+    it("shows a non-string prompt as text", async () => {
+        const jsPapyros = await launchPapyros(ProgrammingLanguage.JavaScript);
+        jsPapyros.runner.code = `prompt(42);`;
+        await waitForInputReady(jsPapyros);
+        const runPromise = jsPapyros.runner.start();
+        await waitForAwaitingInput(jsPapyros);
+        expect(jsPapyros.io.prompt).toBe("42");
+        await jsPapyros.runner.stop();
+        await runPromise;
+        jsPapyros.dispose();
+    });
+
+    it("shows a non-string prompt as text in python", async () => {
+        papyros.runner.code = `input(5)`;
+        await waitForInputReady(papyros);
+        const runPromise = papyros.runner.start();
+        await waitForAwaitingInput(papyros);
+        expect(papyros.io.prompt).toBe("5");
+        await papyros.runner.stop();
+        await runPromise;
+    });
+
     it("stops asking for input on stop", async () => {
         papyros.runner.code = `print("hello " + input())`; // eslint-disable-line quotes
         await waitForInputReady(papyros);


### PR DESCRIPTION
This pull request converts the prompt of `input()` and `prompt()` to a string before it is sent to the main thread, and stores it as a string in `InputOutput`.

Sentry DODONA-FRONTEND-2CE: `TypeError: this.content.cloneNode is not a function` in CodeMirror's `Placeholder.toDOM` while `BatchInput` renders.

**Cause.** `python_runner`'s `input()` forwards its argument unchanged and `papyros.py` sends it as the event data, so `input(5)` reaches the main thread as a number through pyodide's conversion and structured clone. `JavaScriptWorker.prompt(text)` does the same for `prompt(42)`. `BatchInput.placeholder` returns `io.prompt` when truthy and `CodeMirrorEditor` passes it to `placeholder()`, whose widget calls `cloneNode` on anything that is neither a string nor a function.

- `papyros.py`: `str(data["prompt"])`, matching what CPython's `input()` prints.
- `JavaScriptWorker.prompt`: `String(text)`.
- `InputOutput`: `this.prompt = String(e.data ?? "")` so the property matches its declared type whatever a backend sends.
- Tests: `prompt(42)` and `input(5)` leave `io.prompt` equal to `"42"` and `"5"`.

**Manual testing instructions**
- Run `input(5)` in the Python sandbox: the input pane shows `5` as its placeholder instead of failing to render.
- Run `prompt(42)` in the JavaScript sandbox: same.

**Checklist**
- Tests: two cases in `InputOutput.test.ts`
- AI: Claude Code traced the Sentry event and wrote the change during dodona's weekly Sentry sweep