### PR TITLE
Publish without waiting for an approval

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -46,7 +46,6 @@ jobs:
   publish:
     needs: [test, verify]
     runs-on: ubuntu-latest
-    environment: npm
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
This pull request removes `environment: npm` from the publish job, so pushing a `v*` tag publishes to npm without waiting for a required reviewer to approve the deployment.

The gate was added in 65929a3d to guard against a mistyped tag being published to the wrong dist-tag. The `verify` job covers that case on its own: it fails on a tag that is not semver and on a tag that does not match the committed `package.json` version, and `publish` needs `verify`.

**Before merging:** check the trusted publisher for `@dodona/papyros` on npmjs.com. If it has the environment set to `npm`, the OIDC token from a job without that environment will be rejected and publishing fails. Clear the environment field there. Trusted publishing was set up in May, before the environment existed, so it is probably empty, but I could not read the config from here.

After merging, the `npm` environment and its reviewers can be deleted under Settings → Environments.

**Checklist**
- Tests: n/a, workflow change. The next tag push will exercise it.
- AI: Claude Code made the change and wrote this description.
